### PR TITLE
Add search support to resource result page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-webpack": "^1.7.0",
     "node-sass": "^3.7.0",
+    "query-string": "^4.2.2",
     "react-icons": "^2.0.1",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
The page at URL /resources?query=:query will display resource search results for the query :query. This change does _not_ wire up the search input fields on the front page or in the header.

The change also replaces tabs with spaces in `ResourcesTable.js`, which makes the change a bit hard to review. I'll point out where the functional changes were made.

Towards #43
