### PR TITLE
Upgrade to webpack 2.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "redux": "^3.6.0",
     "redux-immutable-state-invariant": "^1.2.4",
     "redux-thunk": "^2.1.0",
-    "webpack": "^1.13.0",
+    "webpack": "^2.6.1",
     "whatwg-fetch": "^2.0.1"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.1",
-    "extended-define-webpack-plugin": "^0.1.0",
+    "extended-define-webpack-plugin": "^0.1.3",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^1.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     filename: 'bundle.js'
   },
   resolve: {
-    extensions: ['', '.tsx', '.ts', '.jsx', '.js'],
+    extensions: ['.tsx', '.ts', '.jsx', '.js'],
   },
   plugins: [
     new HtmlWebpackPlugin({
@@ -31,28 +31,51 @@ module.exports = {
   ],
   devtool: 'source-map',
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.jsx?$/,
-        loader: 'babel-loader',
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['es2015', 'react', 'stage-2']
+            }
+          }
+        ],
         exclude: [/node_modules/, /typings/],
-        query: {
-          presets: ['es2015', 'react', 'stage-2']
-        }
       },
       {
         test: /\.scss$/,
-        loaders: ['style', 'css', 'sass']
+        use: ['style-loader', 'css-loader', 'sass-loader']
       },
       {
         test: /\.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
-        loader: 'file-loader?name=fonts/[name].[ext]'
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: 'fonts/[name].[ext]'
+            }
+          }
+        ]
       },
       {
         test: /\.(jpe?g|png|gif|svg)$/i,
-        loaders: [
-          'file?name=[name]-[sha512:hash:hex:8].[ext]',
-          'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false'
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name]-[sha512:hash:hex:8].[ext]',
+            }
+          },
+          {
+            loader: 'image-webpack-loader',
+            options: {
+              bypassOnDebug: true,
+              optimizationLevel: 7,
+              interlaced: false
+            }
+          }
         ]
       }
     ]


### PR DESCRIPTION
This is just a small change to upgrade webpack to 2.6, which is the last of the 2.x line. I wasn't able to upgrade it to 3.0 because some of our other dependencies claim that they depend on `^2.x.x`, and I didn't want to go and actually verify whether or not they work yet. We may want to upgrade some other packages to their latest available versions so that we can more easily upgrade webpack or other dependencies in the future.