### PR TITLE
Include query parameters when proxying to the API.

### DIFF
--- a/docker/tiller/templates/askdarcel-web.erb
+++ b/docker/tiller/templates/askdarcel-web.erb
@@ -19,7 +19,7 @@ server {
         resolver_timeout 5s;
 
         set $api_url <%= env_api_url.chomp '/' %>;
-        proxy_pass $api_url/$1;
+        proxy_pass $api_url/$1$is_args$args;
         proxy_redirect off;
     }
 


### PR DESCRIPTION
When using a regex location with a match variable, nginx doesn't pass these through automatically.