### PR TITLE
Enable adding multiple phones; also display and make editable phone service_type.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,9 +12,7 @@ app/components/Auth/RequireAuth.js
 app/components/Edit/EditAddress.js
 app/components/Edit/EditCollection.js
 app/components/Edit/EditNotes.js
-app/components/Edit/EditPhones.js
 app/components/Edit/EditSchedule.js
-app/components/Edit/EditSections.js
 app/components/Edit/EditServices.js
 app/components/Find/CategoryItem.js
 app/components/Find/FindHeader.js
@@ -23,7 +21,6 @@ app/components/Footer.js
 app/components/Resource/CommunicationBoxes.js
 app/components/Resource/Hours.js
 app/components/Resource/Resource.js
-app/components/Resource/ResourceInfos.js
 app/components/Resource/ResourceMap.js
 app/components/Resource/Services.js
 app/components/Search/ResourcesMap.js

--- a/app/components/Edit/EditPhones.js
+++ b/app/components/Edit/EditPhones.js
@@ -1,53 +1,68 @@
 import React, { Component } from 'react';
-import editCollectionHOC from './EditCollection';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
+import editCollectionHOC from './EditCollection';
 
 class EditPhone extends Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            phone: _.clone(this.props.item)
-        };
+    this.state = {
+      phone: _.clone(this.props.item),
+    };
 
-        this.handleFieldChange = this.handleFieldChange.bind(this);
+    this.handleFieldChange = this.handleFieldChange.bind(this);
+  }
+
+  handleFieldChange(e) {
+    const value = e.target.value;
+    const field = e.target.dataset.field;
+    const phone = this.state.phone;
+
+    if (phone[field] || value !== this.props.item[field]) {
+      phone[field] = value;
+      this.setState({ phone });
+      this.props.handleChange(this.props.index, phone);
     }
+  }
 
-    handleFieldChange(e) {
-        let value = e.target.value;
-        let field = e.target.dataset.field;
-        let phone = this.state.phone;
-
-        if(phone[field] || value != this.props.item[field]) {
-            phone[field] = value;
-            this.setState({phone: phone});
-            this.props.handleChange(this.props.index, phone);
-        }		
-    }
-
-    render() {
-        let phone = this.props.item;
-        return (
-            <li key="tel" className="edit--section--list--item tel">
-                <label>Telephone</label>
-                <input 
-                    type="tel" 
-                    placeholder="Phone number" 
-                    data-field="number" 
-                    defaultValue={phone.number} 
-                    onChange={this.handleFieldChange} 
-                />
-                <input
-                    type="tel"
-                    placeholder="Service type"
-                    data-field="service_type"
-                    defaultValue={phone.service_type}
-                    onChange={this.handleFieldChange}
-                />
-            </li>
-        );
-    }
+  render() {
+    const phone = this.props.item;
+    const htmlID = `phonenumber${this.props.index}`;
+    return (
+      <li key="tel" className="edit--section--list--item tel">
+        <label htmlFor={htmlID}>Telephone</label>
+        <input
+          id={htmlID}
+          type="tel"
+          placeholder="Phone number"
+          data-field="number"
+          defaultValue={phone.number}
+          onChange={this.handleFieldChange}
+        />
+        <input
+          type="tel"
+          placeholder="Service type"
+          data-field="service_type"
+          defaultValue={phone.service_type}
+          onChange={this.handleFieldChange}
+        />
+      </li>
+    );
+  }
 }
 
-const EditPhones = editCollectionHOC(EditPhone, "Phones", {});
+EditPhone.propTypes = {
+  handleChange: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired,
+  item: PropTypes.shape({
+    country_code: PropTypes.string,
+    extension: PropTypes.string,
+    id: PropTypes.number,
+    number: PropTypes.string,
+    service_type: PropTypes.string,
+  }).isRequired,
+};
+
+const EditPhones = editCollectionHOC(EditPhone, 'Phones', {});
 export default EditPhones;

--- a/app/components/Edit/EditPhones.js
+++ b/app/components/Edit/EditPhones.js
@@ -37,10 +37,17 @@ class EditPhone extends Component {
                     defaultValue={phone.number} 
                     onChange={this.handleFieldChange} 
                 />
+                <input
+                    type="tel"
+                    placeholder="Service type"
+                    data-field="service_type"
+                    defaultValue={phone.service_type}
+                    onChange={this.handleFieldChange}
+                />
             </li>
         );
     }
 }
 
-const EditPhones = editCollectionHOC(EditPhone, "Phones", {}, false);
+const EditPhones = editCollectionHOC(EditPhone, "Phones", {});
 export default EditPhones;

--- a/app/components/Edit/EditSections.js
+++ b/app/components/Edit/EditSections.js
@@ -111,7 +111,7 @@ class EditSections extends React.Component {
         }
 
         //Fire off phone requests
-        this.postCollection(this.state.phones, this.state.resource.phones, 'phones', promises);
+        this.postCollection(this.state.phones, this.state.resource.phones, 'phones', promises, this.state.resource.id);
 
         //schedule
         this.postObject(this.state.scheduleObj, 'schedule_days', promises);
@@ -138,7 +138,7 @@ class EditSections extends React.Component {
 
     }
 
