### PR TITLE
Collapse change request groups in Admin approval page

### DIFF
--- a/app/styles/components/_admin.scss
+++ b/app/styles/components/_admin.scss
@@ -7,7 +7,27 @@
             padding-top: calc-em(15px);
 
             h1 {
+                cursor: pointer;
+                user-select: none;
                 padding-bottom: calc-em(5px);
+            }
+
+            .expander {
+                transition: 0.2s ease;
+
+                &.collapsed {
+                    transform: rotate(180deg);
+                }
+            }
+
+            .group-content {
+                transition: 0.2s ease;
+                overflow: hidden;
+
+                &.collapsed {
+                    opacity: 0;
+                    max-height: 0;
+                }
             }
         }
 


### PR DESCRIPTION
**Important note**: This was branched from #216, so don't merge until that's merge. See below more details.

This makes it so that change requests are collapsed per resource on the Admin approval page.

<img width="1069" alt="screen shot 2017-05-11 at 8 48 37 am" src="https://cloud.githubusercontent.com/assets/1002748/25958824/a72c60d6-3626-11e7-948a-74a9d825894e.png">

I've added a little chevron as a UI indicator that the object can be expanded, and the whole `<h1>` tag is clickable to make it easier to expand. Everything starts out collapsed by default.

On a technical note, I based this branch on @twolfe2's #216 branch, since I noticed he had re-indented a lot of the files there, and I wanted to minimize the merge conflicts, especially because I'm going to be out of town this weekend. Therefore, you should use https://github.com/ShelterTechSF/askdarcel-web/compare/admin-page-edit-ability...198-group-change-requests?w=1 to see the actual diff of the changes I added, and you should only merge this after #216 merges.

One bigger change I had to make in this PR  was to turn the ChangeRequests component into an actual React component instead of just being a function that returns a template, since I needed to add a `state` object to keep track of what's collapsed and what's displayed. To avoid touching too much code and potentially causing another merge conflict, I only moved the minimum things required into the component, which were the `render()` method and the `renderChangeRequests()` method which now contains the expand/collapse button.

As a side note, given that we're probably going to have to rewrite a lot of this code to support Redux and to implement Derek's new designs, I would highly recommend breaking out each group of change requests (everything under a resource) into its own React component. It would simplify a lot of the logic and prevent the need to build all these independent mapping objects between resourceID and some bit of useful information.