### PR TITLE
Do not treat 0 as an invalid time.

### DIFF
--- a/app/components/Resource/DetailedHours.js
+++ b/app/components/Resource/DetailedHours.js
@@ -14,7 +14,7 @@ export default function DetailedHours(props) {
         </div>
       );
     }
-    if (item.opens_at !== 0 && item.closes_at !== 0) {
+    if (item.opens_at !== null && item.closes_at !== null) {
       return (
         <div key={item.id} className="weekly-hours-list--item">
           <span className="weekly-hours-list--item--day">{`${item.day}`}</span>

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -17,15 +17,15 @@ export function getAuthRequestHeaders() {
  * '1330' to new Date(..., ..., ..., 13, 30)
  */
 function timeToDate(hours) {
-  const date = new Date();
-  if (hours) {
-    const hoursString = hours.toString();
-    date.setHours(hoursString.substring(0, hoursString.length - 2));
-    date.setMinutes(hoursString.substring(hoursString.length - 2, hoursString.length));
-    date.setSeconds(0);
-    return date;
+  if (hours === null) {
+    return null;
   }
-  return null;
+  const date = new Date();
+  const hoursString = hours.toString();
+  date.setHours(hoursString.substring(0, hoursString.length - 2));
+  date.setMinutes(hoursString.substring(hoursString.length - 2, hoursString.length));
+  date.setSeconds(0);
+  return date;
 }
 
 /**
@@ -37,10 +37,10 @@ function timeToDate(hours) {
  */
 export function timeToString(hours) {
   const date = timeToDate(hours);
-  if (date) {
-    return date.toLocaleTimeString().replace(/:\d+ /, ' ');
+  if (date === null) {
+    return null;
   }
-  return null;
+  return date.toLocaleTimeString().replace(/:\d+ /, ' ');
 }
 
 /**
@@ -57,14 +57,14 @@ export function timeToString(hours) {
  */
 export function timeToTimeInputValue(hours) {
   const date = timeToDate(hours);
-  if (date) {
-    const hour = date.getHours();
-    const strHour = (hour < 10) ? `0${hour.toString()}` : hour.toString();
-    const minute = date.getMinutes();
-    const strMinute = (minute < 10) ? `0${minute.toString()}` : minute.toString();
-    return `${strHour}:${strMinute}`;
+  if (date === null) {
+    return null;
   }
-  return null;
+  const hour = date.getHours();
+  const strHour = (hour < 10) ? `0${hour.toString()}` : hour.toString();
+  const minute = date.getMinutes();
+  const strMinute = (minute < 10) ? `0${minute.toString()}` : minute.toString();
+  return `${strHour}:${strMinute}`;
 }
 
 export function stringToTime(timeString) {


### PR DESCRIPTION
See cleaner, whitespace-agnostic diff here: https://github.com/ShelterTechSF/askdarcel-web/compare/295-do-not-treat-midnight-as-null?w=1

There was a minor bug in our time formatting helper functions where an `if (time)` would evaluate to false if the time is 0, since in JavaScript 0 is falsy. I fixed the comparisons to explicitly check for `if (time === null)`. This fixes the UI so that 0 is displayed as 12:00am instead of "null", and I also fixed the logic to filter out ScheduleDays that have 0 for either open or close times to filter out just nulls.