### PR TITLE
Fixed the logic for displaying open/close times in search results and made it so null times don't display

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -23,8 +23,10 @@ app/components/Resource/Hours.js
 app/components/Resource/Resource.js
 app/components/Resource/ResourceMap.js
 app/components/Resource/Services.js
+app/components/Resource/DetailedHours.js
 app/components/Search/ResourcesMap.js
 app/components/Search/ResourcesTable.js
+app/components/Search/ResourcesRow.js
 app/components/User/CreateAccount.js
 app/components/User/Login.js
 app/components/User/Splash.js

--- a/app/components/Resource/DetailedHours.js
+++ b/app/components/Resource/DetailedHours.js
@@ -14,13 +14,15 @@ export default function DetailedHours(props) {
         </div>
       );
     }
-    return (
-      <div key={item.id} className="weekly-hours-list--item">
-        <span className="weekly-hours-list--item--day">{`${item.day}`}</span>
-        <span className="weekly-hours-list--item--hours">{`${timeToString(item.opens_at)} - ${timeToString(item.closes_at)}`}
-        </span>
-      </div>
-    );
+    if (item.opens_at !== 0 && item.closes_at !== 0) {
+      return (
+        <div key={item.id} className="weekly-hours-list--item">
+          <span className="weekly-hours-list--item--day">{`${item.day}`}</span>
+          <span className="weekly-hours-list--item--hours">{`${timeToString(item.opens_at)} - ${timeToString(item.closes_at)}`}
+          </span>
+        </div>
+      );
+    }
   });
   return (
     <span className="weekly-hours-list">

--- a/app/components/Search/ResourcesRow.jsx
+++ b/app/components/Search/ResourcesRow.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router';
 import Rating from './Rating'
 import { timeToString, stringToTime, daysOfTheWeek } from '../../utils/index';
-
+import moment from 'moment';
 
 class ResourcesRow extends Component {
   constructor(props) {
@@ -40,7 +40,7 @@ class ResourcesRow extends Component {
     let date = new Date();
     let day = date.getDay();
     let days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-    let hour = date.getHours();
+    let currTime = moment().format("HH:mm").replace(':', '');
     let closingOpeningTimes = {};
     let currDay = days[day];
     let result = { open: false };
@@ -52,7 +52,8 @@ class ResourcesRow extends Component {
       };
     });
 
-    if(closingOpeningTimes[currDay] && hour < closingOpeningTimes[currDay].close) {
+
+    if(closingOpeningTimes[currDay] && currTime < closingOpeningTimes[currDay].close) {
       return {
         open:true,
         time: timeToString(closingOpeningTimes[currDay].close)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "html-webpack-plugin": "^2.19.0",
     "image-webpack-loader": "^1.8.0",
     "lodash": "^4.17.4",
+    "moment": "^2.18.1",
     "prop-types": "^15.5.10",
     "react": "^15.1.0",
     "react-autosize-textarea": "^0.4.3",


### PR DESCRIPTION
**Issue 1:**The logic for displaying whether or not a resource is open was flawed and in order to fix it I brought in a third party time library, moment.js. 

**Issue 2:** Some of the days in our data had open/close times that were `null`. In order to clean up the UI, any day that has an open or close time that is `null` will not be displayed. The main reason we get nulls is because any open/close time left empty in the edit pages will update the data to be `null`.

Fixes #286 