### PR TITLE
Show navigation, even on phone-sized screens.

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -37,16 +37,14 @@ class App extends Component {
       });
     });
 
-    return (!this.props.error && this.props.location.pathname != '/') ? (
+    return (
       <div>
         <Navigation />
         <div className="container">
           {childrenWithProps}
         </div>
       </div>
-    ) : <div>
-    	{childrenWithProps}
-    	</div>
+    )
   }
 
 };

--- a/app/styles/components/_navigation.scss
+++ b/app/styles/components/_navigation.scss
@@ -16,23 +16,14 @@ $navigation-height: calc-em(60px);
   background: $color-brand;
   padding: calc-em(10px) calc-em(20px);
   @include r_max($break-tablet-s) {
-    display: none;
-    background: $color-white;
-    bottom: 0;
-    top: auto;
     border-top: 1px solid $color-grey3;
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }
 
 .find-page .site-nav {
   .nav-search {
-    display: none;
-  }
-}
-
-.nav-left {
-  @include r_max($break-tablet-s) {
     display: none;
   }
 }
@@ -44,9 +35,6 @@ $navigation-height: calc-em(60px);
   img {
     height: calc-em(34px);
     width: auto;
-  }
-  @include r_max($break-tablet-s) {
-    display: none;
   }
 }
 


### PR DESCRIPTION
Fixes #138.

The nav bar was being explicitly hidden on phone-sized screens, but this caused the page to look weird on the search results page. I changed it so that it'll still be displayed on phones, but
I kept the navigation search bar hidden, since it won't fit. I also changed the main App component to always render the page with the `<Navigation />` component and the `.container` wrapper, even on the root page, since without the `.container` wrapper the top of the hero banner was getting covered by the nav.

This technically ends up double-rendering the Navigation bar on the home page, but the version without the search bar is displayed on top, so it still looks correct, but we probably want to fix that later.

Here are some screenshots of what it looks like now on Desktop Chrome using the responsive dev tools:

### Home page desktop size (just to prove that the double rendering of the navigation is OK)
<img width="1071" alt="screen shot 2017-02-15 at 8 26 51 pm" src="https://cloud.githubusercontent.com/assets/1002748/23007365/1fe0a264-f3bd-11e6-969a-81c24be5e9e6.png">

### Home page
<img width="375" alt="screen shot 2017-02-15 at 8 21 59 pm" src="https://cloud.githubusercontent.com/assets/1002748/23007370/2b00b652-f3bd-11e6-945a-737c2ce4ded4.png">

### Search results
<img width="411" alt="screen shot 2017-02-15 at 8 22 06 pm" src="https://cloud.githubusercontent.com/assets/1002748/23007374/2e80cc2c-f3bd-11e6-8ec7-05700ccd2740.png">

### Resource page
<img width="390" alt="screen shot 2017-02-15 at 8 22 12 pm" src="https://cloud.githubusercontent.com/assets/1002748/23007376/313f30b6-f3bd-11e6-9c20-e194c538e44e.png">
