### PR TITLE
Allow category editing for existing services

### DIFF
--- a/app/components/Edit/EditServices.js
+++ b/app/components/Edit/EditServices.js
@@ -167,7 +167,7 @@ class EditService extends Component {
 
 					<EditNotes notes={this.props.service.notes} handleNotesChange={this.handleNotesChange} />
 
-          			<CategoriesDropdown categories={this.props.service.categories} handleCategoryChange={this.handleCategoryChange} />
+					<CategoriesDropdown categories={this.props.service.categories} handleCategoryChange={this.handleCategoryChange} />
 				</ul>
 			</li>
     );

--- a/app/components/Edit/EditServices.js
+++ b/app/components/Edit/EditServices.js
@@ -167,7 +167,7 @@ class EditService extends Component {
 
 					<EditNotes notes={this.props.service.notes} handleNotesChange={this.handleNotesChange} />
 
-          {this.renderCategories()}
+          			<CategoriesDropdown categories={this.props.service.categories} handleCategoryChange={this.handleCategoryChange} />
 				</ul>
 			</li>
     );


### PR DESCRIPTION
Fixes Issue #288 
Show dropdown component in edit mode instead of rendering category list.
Not sure if this resulted in a correct change request since my admin UI isn't loading