-    postCollection(collection, originalCollection, path, promises) {
+    postCollection(collection, originalCollection, path, promises, resourceID) {
         for(let i = 0; i < collection.length; i++) {
             let item = collection[i];
 
@@ -149,7 +149,8 @@ class EditSections extends React.Component {
                     this.updateCollectionObject(diffObj.obj, item.id, path, promises);
                 }
             } else if(item.dirty) {
-                //post a new object
+                delete item.dirty
+                this.createCollectionObject(item, path, promises, resourceID);
             }
         }
     }
@@ -177,6 +178,18 @@ class EditSections extends React.Component {
                 {change_request: object}
             )
         );
+    }
+
+    /**
+     * Create a change request for a new object
+     */
+    createCollectionObject(object, path, promises, resourceID) {
+        promises.push(
+            dataService.post(
+              '/api/change_requests',
+              {change_request: object, type: path, parent_resource_id: resourceID}
+            )
+        )
     }
 
     postObject(object, path, promises) {

--- a/app/components/Edit/EditSections.js
+++ b/app/components/Edit/EditSections.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router';
-import { browserHistory } from 'react-router'
-import { images } from '../../assets';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import _ from 'lodash';
+
 import Loader from '../Loader';
 import EditAddress from './EditAddress';
 import EditServices from './EditServices';
@@ -9,433 +10,420 @@ import EditNotes from './EditNotes';
 import EditSchedule from './EditSchedule';
 import EditPhones from './EditPhones';
 import * as dataService from '../../utils/DataService';
-import { withRouter } from 'react-router';
 import { daysOfTheWeek } from '../../utils/index';
-import _ from 'lodash';
+
+function getDiffObject(curr, orig) {
+  return Object.entries(curr).reduce((acc, [key, value]) => {
+    if (!_.isEqual(orig[key], value)) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
+}
+
+function updateCollectionObject(object, id, path, promises) {
+  promises.push(
+    dataService.post(
+      `/api/${path}/${id}/change_requests`,
+      { change_request: object },
+    ),
+  );
+}
+
+/**
+ * Create a change request for a new object.
+ */
+function createCollectionObject(object, path, promises, resourceID) {
+  promises.push(
+    dataService.post(
+      '/api/change_requests',
+      { change_request: object, type: path, parent_resource_id: resourceID },
+    ),
+  );
+}
+
+function postCollection(collection, originalCollection, path, promises, resourceID) {
+  for (let i = 0; i < collection.length; i += 1) {
+    const item = collection[i];
+
+    if (i < originalCollection.length && item.dirty) {
+      const diffObj = getDiffObject(item, originalCollection[i]);
+      if (!_.isEmpty(diffObj)) {
+        delete diffObj.obj.dirty;
+        updateCollectionObject(diffObj.obj, item.id, path, promises);
+      }
+    } else if (item.dirty) {
+      delete item.dirty;
+      createCollectionObject(item, path, promises, resourceID);
+    }
+  }
+}
+
+function postObject(object, path, promises) {
+  Object.entries(object).forEach(([key, value]) => {
+    promises.push(dataService.post(`/api/${path}/${key}/change_requests`, { change_request: value }));
+  });
+}
+
+function postSchedule(scheduleObj, promises) {
+  if (scheduleObj) {
+    postObject(scheduleObj, 'schedule_days', promises);
+  }
+}
+
+function postNotes(notesObj, promises, uriObj) {
+  if (notesObj && notesObj.notes) {
+    const notes = notesObj.notes;
+    Object.entries(notes).forEach(([key, currentNote]) => {
+      if (key < 0) {
+        const uri = `/api/${uriObj.path}/${uriObj.id}/notes`;
+        promises.push(dataService.post(uri, { note: currentNote }));
+      } else {
+        const uri = `/api/notes/${key}/change_requests`;
+        promises.push(dataService.post(uri, { change_request: currentNote }));
+      }
+    });
+  }
+}
+
+function createFullSchedule(scheduleObj) {
+  const daysTemplate = {};
+  for (let i = 0; i < daysOfTheWeek().length; i += 1) {
+    const day = daysOfTheWeek()[i];
+    daysTemplate[day] = {
+      day,
+      opens_at: null,
+      closes_at: null,
+    };
+  }
+
+  if (scheduleObj) {
+    Object.values(scheduleObj).forEach((scheduleDay) => {
+      Object.entries(scheduleDay).forEach(([dayKey, schedule]) => {
+        daysTemplate[scheduleDay.day][dayKey] = schedule;
+      });
+    });
+  }
+
+  return { schedule_days: Object.values(daysTemplate) };
+}
 
 class EditSections extends React.Component {
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            scheduleObj: {},
-            schedule_days: {},
-            resourceFields: {},
-            serviceFields: {},
-            addressFields: {},
-            services: {},
-            notes: {},
-            phones: [],
-            submitting: false
-        };
+    this.state = {
+      scheduleObj: {},
+      schedule_days: {},
+      resourceFields: {},
+      serviceFields: {},
+      addressFields: {},
+      services: {},
+      notes: {},
+      phones: [],
+      submitting: false,
+    };
 
-        this.handleResourceFieldChange = this.handleResourceFieldChange.bind(this);
-        this.handleScheduleChange = this.handleScheduleChange.bind(this);
-        this.handlePhoneChange = this.handlePhoneChange.bind(this);
-        this.handleAddressChange = this.handleAddressChange.bind(this);
-        this.handleServiceChange = this.handleServiceChange.bind(this);
-        this.handleNotesChange = this.handleNotesChange.bind(this);
-        this.handleSubmit = this.handleSubmit.bind(this);
-        this.postServices = this.postServices.bind(this);
-        this.postObject = this.postObject.bind(this);
-        this.postNotes = this.postNotes.bind(this);
-        this.postSchedule = this.postSchedule.bind(this);
-    }
+    this.handleResourceFieldChange = this.handleResourceFieldChange.bind(this);
+    this.handleScheduleChange = this.handleScheduleChange.bind(this);
+    this.handlePhoneChange = this.handlePhoneChange.bind(this);
+    this.handleAddressChange = this.handleAddressChange.bind(this);
+    this.handleServiceChange = this.handleServiceChange.bind(this);
+    this.handleNotesChange = this.handleNotesChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.postServices = this.postServices.bind(this);
+  }
 
-    hasKeys(object) {
-        let size = 0;
-        for(let key in object) {
-            if(object.hasOwnProperty(key)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    componentDidMount() {
-        let { query } = this.props.location;
-	    let resourceID = query.resourceid;
-	    let url = '/api/resources/' + resourceID;
-	    fetch(url).then(r => r.json())
-	    .then(data => {
-	      	this.setState({
-                  resource: data.resource,
-                  originalResource: data.resource
-            });
-
-            let scheduleMap = {};
-            data.resource.schedule.schedule_days.forEach(function(day) {
-                scheduleMap[day.day] = day;
-            });
-            this.setState({scheduleMap: scheduleMap});
-	    });
-    }
-
-    handleSubmit() {
-        this.setState({submitting: true});
-        let resource = this.state.resource;
-        let promises = [];
-
-        //Resource
-        let resourceChangeRequest = {};
-        let resourceModified = false;
-        if(this.state.name && this.state.name !== resource.name) {
-            resourceChangeRequest.name = this.state.name;
-            resourceModified = true;
-        }
-        if(this.state.long_description && this.state.long_description !== resource.long_description) {
-            resourceChangeRequest.long_description = this.state.long_description;
-            resourceModified = true;
-        }
-        if(this.state.short_description && this.state.short_description !== resource.short_description) {
-            resourceChangeRequest.short_description = this.state.short_description;
-            resourceModified = true;
-        }
-        if(this.state.website && this.state.website !== resource.website) {
-            resourceChangeRequest.website = this.state.website;
-            resourceModified = true;
-        }
-        if(this.state.name && this.state.name !== resource.name) {
-            resourceChangeRequest.name = this.state.name;
-            resourceModified = true;
-        }
-        if(this.state.email && this.state.email !== resource.email) {
-            resourceChangeRequest.email = this.state.email;
-            resourceModified = true;
-        }
-        //fire off resource request
-        if(resourceModified) {
-            promises.push(dataService.post('/api/resources/' + resource.id + '/change_requests', {change_request: resourceChangeRequest}));
-        }
-
-        //Fire off phone requests
-        this.postCollection(this.state.phones, this.state.resource.phones, 'phones', promises, this.state.resource.id);
-
-        //schedule
-        this.postObject(this.state.scheduleObj, 'schedule_days', promises);
-
-        //address
-        if(this.hasKeys(this.state.address) && this.state.resource.address) {
-            promises.push(dataService.post('/api/addresses/' + this.state.resource.address.id + '/change_requests', {
-                change_request: this.state.address
-            }));
-        }
-
-        //Services
-        this.postServices(this.state.services.services, promises);
-
-        //Notes
-        this.postNotes(this.state.notes, promises, {path: "resources", id: this.state.resource.id});
-
-        var that = this;
-        Promise.all(promises).then(function(resp) {
-            that.props.router.push({ pathname: "/resource", query: { id: that.state.resource.id } });
-        }).catch(function(err) {
-            console.log(err);
+  componentDidMount() {
+    const resourceID = this.props.location.query.resourceid;
+    const url = `/api/resources/${resourceID}`;
+    fetch(url).then(r => r.json())
+      .then((data) => {
+        this.setState({
+          resource: data.resource,
+          originalResource: data.resource,
         });
 
+        const scheduleMap = {};
+        data.resource.schedule.schedule_days.forEach((day) => {
+          scheduleMap[day.day] = day;
+        });
+        this.setState({ scheduleMap });
+      });
+  }
+
+  handleSubmit() {
+    this.setState({ submitting: true });
+    const resource = this.state.resource;
+    const promises = [];
+
+    // Resource
+    const resourceChangeRequest = {};
+    let resourceModified = false;
+    if (this.state.name && this.state.name !== resource.name) {
+      resourceChangeRequest.name = this.state.name;
+      resourceModified = true;
+    }
+    if (this.state.long_description && this.state.long_description !== resource.long_description) {
+      resourceChangeRequest.long_description = this.state.long_description;
+      resourceModified = true;
+    }
+    if (this.state.short_description &&
+      this.state.short_description !== resource.short_description) {
+      resourceChangeRequest.short_description = this.state.short_description;
+      resourceModified = true;
+    }
+    if (this.state.website && this.state.website !== resource.website) {
+      resourceChangeRequest.website = this.state.website;
+      resourceModified = true;
+    }
+    if (this.state.name && this.state.name !== resource.name) {
+      resourceChangeRequest.name = this.state.name;
+      resourceModified = true;
+    }
+    if (this.state.email && this.state.email !== resource.email) {
+      resourceChangeRequest.email = this.state.email;
+      resourceModified = true;
+    }
+    // fire off resource request
+    if (resourceModified) {
+      promises.push(dataService.post(`/api/resources/${resource.id}/change_requests`, { change_request: resourceChangeRequest }));
     }
 
-    postCollection(collection, originalCollection, path, promises, resourceID) {
-        for(let i = 0; i < collection.length; i++) {
-            let item = collection[i];
+    // Fire off phone requests
+    postCollection(this.state.phones, this.state.resource.phones, 'phones', promises, resource.id);
 
-            if(i < originalCollection.length && item.dirty) {
-                let diffObj = this.getDiffObject(item, originalCollection[i]);
-                if(diffObj.numKeys > 0) {
-                    delete diffObj.obj.dirty;
-                    this.updateCollectionObject(diffObj.obj, item.id, path, promises);
-                }
-            } else if(item.dirty) {
-                delete item.dirty
-                this.createCollectionObject(item, path, promises, resourceID);
-            }
-        }
+    // schedule
+    postObject(this.state.scheduleObj, 'schedule_days', promises);
+
+    // address
+    if (!_.isEmpty(this.state.address) && this.state.resource.address) {
+      promises.push(dataService.post(`/api/addresses/${this.state.resource.address.id}/change_requests`, {
+        change_request: this.state.address,
+      }));
     }
 
-    getDiffObject(curr, orig) {
-        let diffObj = {
-            obj: {},
-            numKeys: 0
-        };
+    // Services
+    this.postServices(this.state.services.services, promises);
 
-        for(let key in curr) {
-            if(!_.isEqual(curr[key], orig[key])) {
-                diffObj.obj[key] = curr[key];
-                diffObj.numKeys++;
-            }
-        }
+    // Notes
+    postNotes(this.state.notes, promises, { path: 'resources', id: this.state.resource.id });
 
-        return diffObj;
-    }
+    // TODO: Handle errors
+    Promise.all(promises).then(() => {
+      this.props.router.push({ pathname: '/resource', query: { id: this.state.resource.id } });
+    });
+  }
 
-    updateCollectionObject(object, id, path, promises) {
-        promises.push(
-            dataService.post(
-                '/api/' + path + '/' + id + '/change_requests', 
-                {change_request: object}
-            )
-        );
-    }
-
-    /**
-     * Create a change request for a new object
-     */
-    createCollectionObject(object, path, promises, resourceID) {
-        promises.push(
-            dataService.post(
-              '/api/change_requests',
-              {change_request: object, type: path, parent_resource_id: resourceID}
-            )
-        )
-    }
-
-    postObject(object, path, promises) {
-        for(let key in object) {
-            if(object.hasOwnProperty(key)) {
-                promises.push(dataService.post('/api/' + path + '/' + key + '/change_requests', {change_request: object[key]}));
-            }
-        }
-    }
-
-    postServices(servicesObj, promises) {
-        let newServices = [];
-        for(let key in servicesObj) {
-            if(servicesObj.hasOwnProperty(key)) {
-                let currentService = servicesObj[key];
-
-                if(key < 0) {
-                    if(currentService.notesObj) {
-                        let notes = this.objToArray(currentService.notesObj.notes);
-                        delete currentService.notesObj;
-                        currentService.notes = notes;
-                    }
-
-                    currentService.schedule = this.createFullSchedule(currentService.scheduleObj);
-                    delete currentService.scheduleObj;
-
-                    if(!isEmpty(currentService)) {
-                        newServices.push(currentService);
-                    }
-                } else {
-                    let uri = '/api/services/' + key + '/change_requests';
-                    this.postNotes(currentService.notesObj, promises, {path: "services", id: key});
-                    delete currentService.notesObj;
-                    this.postSchedule(currentService.scheduleObj, promises);
-                    delete currentService.scheduleObj;
-                    if(!isEmpty(currentService)) {
-                        promises.push(dataService.post(uri, {change_request: currentService}));
-                    }
-
-                }
-            }
+  postServices(servicesObj, promises) {
+    if (!servicesObj) return;
+    const newServices = [];
+    Object.entries(servicesObj).forEach(([key, value]) => {
+      const currentService = value;
+      if (key < 0) {
+        if (currentService.notesObj) {
+          const notes = Object.values(currentService.notesObj.notes);
+          delete currentService.notesObj;
+          currentService.notes = notes;
         }
 
-        if(newServices.length > 0) {
-            let uri = '/api/resources/' + this.state.resource.id + '/services';
-            promises.push(dataService.post(uri, {services: newServices}));
+        currentService.schedule = createFullSchedule(currentService.scheduleObj);
+        delete currentService.scheduleObj;
+
+        if (!_.isEmpty(currentService)) {
+          newServices.push(currentService);
         }
-    }
-
-    createFullSchedule(scheduleObj) {
-        let daysTemplate = {};
-        for(let i = 0; i < daysOfTheWeek().length; i++) {
-            let day = daysOfTheWeek()[i];
-            daysTemplate[day] = {
-                day: day,
-                opens_at: null,
-                closes_at: null
-            }
+      } else {
+        const uri = `/api/services/${key}/change_requests`;
+        postNotes(currentService.notesObj, promises, { path: 'services', id: key });
+        delete currentService.notesObj;
+        postSchedule(currentService.scheduleObj, promises);
+        delete currentService.scheduleObj;
+        if (!_.isEmpty(currentService)) {
+          promises.push(dataService.post(uri, { change_request: currentService }));
         }
+      }
+    });
 
-        if(scheduleObj) {
-            for(let key in scheduleObj) {
-                if(scheduleObj.hasOwnProperty(key)) {
-                    let scheduleDay = scheduleObj[key];
-                    for(let dayKey in scheduleDay) {
-                        daysTemplate[scheduleDay.day][dayKey] = scheduleDay[dayKey];
-                    }
-                }
-            }
-        }
-
-        let scheduleDays = [];
-        for(let day in daysTemplate) {
-            if(daysTemplate.hasOwnProperty(day)) {
-                scheduleDays.push(daysTemplate[day]);
-            }
-        }
-
-        return {schedule_days: scheduleDays};
+    if (newServices.length > 0) {
+      const uri = `/api/resources/${this.state.resource.id}/services`;
+      promises.push(dataService.post(uri, { services: newServices }));
     }
+  }
 
-    objToArray(obj) {
-        let arr = [];
-        for(let key in obj) {
-            if(obj.hasOwnProperty(key)) {
-                arr.push(obj[key]);
-            }
-        }
+  handlePhoneChange(phoneCollection) {
+    this.setState({ phones: phoneCollection });
+  }
 
-        return arr;
-    }
+  handleResourceFieldChange(e) {
+    const field = e.target.dataset.field;
+    const value = e.target.value;
+    const object = {};
+    object[field] = value;
+    this.setState(object);
+  }
 
-    postSchedule(scheduleObj, promises, uriObj) {
-        if(scheduleObj) {
-            this.postObject(scheduleObj, 'schedule_days', promises);
-        }
-    }
+  handleScheduleChange(scheduleObj) {
+    this.setState({ scheduleObj });
+  }
 
-    postNotes(notesObj, promises, uriObj) {
-        if(notesObj) {
-            let notes = notesObj.notes;
-            let newNotes = [];
-            for(let key in notes) {
-                if(notes.hasOwnProperty(key)) {
-                    let currentNote = notes[key];
-                    if(key < 0) {
-                        let uri = '/api/' + uriObj.path + '/' + uriObj.id + '/notes';
-                        promises.push(dataService.post(uri, {note: currentNote}));
-                    } else {
-                        let uri = '/api/notes/' + key + '/change_requests';
-                        promises.push(dataService.post(uri, {change_request: currentNote}));
-                    }
-                }
-            }
-        }
-    }
+  handleAddressChange(addressObj) {
+    this.setState({ address: addressObj });
+  }
 
-    handlePhoneChange(phoneCollection) {
-        this.setState({phones: phoneCollection});
-    }
+  handleServiceChange(servicesObj) {
+    this.setState({ services: servicesObj });
+  }
 
-    handleResourceFieldChange(e) {
-        let field = e.target.dataset.field;
-        let value = e.target.value;
-        let object = {};
-        object[field] = value;
-        this.setState(object);
-	}
+  handleNotesChange(notesObj) {
+    this.setState({ notes: notesObj });
+  }
 
-    handleScheduleChange(scheduleObj) {
-        this.setState({scheduleObj: scheduleObj});
-    }
+  handleServiceNotesChange(notesObj) {
+    this.setState({ serviceNotes: notesObj });
+  }
 
-    handleAddressChange(addressObj) {
-        this.setState({address: addressObj});
-    }
+  renderSectionFields() {
+    const resource = this.state.resource;
+    return (
+      <section id="info" className="edit--section">
+        <header className="edit--section--header">
+          <h4>Info</h4>
+        </header>
+        <ul className="edit--section--list">
 
-    handleServiceChange(servicesObj) {
-        this.setState({services: servicesObj});
-    }
+          <li key="name" className="edit--section--list--item">
+            <label htmlFor="edit-name-input">Name</label>
+            <input
+              id="edit-name-input"
+              type="text"
+              placeholder="Name"
+              data-field="name"
+              defaultValue={resource.name}
+              onChange={this.handleResourceFieldChange}
+            />
+          </li>
 
-    handleNotesChange(notesObj) {
-        this.setState({notes: notesObj});
-    }
+          <EditAddress
+            address={this.state.resource.address}
+            updateAddress={this.handleAddressChange}
+          />
 
-    handleServiceNotesChange(notesObj) {
-        this.setState({serviceNotes: notesObj});
-    }
+          <EditPhones
+            collection={this.state.resource.phones}
+            handleChange={this.handlePhoneChange}
+          />
 
-    formatTime(time) {
-        //FIXME: Use full times once db holds such values.
-        return time.substring(0, 2);
-    }
+          <li key="website" className="edit--section--list--item email">
+            <label htmlFor="edit-website-input">Website</label>
+            <input
+              id="edit-website-input"
+              type="url"
+              defaultValue={resource.website}
+              data-field="website"
+              onChange={this.handleResourceFieldChange}
+            />
+          </li>
 
-    renderSectionFields() {
-        let fields = [];
-        let resource = this.state.resource;
-        return (
-        <section id="info" className="edit--section">
-        	<header className="edit--section--header">
-        		<h4>Info</h4>
-        	</header>
-          <ul className="edit--section--list">
+          <li key="email" className="edit--section--list--item email">
+            <label htmlFor="edit-email-input">E-Mail</label>
+            <input
+              id="edit-email-input"
+              type="email"
+              defaultValue={resource.email}
+              data-field="email"
+              onChange={this.handleResourceFieldChange}
+            />
+          </li>
 
-            <li key="name" className="edit--section--list--item">
-                <label>Name</label>
-                <input type="text" placeholder="Name" data-field='name' defaultValue={resource.name} onChange={this.handleResourceFieldChange} />
-            </li>
+          <li key="long_description" className="edit--section--list--item">
+            <label htmlFor="edit-description-input">Description</label>
+            <textarea
+              id="edit-description-input"
+              className=""
+              defaultValue={resource.long_description}
+              data-field="long_description"
+              onChange={this.handleResourceFieldChange}
+            />
+          </li>
 
-            <EditAddress address={this.state.resource.address} updateAddress={this.handleAddressChange}/>
+          <EditSchedule
+            schedule={this.state.resource.schedule}
+            handleScheduleChange={this.handleScheduleChange}
+          />
 
-            <EditPhones collection={this.state.resource.phones} handleChange={this.handlePhoneChange} />
+          <EditNotes
+            notes={this.state.resource.notes}
+            handleNotesChange={this.handleNotesChange}
+          />
 
-            <li key="website" className="edit--section--list--item email">
-                <label>Website</label>
-                <input type="url" defaultValue={resource.website} data-field='website' onChange={this.handleResourceFieldChange}/>
-            </li>
+        </ul>
+      </section>
+    );
+  }
 
-            <li key="email" className="edit--section--list--item email">
-                <label>E-Mail</label>
-                <input type="url" defaultValue={resource.email} data-field='email' onChange={this.handleResourceFieldChange}/>
-            </li>
+  renderServices() {
+    return (
+      <section id="services" className="edit--section">
+        <header className="edit--section--header">
+          <h4>Services</h4>
+        </header>
+        <ul className="edit--section--list">
+          <EditServices
+            services={this.state.resource.services}
+            handleServiceChange={this.handleServiceChange}
+          />
+        </ul>
+      </section>
+    );
+  }
 
-            <li key="long_description" className="edit--section--list--item">
-                <label>Description</label>
-                <textarea className="" defaultValue={resource.long_description} data-field='long_description' onChange={this.handleResourceFieldChange} />
-            </li>
-
-            <EditSchedule schedule={this.state.resource.schedule} handleScheduleChange={this.handleScheduleChange} />
-
-            <EditNotes notes={this.state.resource.notes} handleNotesChange={this.handleNotesChange} />
-
-          </ul>
-        </section>
-        );
-    }
-
-    renderServices() {
-    	let fields = [];
-      let resource = this.state.resource;
-    	return (
-    		<section id="services" className="edit--section">
-    			<header className="edit--section--header">
-    				<h4>Services</h4>
-    			</header>
-    			<ul className="edit--section--list">
-    				<EditServices services={this.state.resource.services} handleServiceChange={this.handleServiceChange} />
-    			</ul>
-    		</section>
-    	)
-    }
-
-    render() {
-      return (
-        !this.state.resource ? <Loader /> :
-        <div className="edit">
-        	<div className="edit--main">
-            <header className="edit--main--header">
-              <h1 className="edit--main--header--title">{this.state.resource.name}</h1>
-            </header>
-            <div className="edit--sections">
-	            {this.renderSectionFields()}
-	            {this.renderServices()}
-            </div>
-          </div>
-          <div className="edit--aside">
-          	<div className="edit--aside--content">
-	          	<button className="edit--aside--content--submit" disabled={this.state.submitting} onClick={this.handleSubmit}>Save changes</button>
-	          	<nav className="edit--aside--content--nav">
-	          		<ul>
-	          			<li><a href="#info">Info</a></li>
-	          			<li><a href="#services">Services</a></li>
-	          		</ul>
-	          	</nav>
-	          </div>
+  render() {
+    return (
+      !this.state.resource ? <Loader /> :
+      <div className="edit">
+        <div className="edit--main">
+          <header className="edit--main--header">
+            <h1 className="edit--main--header--title">{this.state.resource.name}</h1>
+          </header>
+          <div className="edit--sections">
+            {this.renderSectionFields()}
+            {this.renderServices()}
           </div>
         </div>
-      )
-    }
+        <div className="edit--aside">
+          <div className="edit--aside--content">
+            <button
+              className="edit--aside--content--submit"
+              disabled={this.state.submitting}
+              onClick={this.handleSubmit}
+            >
+              Save changes
+            </button>
+            <nav className="edit--aside--content--nav">
+              <ul>
+                <li><a href="#info">Info</a></li>
+                <li><a href="#services">Services</a></li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 
-function isEmpty(map) {
-   for(var key in map) {
-      return !map.hasOwnProperty(key);
-   }
-   return true;
-}
+EditSections.propTypes = {
+  // TODO: location is only ever used to get the resourceid; we should just pass
+  // in the resourceid directly as a prop
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      resourceid: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  // TODO: Figure out what type router actually is
+  router: PropTypes.instanceOf(Object).isRequired,
+};
 
 export default withRouter(EditSections);

--- a/app/components/Resource/Resource.js
+++ b/app/components/Resource/Resource.js
@@ -1,6 +1,6 @@
 
 import React, { Component } from 'react';
-import {AddressInfo, TodaysHours, PhoneNumber, WeeklyHours, ResourceCategories, Website, Languages, StreetView} from './ResourceInfos';
+import {AddressInfo, TodaysHours, PhoneNumber, WeeklyHours, ResourceCategories, Website, StreetView} from './ResourceInfos';
 import DetailedHours from './DetailedHours';
 import CommunicationBoxes from './CommunicationBoxes';
 import Services from './Services';
@@ -36,7 +36,7 @@ class Resource extends Component {
         <article className="org" id="resource">
 	        <div className="org--map">
 	          <ResourceMap name={resource.name} lat={ resource.address.latitude} long={resource.address.longitude} userLocation={this.props.userLocation} />
-	          <StreetView address={resource.address} />
+	          <StreetView address={resource.address} resourceName={resource.name} />
 	        </div>
 	        <div className="org--main">
 						<div className="org--main--left">

--- a/app/components/Resource/ResourceInfos.js
+++ b/app/components/Resource/ResourceInfos.js
@@ -1,149 +1,175 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
 import Hours from './Hours';
-import classNames from 'classnames/bind';
-import { timeToString, stringToTime, daysOfTheWeek, buildHoursText} from '../../utils/index';
 
-class Cat extends Component {
-  render() {
-    return <p>{this.props.category}</p>;
-  }
+function Cat(props) {
+  return <p>{props.category}</p>;
 }
 
-class ResourceCategories extends Component {
-  constructor(props) {
-    super(props);
-  }
+Cat.propTypes = {
+  category: PropTypes.string.isRequired,
+};
 
-  render() {
-    if(this.props.categories.length) {
-      let categoryMap = {};
-      this.props.categories.forEach(category => {
-        categoryMap[category.name] = true;
-      });
 
-      let cats = Object.keys(categoryMap).map((cat, i) =>{
-        return <Cat category={cat} key={i} />
-      });
-      return <span className="categories">{cats}</span>;
-    } else {
-      return null;
-    }
+function ResourceCategories(props) {
+  if (props.categories.length) {
+    const categories = _.uniqBy(props.categories, 'id');
+    const cats = categories.map(cat => <Cat category={cat.name} key={cat.id} />);
+    return <span className="categories">{cats}</span>;
   }
+  return null;
 }
 
-class AddressInfo extends Component {
-  render() {
-    return (
-      <span className="address">
-        {buildLocation(this.props.address)}
-      </span>
-    );
-  }
-}
+ResourceCategories.propTypes = {
+  categories: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+  })).isRequired,
+};
 
-class TodaysHours extends Component {
-  render() {
-    return (
-      <Hours schedule={this.props.schedule_days} />
-    );
-  }
-}
-
-class PhoneNumber extends Component {
-  render() {
-    return (
-      <span className="phone">
-        {buildPhoneNumber(this.props.phones)}
-      </span>
-    );
-  }
-}
-
-class Languages extends Component {
-  render() {
-    return (
-      <span className="lang">
-        <p>English, Spanish</p>
-      </span>
-    );
-  }
-}
-
-class Website extends Component {
-  render() {
-    return (
-      <span className="website">
-        <a href={this.props.website} target="_blank">{this.props.website}</a>
-      </span>
-    );
-  }
-}
-
-class StreetView extends Component {
-  render() {
-    return (
-      <div className="org-streetview">
-        <img className="org-streetview--img" src={buildImgURL(this.props.address)} />
-      </div>
-    );
-  }
-}
 
 function buildLocation(address) {
-  let line1 = "";
-  let line2 = "";
+  let line1 = '';
+  let line2 = '';
 
-  if(address) {
-    if(address.address_1) {
+  if (address) {
+    if (address.address_1) {
       line1 += address.address_1;
     }
 
-    if(address.address_2) {
-      line1 += ", " + address.address_2;
+    if (address.address_2) {
+      line1 += `, ${address.address_2}`;
     }
 
-    if(address.city) {
+    if (address.city) {
       line2 += address.city;
     }
 
-    if(address.state_province) {
-      line2 += ", " + address.state_province;
+    if (address.state_province) {
+      line2 += `, ${address.state_province}`;
     }
 
-    if(address.postal_code) {
-      line2 += ", " + address.postal_code;
+    if (address.postal_code) {
+      line2 += `, ${address.postal_code}`;
     }
   }
 
   return (
     <span>
-    {line1}<br />{line2}
+      {line1}<br />{line2}
     </span>
   );
 }
 
-function buildPhoneNumber(phones) {
-  if(!phones) {
-    return;
-  }
-
-  return phones.map((phone) =>
-    <p key={phone.id}>{phone.number} {phone.service_type}</p>
+function AddressInfo(props) {
+  return (
+    <span className="address">
+      {buildLocation(props.address)}
+    </span>
   );
 }
 
-function buildImgURL(address) {
-  if(address) {
-     let url = "https://maps.googleapis.com/maps/api/streetview?size=400x400&location=" +
-      address.latitude + "," + address.longitude +
-      "&fov=90&heading=235&pitch=10";
-      if(CONFIG.GOOGLE_API_KEY) {
-        url += '&key=' + CONFIG.GOOGLE_API_KEY;
-      }
-      return url;
-  } else {
-    return "http://lorempixel.com/200/200/city/";
-  }
+const AddressType = PropTypes.shape({
+  address_1: PropTypes.string,
+  address_2: PropTypes.string,
+  city: PropTypes.string,
+  state: PropTypes.string,
+  postal_code: PropTypes.string,
+});
+
+AddressInfo.propTypes = {
+  address: AddressType,
+};
+
+
+function TodaysHours(props) {
+  return (
+    <Hours schedule={props.schedule_days} />
+  );
 }
 
-export {Cat, AddressInfo, TodaysHours, PhoneNumber, ResourceCategories, Website, Languages, StreetView};
+TodaysHours.propTypes = {
+  schedule_days: PropTypes.arrayOf(PropTypes.shape({
+    closes_at: PropTypes.number.isRequired,
+    day: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
+    opens_at: PropTypes.number.isRequired,
+  })),
+};
+
+
+function buildPhoneNumber(phones) {
+  if (!phones) {
+    return null;
+  }
+
+  return phones.map(phone =>
+    <p key={phone.id}>{phone.number} {phone.service_type}</p>,
+  );
+}
+
+function PhoneNumber(props) {
+  return (
+    <span className="phone">
+      {buildPhoneNumber(props.phones)}
+    </span>
+  );
+}
+
+PhoneNumber.propTypes = {
+  phones: PropTypes.arrayOf(PropTypes.shape({
+    country_code: PropTypes.string,
+    extension: PropTypes.string,
+    id: PropTypes.number.isRequired,
+    number: PropTypes.string.isRequired,
+    service_type: PropTypes.string,
+  })).isRequired,
+};
+
+
+function Website(props) {
+  return (
+    <span className="website">
+      <a href={props.website} target="_blank" rel="noopener noreferrer">{props.website}</a>
+    </span>
+  );
+}
+
+Website.propTypes = {
+  website: PropTypes.string,
+};
+
+
+function buildImgURL(address) {
+  if (address) {
+    let url = `https://maps.googleapis.com/maps/api/streetview?size=400x400&location=${address.latitude},${address.longitude}&fov=90&heading=235&pitch=10`;
+    // Ignore undefined CONFIG because it gets injected by extended-define-webpack-plugin
+    /* eslint-disable no-undef */
+    if (CONFIG.GOOGLE_API_KEY) {
+      url += `&key=${CONFIG.GOOGLE_API_KEY}`;
+    }
+    /* eslint-enable no-undef */
+    return url;
+  }
+  return 'http://lorempixel.com/200/200/city/';
+}
+
+function StreetView(props) {
+  return (
+    <div className="org-streetview">
+      <img
+        className="org-streetview--img"
+        src={buildImgURL(props.address)}
+        alt={`Street view of ${props.resourceName}`}
+      />
+    </div>
+  );
+}
+
+StreetView.propTypes = {
+  address: AddressType,
+  resourceName: PropTypes.string.isRequired,
+};
+
+export { Cat, AddressInfo, TodaysHours, PhoneNumber, ResourceCategories, Website, StreetView };

--- a/app/components/Resource/ResourceInfos.js
+++ b/app/components/Resource/ResourceInfos.js
@@ -127,14 +127,8 @@ function buildPhoneNumber(phones) {
     return;
   }
 
-  let phone = {};
-
-  if(phones.length && phones.length > 0) {
-    phone = phones[0];
-  }
-
-  return (
-    <p>{phone.number}</p>
+  return phones.map((phone) =>
+    <p key={phone.id}>{phone.number} {phone.service_type}</p>
   );
 }
 

--- a/app/styles/components/_edit.scss
+++ b/app/styles/components/_edit.scss
@@ -151,6 +151,10 @@
 			margin-bottom: calc-em(10px);
 		}
 
+		input:not(last-of-type) {
+			margin-right: calc-em(10px);
+		}
+
 		textarea {
 			height: calc-em(200px);
 		}
@@ -214,6 +218,7 @@
 		label {
 			width: calc-em(150px);
 			color: #333333;
+			flex-shrink: 0;
 			font-size: calc-em(17px);
 			font-weight: bold;
 			padding-top: calc-em(15px);


### PR DESCRIPTION
Depends on https://github.com/ShelterTechSF/askdarcel-api/pull/180

I added a new API endpoint for adding new phone numbers on the edit page. I also noticed that the `service_type` of the phone number wasn't hooked up, so I added it in both the display and edit views. One thing of note is that the linksf data appears to have put phone number extensions in the `service_type` field for many numbers. This will at least have the side effect of displaying them and making them editable, but we should probably be putting the extensions into the number field.

<img width="936" alt="screen shot 2017-07-06 at 7 55 28 pm" src="https://user-images.githubusercontent.com/1002748/27941494-b5395978-6285-11e7-9d32-53926dc46d49.png">

<img width="1057" alt="screen shot 2017-07-06 at 7 56 16 pm" src="https://user-images.githubusercontent.com/1002748/27941497-ba653138-6285-11e7-805d-fc949c0b48e8.png">

I attempted to lint the files that I edited here, but that's proving to be quite the endeavor because of how long the EditSections.js and ResourceInfos.js files are. I'm going to try to add linting on top of this, but if I don't get to that in time, I think this can merge in first. We're definitely going to want to do some extensive manual QA if I do get this linted because it's forcing me to make pretty large changes to EditSections.js.