### PR TITLE
Don't require superuser access for development.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "webpack-dev-server": "^1.14.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo 'Yee-haw!'",
     "postinstall": "npm run build",
     "build": "webpack",
     "dev": "webpack-dev-server --hot --inline --open"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,13 @@
 var path = require('path');
 var webpack = require('webpack');
 
-var outputPath = '/dist';
-
 module.exports = {
   context: __dirname,
   entry: './init.js',
-  output: { 
-    path: outputPath,
+  output: {
+    path: path.resolve(__dirname, 'build/public'),
     publicPath: '/dist',
-    filename: 'bundle.js' 
+    filename: 'bundle.js'
   },
   devtool: 'source-map',
   module: {
@@ -26,7 +24,7 @@ module.exports = {
         test: /\.scss$/,
         loaders: ['style', 'css', 'sass']
       },
-      { test: /\.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/, 
+      { test: /\.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
       loader: 'file-loader?name=fonts/[name].[ext]' }
     ]
   },
@@ -41,6 +39,6 @@ module.exports = {
           req.url = req.url.replace(/^\/api/, '');
         }
       }
-    }  
+    }
   }
 };


### PR DESCRIPTION
Updates the webpack config to put the compiled bundle in `./build/public` rather than the developer's `/dist` directory.

We still need to do more to get CI working:

1. ~~Fix `npm run build`.~~
2. ~~Fix `npm run test`.~~ In an ideal world it would also run tests.
