### PR TITLE
Fix CategoryDropdown initial value.

### DIFF
--- a/app/components/Edit/CategoriesDropdown.js
+++ b/app/components/Edit/CategoriesDropdown.js
@@ -2,12 +2,19 @@ import React, { Component, PropTypes } from 'react';
 import Select from 'react-select';
 import * as dataService from '../../utils/DataService';
 
+function categoryToSelectValue(category) {
+  return {
+    label: category.name,
+    value: category,
+  };
+}
+
 class CategoriesDropdown extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      selectedValues: [],
+      selectedValues: props.categories.map(categoryToSelectValue),
       options: [],
     };
 
@@ -17,10 +24,7 @@ class CategoriesDropdown extends Component {
   componentDidMount() {
     dataService.get('/api/categories').then((json) => {
       this.setState({
-        options: json.categories.map(category => ({
-          label: category.name,
-          value: category,
-        })),
+        options: json.categories.map(categoryToSelectValue),
       });
     });
   }
@@ -48,6 +52,12 @@ class CategoriesDropdown extends Component {
 }
 
 CategoriesDropdown.propTypes = {
+  categories: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+    }).isRequired,
+  ).isRequired,
   handleCategoryChange: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
This fixes one of the issues described in #307, where the initial value of the CategoryDropdown was blank regardless of whether a service had existing categories. We were just unconditionally initializing the dropdown to the empty array. This PR changes it to use the list of categories that were already being passed into the component as props.