### PR TITLE
Disable the add button for phone numbers

### DIFF
--- a/app/components/Edit/EditCollection.js
+++ b/app/components/Edit/EditCollection.js
@@ -8,7 +8,8 @@ import React, { Component } from 'react';
  */
 export default function editCollectionHOC(ResourceObjectItem,
                             label,
-                            blankTemplateObj
+                            blankTemplateObj,
+                            showAdd=true
                         ) {
     return class EditCollection extends Component {
         constructor(props) {
@@ -60,10 +61,12 @@ export default function editCollectionHOC(ResourceObjectItem,
                     <ul className="edit--section--list--item--sublist">
                         {this.createItemComponents()}
                     </ul>
-                    <button className="edit--section--list--item--button" onClick={this.addItem}>
-                        <i className="material-icons">add_box</i>
-                        Add
-                    </button>
+                    {showAdd &&
+                        <button className="edit--section--list--item--button" onClick={this.addItem}>
+                            <i className="material-icons">add_box</i>
+                            Add
+                        </button>
+                    }
 			    </li>
             );
         }

--- a/app/components/Edit/EditPhones.js
+++ b/app/components/Edit/EditPhones.js
@@ -42,5 +42,5 @@ class EditPhone extends Component {
     }
 }
 
-const EditPhones = editCollectionHOC(EditPhone, "Phones", {});
+const EditPhones = editCollectionHOC(EditPhone, "Phones", {}, false);
 export default EditPhones;


### PR DESCRIPTION
This PR disables the "Add" button for phone numbers, since we actually haven't even implemented the code path for handling adding new phone numbers: https://github.com/ShelterTechSF/askdarcel-web/blob/c090b215dfc7e8ccf74b73dc7d49b6f7d732b864/app/components/Edit/EditSections.js#L152

See https://github.com/ShelterTechSF/askdarcel-api/issues/172 for what I think we need in general in order to create change requests that represent new database model instances that should get created, as opposed to change requests that only edit existing model instances.