### PR TITLE
Add handler for PhoneChangeRequests. Fix handler for AddressChangeRequests

### DIFF
--- a/app/components/Admin/ChangeRequest.js
+++ b/app/components/Admin/ChangeRequest.js
@@ -30,7 +30,10 @@ class ChangeRequest extends React.Component {
                 object = resource.schedule.schedule_days.filter(day => day.id === changeRequest.object_id)[0];
                 break;
             case 'AddressChangeRequest':
-                object = resources.address;
+                object = resource.address;
+                break;
+            case 'PhoneChangeRequest':
+                object = resource.phones.filter(phone => phone.id === changeRequest.object_id)[0];
                 break;
         }
 


### PR DESCRIPTION
The reason phone numbers weren't displaying in the admin change requests page was because the switch statement that figures out how to pull out the original field value is missing a case for PhoneChangeRequests. This adds it to the list so that the phone number displays properly.

I also noticed that there was a minor typo in the AddressChangeRequest case, too, that I also fixed.

Lastly, I noticed that there's one more change request type that we're missing, the NoteChangeRequest. I didn't add it here, since there's currently no way to even submit a change request for a note, but I can create a new ticket to remind us to add it.