### PR TITLE
Add a label to the categories dropdown.

### DIFF
--- a/app/components/Edit/EditServices.js
+++ b/app/components/Edit/EditServices.js
@@ -168,7 +168,10 @@ class EditService extends Component {
 					<EditNotes notes={this.props.service.notes} handleNotesChange={this.handleNotesChange} />
 
 					
-					{this.renderCategories()}
+					<li className="edit--section--list--item">
+						<label>Categories</label>
+						{this.renderCategories()}
+					</li>
 				</ul>
 			</li>
 		);


### PR DESCRIPTION
There's currently no label for the add new service categories dropdown, so this adds one.

<img width="745" alt="screen shot 2017-07-13 at 8 00 28 pm" src="https://user-images.githubusercontent.com/1002748/28196520-0fe3a092-6806-11e7-9860-f8a5e589bd88.png">
