### PR TITLE
Add verification button

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -20,7 +20,6 @@ app/components/Find/FindPage.js
 app/components/Footer.js
 app/components/Resource/CommunicationBoxes.js
 app/components/Resource/Hours.js
-app/components/Resource/Resource.js
 app/components/Resource/ResourceMap.js
 app/components/Resource/Services.js
 app/components/Resource/DetailedHours.js

--- a/app/components/Resource/Resource.js
+++ b/app/components/Resource/Resource.js
@@ -1,146 +1,168 @@
-
 import React, { Component } from 'react';
-import {AddressInfo, TodaysHours, PhoneNumber, WeeklyHours, ResourceCategories, Website, StreetView} from './ResourceInfos';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+import { AddressInfo, TodaysHours, PhoneNumber, ResourceCategories, Website, StreetView } from './ResourceInfos';
 import DetailedHours from './DetailedHours';
-import CommunicationBoxes from './CommunicationBoxes';
 import Services from './Services';
 import Notes from './Notes';
 import Loader from '../Loader';
 import ResourceMap from './ResourceMap';
-import { Link } from 'react-router';
+
+function scrollToElement(selector) {
+  const elem = document.getElementById(selector);
+  if (elem) {
+    elem.scrollIntoView({ block: 'start', behaviour: 'smooth' });
+  }
+}
 
 class Resource extends Component {
   constructor(props) {
     super(props);
     this.state = { resource: null };
-    this.scrollToElement = this.scrollToElement.bind(this);
-  }
-
-  scrollToElement(selector){
-    var elem = document.getElementById(selector);
-    if(elem){
-      elem.scrollIntoView({block: 'start',  behaviour: 'smooth'});
-    }
-  }
-
-  loadResourceFromServer() {
-    let { query } = this.props.location;
-    let resourceID = query.id;
-    let url = '/api/resources/' + resourceID;
-    fetch(url).then(r => r.json())
-    .then(data => {
-      this.setState({resource: data.resource});
-    });
   }
 
   componentDidMount() {
     this.loadResourceFromServer();
   }
 
+  loadResourceFromServer() {
+    const { query } = this.props.location;
+    const resourceID = query.id;
+    const url = `/api/resources/${resourceID}`;
+    fetch(url).then(r => r.json())
+    .then((data) => {
+      this.setState({ resource: data.resource });
+    });
+  }
+
   render() {
     const { resource } = this.state;
-    return ( !resource || !window.google ? <Loader /> :
-      <div className="org-container">
-        <article className="org" id="resource">
-	        <div className="org--map">
-	          <ResourceMap name={resource.name} lat={ resource.address.latitude} long={resource.address.longitude} userLocation={this.props.userLocation} />
-	          <StreetView address={resource.address} resourceName={resource.name} />
-	        </div>
-	        <div className="org--main">
-						<div className="org--main--left">
+    return (!resource || !window.google ? <Loader /> :
+    <div className="org-container">
+      <article className="org" id="resource">
+        <div className="org--map">
+          <ResourceMap
+            name={resource.name}
+            lat={resource.address.latitude}
+            long={resource.address.longitude}
+            userLocation={this.props.userLocation}
+          />
+          <StreetView address={resource.address} resourceName={resource.name} />
+        </div>
+        <div className="org--main">
+          <div className="org--main--left">
 
-		          <header className="org--main--header">
-                <h1 className="org--main--header--title">{resource.name}</h1>
-                <div className="org--main--header--rating disabled-feature">
-                  <p className="excellent">{Math.floor(Math.random()*10)%6} <i className="material-icons">sentiment_very_satisfied</i><i className="material-icons">sentiment_very_satisfied</i><i className="material-icons">sentiment_very_satisfied</i><i className="material-icons">sentiment_very_satisfied</i><i className="material-icons">sentiment_very_satisfied</i></p>
-                </div>
-                <div className="org--main--header--hours">
-                	<TodaysHours schedule_days={resource.schedule.schedule_days} />
-                </div>
-                <div className="org--main--header--phone">
+            <header className="org--main--header">
+              <h1 className="org--main--header--title">{resource.name}</h1>
+              <div className="org--main--header--rating disabled-feature">
+                <p className="excellent">
+                  <i className="material-icons">sentiment_very_satisfied</i>
+                  <i className="material-icons">sentiment_very_satisfied</i>
+                  <i className="material-icons">sentiment_very_satisfied</i>
+                  <i className="material-icons">sentiment_very_satisfied</i>
+                  <i className="material-icons">sentiment_very_satisfied</i>
+                </p>
+              </div>
+              <div className="org--main--header--hours">
+                <TodaysHours schedule_days={resource.schedule.schedule_days} />
+              </div>
+              <div className="org--main--header--phone">
                 <PhoneNumber phones={resource.phones} />
+              </div>
+              <div className="org--main--header--description">
+                <header>About this resource</header>
+                <p>{resource.long_description || resource.short_description || 'No Description available'}</p>
+              </div>
+            </header>
+
+            <section className="service--section" id="services">
+              <header className="service--section--header">
+                <h4>Services</h4>
+              </header>
+              <ul className="service--section--list">
+                <Services description={resource.long_description} services={resource.services} />
+              </ul>
+            </section>
+
+            <Notes notes={this.state.resource.notes} />
+
+            <section className="info--section" id="info">
+              <header className="service--section--header">
+                <h4>Info</h4>
+              </header>
+              <ul className="info">
+                <div className="info--column">
+                  <ResourceCategories categories={resource.categories} />
+                  <AddressInfo address={resource.address} />
+                  <PhoneNumber phones={resource.phones} />
+                  <Website website={resource.website} />
+                  <span className="website">
+                    <a href={`mailto:${this.state.resource.email}`} target="_blank">{this.state.resource.email}</a>
+                  </span>
                 </div>
-                <div className="org--main--header--description">
-                	<header>About this resource</header>
-                  <p>{resource.long_description || resource.short_description || "No Description available"}</p>
+                <div className="info--column">
+                  <DetailedHours schedule={resource.schedule.schedule_days} />
                 </div>
-		          </header>
-
-		          <section className="service--section" id="services">
-				      	<header className="service--section--header">
-				      		<h4>Services</h4>
-				      	</header>
-				      	<ul className="service--section--list">
-		          		<Services description={resource.long_description} services={resource.services}/>
-				      	</ul>
-				      </section>
-
-              <Notes notes={this.state.resource.notes} />
-
-				      <section className="info--section" id="info">
-				      	<header className="service--section--header">
-				      		<h4>Info</h4>
-				      	</header>
-			          <ul className="info">
-				          <div className="info--column">
-				          	<ResourceCategories categories={resource.categories} />
-				            <AddressInfo address={resource.address} />
-				            <PhoneNumber phones={resource.phones} />
-				            <Website website={resource.website} />
-                    <span className="website">
-                      <a href={"mailto:"+this.state.resource.email} target="_blank">{this.state.resource.email}</a>
-                    </span>
-				          </div>
-				          <div className="info--column">
-			            	<DetailedHours schedule={resource.schedule.schedule_days} />
-			            </div>
-			          </ul>
-		          </section>
-	          </div>
-
-	          <div className="org--aside">
-	          	<div className="org--aside--content">
-		          	<a
-                  href={`https://maps.google.com?saddr=Current+Location&daddr=${resource.address.latitude},${resource.address.longitude}&dirflg=w`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="org--aside--content--button directions-button"
-                >
-                	Get Directions
-                </a>
-                <Link to={{ pathname: "/resource/edit", query: { resourceid: resource.id } }} className="org--aside--content--button edit-button">
-                    Make Edits
-                </Link>
-		          	<nav className="org--aside--content--nav">
-		          		<ul>
-		          			<li><a href="#resource">{resource.name}</a></li>
-		          			<li><a href="#services">Services</a>
-                      <ul className="service--nav--list">
-                        { 
-                          resource.services.map(service => {
-                            return (
-                              <li key={service.id}>
-                                <a href={`#service-${service.id}`} onClick={ this.scrollToElement("service-" + service.id) }>
-                                  {service.name}
-                                </a>
-                              </li>
-                            )
-                          })
-                        }
-                      </ul>
-                    </li>
-		          			<li><a href="#info">Info</a></li>
-		          		</ul>
-		          	</nav>
-		          </div>
-	          </div>
+              </ul>
+            </section>
           </div>
-        </article>
-      </div>
+
+          <div className="org--aside">
+            <div className="org--aside--content">
+              <a
+                href={`https://maps.google.com?saddr=Current+Location&daddr=${resource.address.latitude},${resource.address.longitude}&dirflg=w`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="org--aside--content--button directions-button"
+              >
+                Get Directions
+              </a>
+              <Link to={{ pathname: '/resource/edit', query: { resourceid: resource.id } }} className="org--aside--content--button edit-button">
+                  Make Edits
+              </Link>
+              <nav className="org--aside--content--nav">
+                <ul>
+                  <li><a href="#resource">{resource.name}</a></li>
+                  <li><a href="#services">Services</a>
+                    <ul className="service--nav--list">
+                      {
+                        resource.services.map(service => (
+                          <li key={service.id}>
+                            <a href={`#service-${service.id}`} onClick={scrollToElement(`service-${service.id}`)}>
+                              {service.name}
+                            </a>
+                          </li>
+                        ))
+                      }
+                    </ul>
+                  </li>
+                  <li><a href="#info">Info</a></li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
     );
   }
 }
 
+Resource.defaultProps = {
+  userLocation: null,
+};
 
+Resource.propTypes = {
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      resourceid: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+  // Not required because will be lazy-loaded after initial render.
+  userLocation: PropTypes.shape({
+    lat: PropTypes.number.isRequired,
+    lng: PropTypes.number.isRequired,
+  }),
+};
 
 export default Resource;

--- a/app/components/Resource/Resource.js
+++ b/app/components/Resource/Resource.js
@@ -112,7 +112,7 @@ class Resource extends Component {
                   <PhoneNumber phones={resource.phones} />
                   <Website website={resource.website} />
                   <span className="website">
-                    <a href={`mailto:${this.state.resource.email}`} target="_blank">{this.state.resource.email}</a>
+                    <a href={`mailto:${this.state.resource.email}`} target="_blank" rel="noopener noreferrer">{this.state.resource.email}</a>
                   </span>
                 </div>
                 <div className="info--column">

--- a/app/components/Resource/Resource.js
+++ b/app/components/Resource/Resource.js
@@ -7,6 +7,7 @@ import Services from './Services';
 import Notes from './Notes';
 import Loader from '../Loader';
 import ResourceMap from './ResourceMap';
+import * as dataService from '../../utils/DataService';
 
 function scrollToElement(selector) {
   const elem = document.getElementById(selector);
@@ -19,6 +20,7 @@ class Resource extends Component {
   constructor(props) {
     super(props);
     this.state = { resource: null };
+    this.verifyResource = this.verifyResource.bind(this);
   }
 
   componentDidMount() {
@@ -33,6 +35,19 @@ class Resource extends Component {
     .then((data) => {
       this.setState({ resource: data.resource });
     });
+  }
+
+  verifyResource() {
+    const changeRequest = { verified_at: new Date().toISOString() };
+    dataService.post(`/api/resources/${this.state.resource.id}/change_requests`, { change_request: changeRequest })
+      .then((response) => {
+        // TODO: Do not use alert() for user notifications.
+        if (response.ok) {
+          alert('Resource verified. Thanks!');  // eslint-disable-line no-alert
+        } else {
+          alert('Issue verifying resource. Please try again.');  // eslint-disable-line no-alert
+        }
+      });
   }
 
   render() {
@@ -120,6 +135,12 @@ class Resource extends Component {
               <Link to={{ pathname: '/resource/edit', query: { resourceid: resource.id } }} className="org--aside--content--button edit-button">
                   Make Edits
               </Link>
+              <button
+                className="org--aside--content--button"
+                onClick={this.verifyResource}
+              >
+                Mark Info as Correct
+              </button>
               <nav className="org--aside--content--nav">
                 <ul>
                   <li><a href="#resource">{resource.name}</a></li>

--- a/app/styles/components/_org-page.scss
+++ b/app/styles/components/_org-page.scss
@@ -239,6 +239,8 @@
 			margin-top: calc-em(10px);
 			display: block;
 			text-align: center;
+			width: 100%;
+			height: auto; // Unset global height for button tag name selector
 			&-first-of-type {
 				margin-top: 0;
 			}


### PR DESCRIPTION
See https://github.com/ShelterTechSF/askdarcel-web/commit/764aed21d1c8c5e5032399090d17fb75e1684974 for a cleaner diff, since I linted `app/components/Resource/Resource.js`.

This adds a simple button to the resources page for verifying the resource's info. I didn't see any designs for it, so I just went with what I thought looked acceptable.

<img width="1234" alt="screen shot 2017-09-05 at 12 24 53 am" src="https://user-images.githubusercontent.com/1002748/30049800-ce4216f6-91d0-11e7-8070-68ca6b5f6313.png">

This actually makes an API request to the ChangeRequests route and creates a ChangeRequest that sets just the `verified_at` field. There wasn't an existing route on the server for directly setting the `verified_at` field, so if we want to allow users to verify resources without requiring an admin to approve it, we'll need to add an endpoint for that.