### PR TITLE
Handle null categories on CategoriesDropdown.

### DIFF
--- a/app/components/Edit/CategoriesDropdown.js
+++ b/app/components/Edit/CategoriesDropdown.js
@@ -57,8 +57,12 @@ CategoriesDropdown.propTypes = {
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
     }).isRequired,
-  ).isRequired,
+  ),
   handleCategoryChange: PropTypes.func.isRequired,
+};
+
+CategoriesDropdown.defaultProps = {
+  categories: [],
 };
 
 export default CategoriesDropdown;


### PR DESCRIPTION
My last PR broke the ability to add a new service to a resource because I wasn't properly handling the case where you might pass in `null` to the CategoriesDropdown component. Now I use the `defaultProps` member of the React component to set the default value to `[]`. I manually tested that this fixes the issue for me locally.