### PR TITLE
Updated approveChangeRequests cli to correctly update fields

### DIFF
--- a/tools/cli/approveChangeRequests.js
+++ b/tools/cli/approveChangeRequests.js
@@ -64,7 +64,7 @@ function approveChangeRequests() {
 
               return new Promise((resolve, reject) => {
                 setTimeout(() => {
-                  resolve(darcel.postData(`/change_requests/${changeRequest.id}/approve`, body))
+                  resolve(darcel.postData(`/change_requests/${changeRequest.id}/approve`, { change_request: body }))
                 }, 10); // Brief timeout because Promise.all with ~500 requests broke the API
               }).then(() => console.log('approved', changeRequest.id));
             } else {


### PR DESCRIPTION
I either tested it against an old version of the API, or I'm stupid and didn't do thorough enough QA. Either way, the body of my change_requests/:id/approve function was not actually updating the values.