### PR TITLE
Add scrollbars back

### DIFF
--- a/app/components/Search/ResourcesMap.js
+++ b/app/components/Search/ResourcesMap.js
@@ -76,7 +76,9 @@ class Gmap extends Component {
 
   render() {
     return (
-      <div ref="map_canvas" className="map_canvas"></div>
+      <div className="results-map-inner">
+        <div ref="map_canvas" className="map_canvas"></div>
+      </div>
     )
   }
 }

--- a/app/components/Search/ResourcesTable.js
+++ b/app/components/Search/ResourcesTable.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import Gmap from './ResourcesMap.js';
+import Loader from '../Loader';
+
 import queryString from 'query-string';
 import ResourcesList from './ResourcesList'
 
@@ -138,22 +140,8 @@ class ResourcesTable extends Component {
   }
 
   render() {
-    return !this.state.resources ? <div className="loader">
-      <div className="sk-fading-circle">
-        <div className="sk-circle1 sk-circle"></div>
-        <div className="sk-circle2 sk-circle"></div>
-        <div className="sk-circle3 sk-circle"></div>
-        <div className="sk-circle4 sk-circle"></div>
-        <div className="sk-circle5 sk-circle"></div>
-        <div className="sk-circle6 sk-circle"></div>
-        <div className="sk-circle7 sk-circle"></div>
-        <div className="sk-circle8 sk-circle"></div>
-        <div className="sk-circle9 sk-circle"></div>
-        <div className="sk-circle10 sk-circle"></div>
-        <div className="sk-circle11 sk-circle"></div>
-        <div className="sk-circle12 sk-circle"></div>
-      </div>
-    </div> : (<div className="results">
+    return (!this.state.resources ? <Loader /> :
+              <div className="results">
                 <div className="results-table">
                   <header>
                     <h1 className="results-title">{this.state.categoryName}</h1>

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Link, browserHistory, IndexRoute } from 'react-router';
+import { Route, Link, browserHistory, IndexRoute, withRouter } from 'react-router';
 
 import configureStore from './store/configureStore';
 import App from './components/App';
@@ -23,8 +23,19 @@ function redirectToRoot (nextState, replace) {
 };
 
 
+// Adapted from
+// https://github.com/ReactTraining/react-router/issues/2019#issuecomment-256591800
+// Note: When we upgrade to react-router 4.x, we should use
+// https://github.com/ReactTraining/react-router/blob/v4.1.1/packages/react-router-dom/docs/guides/scroll-restoration.md
+function scrollToTop(prevState, nextState) {
+  if (nextState.location.action !== "POP") {
+    window.scrollTo(0, 0);
+  }
+}
+
+
 export default (
-  <Route path="/" component={ App } >
+  <Route path="/" component={ App } onChange={ scrollToTop } >
     <IndexRoute component={ CategoryPage } />
     <Route name="resources" path="/resources" component={ ResourcesTable } />
     <Route name="editResource" path="/resource/edit" component={ EditSections } />

--- a/app/styles/components/_edit.scss
+++ b/app/styles/components/_edit.scss
@@ -3,7 +3,6 @@
 .edit-section-title
 .edit-page {
     width: 100%;
-    overflow: hidden;
     margin-top: #{$navigation-height};
 }
 .edit-header {

--- a/app/styles/components/_org-table.scss
+++ b/app/styles/components/_org-table.scss
@@ -4,13 +4,11 @@
 .results {
   @extend %flex-row;
   width: 100%;
-  height: calc(100vh - #{$navigation-height});
-  overflow: hidden;
   margin-top: #{$navigation-height};
+  align-items: flex-start;
   @include r_max($break-tablet-s) {
     margin-top: 0;
     flex-direction: column;
-    align-items: stretch;
     margin-bottom: #{$navigation-height};
   }
 }
@@ -24,6 +22,11 @@
     height: calc-em(180px);
     width: 100%;
   }
+}
+
+.results-map-inner {
+  position: fixed;
+  width: 100%;
 }
 
 .results-table {
@@ -81,7 +84,6 @@
 }
 
 .results-table-body {
-  overflow-y: scroll;
   flex: 1 1 auto;
 }
 

--- a/app/styles/utils/_layout.scss
+++ b/app/styles/utils/_layout.scss
@@ -55,10 +55,7 @@ $break-desktop-xl: 2000px;
 }
 
 body, html {
-  overflow:hidden;
-  height:100%;
   min-height: inherit;
-  position:fixed;
   width:100%;
   top:0;
   left:0;
@@ -66,10 +63,6 @@ body, html {
 
 #root {
   @extend %flex-column;
-  overflow-x: hidden;
-  overflow-y: scroll;
-  height: 100vh;
-  -webkit-overflow-scrolling: touch;
   @include r_max($break-tablet-s) {
     padding-bottom: calc-em(60px);
   }

--- a/app/styles/utils/_reset.scss
+++ b/app/styles/utils/_reset.scss
@@ -23,17 +23,6 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
   -webkit-backface-visibility: hidden;
 }
 
-html {
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-}
-::-webkit-scrollbar {
-    width: 0px;  /* remove scrollbar space */
-    background: transparent;  /* optional: just make scrollbar invisible */
-}
-::-webkit-scrollbar-thumb {
-    background: rgb(0,255,147);
-}
-
 // Zero out font sizes. Most browser defaults ~16px */
 html { font-size: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; overflow-y:scroll; min-height: 100vh;-webkit-font-smoothing: antialiased;}
 body {min-height: 100vh;}


### PR DESCRIPTION
This might require testing across multiple browsers to ensure that no regressions have slipped through. There was a bit of a domino effect where changing one thing had many other undesirable effects, but I think I stomped them all out.

## Adding scroll bars back in
Several styles were preventing scrollbars from displaying:
- it looks like we had some webkit-specific styles to explicitly hide the scrollbars by making them have 0 width and be transparent
- the #root element had a height of 100vh set, which meant that it could never be larger than the viewport
- the body and html elements had `position: fixed` set, which prevents scrollbars from appearing

I undid all of those and it now allows scrollbars to appear.

Basically, originally the `<html>` element had a height that was fixed to the viewport height, which prevented normal scrollbars from appearing. After my changes, the `<html>` has a height that reflects the true height of all the page content.

I also got rid of an unnecessary `overflow-y: scroll` on a non-root element, since that was causing a scroll bar to appear in the middle of the page on Edge, even though the element itself was unscrollable because its height was the same as its content. These types of things are difficult for me to detect because OS X will hide scrollbars by default if a mouse isn't attached.

## Fix positioning of map on search results page
On larger screens, the map is displayed to the right of the search results. Previously, when the `<html>` element had a height equal to the viewport, the map would be in a fixed position while only the search results element would internally scroll through its overflowed content.

With my changes, the actual page height is now taller, but this caused the map to get placed in the center of the page, meaning that you'd have to scroll down to see it. To fix this, I told the flexbox container holding both the results and the map to align to the top, not the center, and I added a `position: fixed` to the map.

On smaller screens, the map is displayed above the search results. Previously, you could only scroll the results section of the page, and on a phone, it was kind of annoying to have such little screen real estate available. It looks like my changes actually changed this behavior so that when you scroll, the results "slide over" the map, due the fixed positioning I added. I could have added a media query to remove the fixed positioning on mobile, but I think it actually looks kind of neat, so I left it in.

## Scroll position weird when clicking links
Because the page's height now reflects its true content height and is not restricted to the viewport height, this caused weird behavior when you clicked a link. If you were scrolled down when you clicked a link, then when the next page loaded, it would also be in the same scroll position instead of being at the top. This is a [known issue](https://github.com/ReactTraining/react-router/issues/2019) with react-router, and the reason it hasn't been fixed is because the behavior you'd want depends on the context (if you had a tabbed navigation that wasn't fixed positioned, then you don't actually want to scroll back to the top).

Our version of react-router is kind of old, so I couldn't apply the latest [recommended fix](https://github.com/ReactTraining/react-router/blob/v4.1.1/packages/react-router-dom/docs/guides/scroll-restoration.md), which only works on 4.x. I found an [older workaround](https://github.com/ReactTraining/react-router/issues/2019#issuecomment-256591800) that works on 2.8 and applied it. Basically, it's a bit of JavaScript to scroll to the top on any routing action except when going back to a previous page.

## How this was tested

Here's what I was able to test this on:

- OS X Chrome, latest
- OS X Firefox, latest
- OS X Safari, latest. Actually, the app performance is terrible on Safari. Going back a page using the trackpad gesture causes the page to lockup for several seconds. I just checked out askdarcel.org on Safari, and the problem is not as bad, but going back a page with the trackpad gesture causes the page to completely reload and scroll back to the top of the page. Interestingly enough, this seems to be less of a problem if you click the back button in the browser chrome.
- Android Chrome, latest
- Xcode iOS simulator
- Windows 10 Edge, via VM

I don't have a great way of testing other versions of Internet Explorer, but I could download more VMs from Microsoft. What's the oldest version of IE we support?