### PR TITLE
Remove unnecessary .obj on diff objects.

### DIFF
--- a/app/components/Edit/EditSections.js
+++ b/app/components/Edit/EditSections.js
@@ -49,8 +49,8 @@ function postCollection(collection, originalCollection, path, promises, resource
     if (i < originalCollection.length && item.dirty) {
       const diffObj = getDiffObject(item, originalCollection[i]);
       if (!_.isEmpty(diffObj)) {
-        delete diffObj.obj.dirty;
-        updateCollectionObject(diffObj.obj, item.id, path, promises);
+        delete diffObj.dirty;
+        updateCollectionObject(diffObj, item.id, path, promises);
       }
     } else if (item.dirty) {
       delete item.dirty;


### PR DESCRIPTION
While I was refactoring the Edit page in order to pass the linter, I accidentally introduced this bug, which prevents us from editing any nested collection items on Resource. Previously our `getDiffObject()`  method returned an object that looked like `{obj: {diffs go here}, numKeys: 10}`. I refactored it to just have the `obj` as the top level object, since the number of keys can be directly gotten from that instead of having to create a separate property. I forgot to change where we use the results of `getDiffObject()` to not try to get `diffObj.obj` anymore.

Tested that this does allow me to edit existing phone numbers, but I discovered another bug with the admin page not showing the phone number edits.