### PR TITLE
Use the correct format for time inputs.

### DIFF
--- a/app/components/Edit/EditSchedule.js
+++ b/app/components/Edit/EditSchedule.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { timeToString, stringToTime, daysOfTheWeek } from '../../utils/index';
+import { timeToTimeInputValue, stringToTime, daysOfTheWeek } from '../../utils/index';
 
 class EditSchedule extends Component {
     constructor(props) {
@@ -54,7 +54,7 @@ class EditSchedule extends Component {
         }
 
         let time = dayRecord[field];
-        return timeToString(time, true);
+        return timeToTimeInputValue(time, true);
     }
 
     render() {

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -9,15 +9,60 @@ export function getAuthRequestHeaders() {
   };
 }
 
-export function timeToString(hours) {
+/**
+ * Convert time from concatenated hours-minutes format to a Date object.
+ *
+ * E.g.
+ * '700' to new Date(..., ..., ..., 7, 0)
+ * '1330' to new Date(..., ..., ..., 13, 30)
+ */
+function timeToDate(hours) {
   const date = new Date();
   if (hours) {
     const hoursString = hours.toString();
     date.setHours(hoursString.substring(0, hoursString.length - 2));
     date.setMinutes(hoursString.substring(hoursString.length - 2, hoursString.length));
     date.setSeconds(0);
+    return date;
+  }
+  return null;
+}
 
+/**
+ * Convert time from concatenated hours-minutes format to HH:MM P
+ *
+ * E.g.
+ * '700' to '7:00 AM'
+ * '1330' to '1:30 PM'
+ */
+export function timeToString(hours) {
+  const date = timeToDate(hours);
+  if (date) {
     return date.toLocaleTimeString().replace(/:\d+ /, ' ');
+  }
+  return null;
+}
+
+/**
+ * Convert time from concatenated hours-minutes format to <input type="time">
+ * format.
+ *
+ * A "time" <input> value should be formatted as an RFC3339 partial-time,
+ * according to
+ * http://w3c.github.io/html-reference/input.time.html#input.time.attrs.value
+ *
+ * E.g.
+ * '700' to '7:00'
+ * '1330' to '13:30'
+ */
+export function timeToTimeInputValue(hours) {
+  const date = timeToDate(hours);
+  if (date) {
+    const hour = date.getHours();
+    const strHour = (hour < 10) ? `0${hour.toString()}` : hour.toString();
+    const minute = date.getMinutes();
+    const strMinute = (minute < 10) ? `0${minute.toString()}` : minute.toString();
+    return `${strHour}:${strMinute}`;
   }
   return null;
 }


### PR DESCRIPTION
As @twolfe2 suspected in #236, we're not passing correctly formatted time values into `<input type="time">` fields. We were passing in things that looked like `7:00 PM`, but what it actually wants is `19:00`.

I added a new helper function, `timeToTimeInputValue()`, which takes our API's "concatenated hour-minute" format (e.g. `1900`) and formats it correctly.

An orthogonal problem that I noticed is that the edit page isn't correctly displaying schedules. The edit pages currently has one field per day, but we can have multiple time ranges per day. What we really need is to have multiple fields per day, and to also allow a user to add more time ranges, but I think that's outside the scope of this PR.