### PR TITLE
Fix posta_code typo.

### DIFF
--- a/app/components/Edit/EditAddress.js
+++ b/app/components/Edit/EditAddress.js
@@ -30,7 +30,7 @@ class EditAddress extends Component {
 				<input type="text" placeholder="City" data-field='city' defaultValue={address.city} onChange={this.handleAddressChange} />
 				<input type="text" placeholder="State/Province" data-field='state_province' defaultValue={address.state_province} onChange={this.handleAddressChange} />
 				<input type="text" placeholder="Country" data-field='country' defaultValue={address.country} onChange={this.handleAddressChange} />
-				<input type="text" placeholder="Postal/Zip Code" data-field='posta_code' defaultValue={address.postal_code} onChange={this.handleAddressChange} />
+				<input type="text" placeholder="Postal/Zip Code" data-field='postal_code' defaultValue={address.postal_code} onChange={this.handleAddressChange} />
 			</li>
 		);
 	}


### PR DESCRIPTION
There was a typo in the change request submission form. After fixing this, I tested that I could update the zip code of a resource locally.