### PR TITLE
Add end to end testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 
 script:
   - npm run lint
+  - ./travis-testcafe.sh
 
 after_success:
   - tools/docker-build.sh

--- a/app/components/Edit/EditPhones.js
+++ b/app/components/Edit/EditPhones.js
@@ -67,4 +67,5 @@ EditPhone.propTypes = {
 };
 
 const EditPhones = editCollectionHOC(EditPhone, 'Phones', {});
+EditPhones.displayName = 'EditPhones';
 export default EditPhones;

--- a/app/styles/components/_org-page.scss
+++ b/app/styles/components/_org-page.scss
@@ -41,6 +41,8 @@
 		margin: 0 auto;
 		padding: 0 calc-em(20px);
 		transform: translateY(-96px);
+		// Prevent empty space to the right of image from covering other elements on page
+		pointer-events: none;
 		&--img {
 			@include aspect-ratio(1, 1);
 		  width: calc-em(130px);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/chalk": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+      "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
+      "dev": true
+    },
+    "@types/error-stack-parser": {
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/@types/error-stack-parser/-/error-stack-parser-1.3.18.tgz",
+      "integrity": "sha1-4ByfjIXKg7YQMgxiJYsMkCat4Pc=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.80",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.80.tgz",
+      "integrity": "sha512-FumgRtCaxilKUcgMnZCzH6K3gntIwLiLLIaR+UBGNZpT/N3ne2dKrDSGoGIxSHYpAjnq6kIVV0r51U+kLXX59A==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -319,6 +337,12 @@
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -343,6 +367,12 @@
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
       "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg="
     },
+    "async-exit-hook": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-1.1.2.tgz",
+      "integrity": "sha1-gJXXXkiMKazuBVH+hyUhadeJz7o=",
+      "dev": true
+    },
     "async-foreach": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
@@ -353,6 +383,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
       "dev": true
     },
     "autoprefixer": {
@@ -1038,6 +1074,15 @@
         "regenerator-transform": "0.10.1"
       }
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -1045,6 +1090,62 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.6.1",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.6.1.tgz",
+          "integrity": "sha512-HBZwVT7ciQB9KlXM3AUMQbnQXtHWPsEUKQTiS0BEFfY5bOrMl94ORaqQD1GyuTGh69ZmYeue9QBqiw219e09eQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000755",
+            "electron-to-chromium": "1.3.27"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.27",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+          "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+          "dev": true
+        }
       }
     },
     "babel-preset-es2015": {
@@ -1275,6 +1376,12 @@
         "executable": "1.1.0"
       }
     },
+    "bin-v8-flags-filter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bin-v8-flags-filter/-/bin-v8-flags-filter-1.1.2.tgz",
+      "integrity": "sha512-ZR9GjYnlyznq67lcdMdnJN2SfwRhukoawyVZEby1DudJ9uiqCT/zFvVVtDhR4eCytr2aQHpAG3uzDOhIIu5PDw==",
+      "dev": true
+    },
     "bin-version": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
@@ -1449,6 +1556,12 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
+    "bowser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+      "integrity": "sha1-N/w4e2Fstq7zcNq01r1AK3TFxU0=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -1472,6 +1585,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "brotli": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
+      "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.1"
+      }
     },
     "browserify-aes": {
       "version": "1.0.8",
@@ -1645,6 +1767,23 @@
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
+    "callsite-record": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/callsite-record/-/callsite-record-4.1.1.tgz",
+      "integrity": "sha512-5kZQsFBN+ft/zLi4nIS7ch/GtObSfbeSPz789PzM1vdBnwK3xUZjuJgZsStV+ltWchStC8cwKQPHPBk6zmrcAA==",
+      "dev": true,
+      "requires": {
+        "@types/chalk": "0.4.31",
+        "@types/error-stack-parser": "1.3.18",
+        "@types/lodash": "4.14.80",
+        "callsite": "1.0.0",
+        "chalk": "1.1.3",
+        "error-stack-parser": "1.3.6",
+        "highlight-es": "1.0.1",
+        "lodash": "4.17.4",
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
@@ -1692,6 +1831,12 @@
       "integrity": "sha1-m7dC+NAmpi34c7wDwGhD0iVbYNc=",
       "dev": true
     },
+    "caniuse-lite": {
+      "version": "1.0.30000755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000755.tgz",
+      "integrity": "sha1-nOX24GvXXsggmr6IU8O+7wIkjWU=",
+      "dev": true
+    },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -1728,6 +1873,17 @@
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
+      }
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chalk": {
@@ -1858,6 +2014,51 @@
           }
         }
       }
+    },
+    "chrome-emulated-devices-list": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chrome-emulated-devices-list/-/chrome-emulated-devices-list-0.1.0.tgz",
+      "integrity": "sha1-GSMzvg71UwzazJW1TRx7XxWOlwM=",
+      "dev": true
+    },
+    "chrome-remote-interface": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.20.0.tgz",
+      "integrity": "sha1-G3joxFjr68AUTLQP5vYjWmrBano=",
+      "dev": true,
+      "requires": {
+        "commander": "2.1.0",
+        "ws": "2.0.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+          "dev": true
+        },
+        "ultron": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+          "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+          "dev": true
+        },
+        "ws": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.0.3.tgz",
+          "integrity": "sha1-Uy/UmcP319cg5UPx+AcQbPxX2cs=",
+          "dev": true,
+          "requires": {
+            "ultron": "1.1.0"
+          }
+        }
+      }
+    },
+    "ci-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -2180,6 +2381,12 @@
       "integrity": "sha1-Wm3ugtmmSMspEx0/ndQA/6RZN0I=",
       "dev": true
     },
+    "connected-domain": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
+      "integrity": "sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM=",
+      "dev": true
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -2340,6 +2547,35 @@
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
+      }
+    },
+    "crypto-md5": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-md5/-/crypto-md5-1.0.0.tgz",
+      "integrity": "sha1-zMjadQx1PH7curxUKWdHKjhOhrs=",
+      "dev": true
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
       }
     },
     "css-color-names": {
@@ -2697,6 +2933,29 @@
         }
       }
     },
+    "dedent": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.4.0.tgz",
+      "integrity": "sha1-h979BAvUwVldljKC7FfzwqhSVkI=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -3046,6 +3305,12 @@
       "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI=",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -3091,6 +3356,33 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "1.4.0"
+      }
+    },
+    "endpoint-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
+      "integrity": "sha1-CAjDNppyfNeWejn/NOvJJriBRqg=",
+      "dev": true,
+      "requires": {
+        "ip": "1.1.5",
+        "pinkie-promise": "1.0.0"
+      },
+      "dependencies": {
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+          "dev": true,
+          "requires": {
+            "pinkie": "1.0.0"
+          }
+        }
       }
     },
     "engine.io": {
@@ -3275,6 +3567,15 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
+      "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+      "dev": true,
+      "requires": {
+        "stackframe": "0.3.1"
       }
     },
     "es-abstract": {
@@ -4933,6 +5234,17 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
+    "highlight-es": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/highlight-es/-/highlight-es-1.0.1.tgz",
+      "integrity": "sha1-O7AesfIGLdqrcviyN2ajv4wadx8=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "is-es2016-keyword": "1.0.0",
+        "js-tokens": "3.0.2"
+      }
+    },
     "history": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/history/-/history-2.0.1.tgz",
@@ -5430,6 +5742,12 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
     "ip-regex": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
@@ -5491,6 +5809,15 @@
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.1"
+      }
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -5509,6 +5836,12 @@
       "requires": {
         "is-primitive": "2.0.0"
       }
+    },
+    "is-es2016-keyword": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz",
+      "integrity": "sha1-9uVOEQxeT40mXmnS7Q6vjPX0dxg=",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -6113,6 +6446,15 @@
         "computed-style": "0.1.4"
       }
     },
+    "linux-platform-info": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/linux-platform-info/-/linux-platform-info-0.0.3.tgz",
+      "integrity": "sha1-La4yQ4Xmbj11W+yD+Gx77qYc64M=",
+      "dev": true,
+      "requires": {
+        "os-family": "1.0.0"
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -6473,6 +6815,35 @@
         "lodash._root": "3.0.1"
       }
     },
+    "log-update-async-hook": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz",
+      "integrity": "sha512-HQwkKFTZeUOrDi1Duf2CSUa/pSpcaCHKLdx3D/Z16DsipzByOBffcg5y0JZA1q0n80dYgLXe2hFM9JGNgBsTDw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "async-exit-hook": "1.1.2",
+        "onetime": "2.0.1",
+        "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        }
+      }
+    },
     "log4js": {
       "version": "0.6.38",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
@@ -6563,6 +6934,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "map-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-reverse/-/map-reverse-1.0.1.tgz",
+      "integrity": "sha1-J06fUAphEVMYO1uNhJCpwcI+4xA=",
+      "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -6766,6 +7143,12 @@
         "mime-db": "1.30.0"
       }
     },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -6802,6 +7185,12 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
+    "moment-duration-format": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz",
+      "integrity": "sha1-VBdxtfh6BJzGVUBHXTrZZnN9aQg=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -6835,6 +7224,12 @@
           }
         }
       }
+    },
+    "mustache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
+      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -7038,6 +7433,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+    },
+    "node-version": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.0.tgz",
+      "integrity": "sha512-t1V2RFiaTavaW3jtQO0A2nok6k7/Gghuvx2rjvICuT0B0dYaObBQ4U0xHL+ZTPFZodt1LMYG2Vi2nypfz4/AJg==",
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -7340,6 +7741,12 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
       "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
     },
+    "os-family": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/os-family/-/os-family-1.0.0.tgz",
+      "integrity": "sha1-0SMIxCSjYwKhwQapUoe73VyiR38=",
+      "dev": true
+    },
     "os-filter-obj": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
@@ -7447,6 +7854,12 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "dev": true
     },
     "parsejson": {
       "version": "0.0.3",
@@ -8277,6 +8690,15 @@
         "asap": "2.0.6"
       }
     },
+    "promisify-event": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promisify-event/-/promisify-event-1.0.0.tgz",
+      "integrity": "sha1-vXUj6ga3AWLzcJeQFrU6aGxg6Q8=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "prop-types": {
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
@@ -8299,6 +8721,15 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+    },
+    "ps-node": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
+      "integrity": "sha1-mvZ6mdex0BMuUaUDCZ04qNKs4sM=",
+      "dev": true,
+      "requires": {
+        "table-parser": "0.1.3"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -8327,6 +8758,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+    },
+    "qrcode-terminal": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz",
+      "integrity": "sha1-p2pI4mEKGPl/o6K9UytoKs/4bFM=",
+      "dev": true
     },
     "qs": {
       "version": "4.0.0",
@@ -8677,6 +9114,15 @@
         }
       }
     },
+    "read-file-relative": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/read-file-relative/-/read-file-relative-1.2.0.tgz",
+      "integrity": "sha1-mPfZbqoh0rTHov69Y9L8jPNen5s=",
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -8940,6 +9386,12 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
     },
+    "replicator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replicator/-/replicator-1.0.1.tgz",
+      "integrity": "sha1-izgrTruHHNu5jiMG/zUq5AnUhKk=",
+      "dev": true
+    },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
@@ -9028,10 +9480,33 @@
         "path-parse": "1.0.5"
       }
     },
+    "resolve-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
+      "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "2.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        }
+      }
+    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
@@ -9103,6 +9578,15 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "1.0.2"
+      }
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -9456,6 +9940,12 @@
         }
       }
     },
+    "shortid": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
+      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9672,6 +10162,18 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "dev": true,
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
     "source-map-support": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
@@ -9680,6 +10182,12 @@
       "requires": {
         "source-map": "0.5.7"
       }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
     },
     "sparkles": {
       "version": "1.0.0",
@@ -9742,6 +10250,18 @@
           "dev": true
         }
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
+      "dev": true
+    },
+    "stackframe": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+      "dev": true
     },
     "stat-mode": {
       "version": "0.2.2",
@@ -10087,6 +10607,15 @@
         }
       }
     },
+    "table-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
+      "integrity": "sha1-BEHPzhallIFoTCfRtaZ/8VpDx7A=",
+      "dev": true,
+      "requires": {
+        "connected-domain": "1.0.0"
+      }
+    },
     "tapable": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
@@ -10151,6 +10680,369 @@
         "os-tmpdir": "1.0.2",
         "uuid": "2.0.3"
       }
+    },
+    "testcafe": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-0.18.2.tgz",
+      "integrity": "sha512-1eHRnGBuSZEePn/wRNfZTE90vr/wMzT9fpKhVpLonu/HVDZ+4WEiGejL7wIyZFlFoyJ6/dze6AVU+xKVSkci+Q==",
+      "dev": true,
+      "requires": {
+        "async-exit-hook": "1.1.2",
+        "babel-core": "6.26.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-runtime": "6.23.0",
+        "babel-preset-env": "1.6.1",
+        "babel-preset-flow": "6.23.0",
+        "babel-preset-stage-2": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "bin-v8-flags-filter": "1.1.2",
+        "callsite": "1.0.0",
+        "callsite-record": "4.1.1",
+        "chai": "3.5.0",
+        "chalk": "1.1.3",
+        "chrome-emulated-devices-list": "0.1.0",
+        "chrome-remote-interface": "0.20.0",
+        "commander": "2.11.0",
+        "debug": "2.6.8",
+        "dedent": "0.4.0",
+        "elegant-spinner": "1.0.1",
+        "endpoint-utils": "1.0.2",
+        "globby": "3.0.1",
+        "indent-string": "1.2.2",
+        "is-ci": "1.0.10",
+        "is-glob": "2.0.1",
+        "lodash": "4.17.4",
+        "log-update-async-hook": "2.0.2",
+        "map-reverse": "1.0.1",
+        "mkdirp": "0.5.1",
+        "moment": "2.18.1",
+        "moment-duration-format": "1.3.0",
+        "mustache": "2.3.0",
+        "node-version": "1.1.0",
+        "os-family": "1.0.0",
+        "parse5": "1.5.1",
+        "pify": "2.3.0",
+        "pinkie": "2.0.4",
+        "promisify-event": "1.0.0",
+        "ps-node": "0.1.6",
+        "qrcode-terminal": "0.10.0",
+        "read-file-relative": "1.2.0",
+        "replicator": "1.0.1",
+        "resolve-cwd": "1.0.0",
+        "sanitize-filename": "1.6.1",
+        "shortid": "2.2.8",
+        "source-map-support": "0.4.17",
+        "stack-chain": "1.3.7",
+        "strip-bom": "2.0.0",
+        "testcafe-browser-tools": "1.4.6",
+        "testcafe-hammerhead": "12.0.0",
+        "testcafe-legacy-api": "3.1.1",
+        "testcafe-reporter-json": "2.1.0",
+        "testcafe-reporter-list": "2.1.0",
+        "testcafe-reporter-minimal": "2.1.0",
+        "testcafe-reporter-spec": "2.1.1",
+        "testcafe-reporter-xunit": "2.1.0",
+        "time-limit-promise": "1.0.2",
+        "tmp": "0.0.28",
+        "tree-kill": "1.2.0",
+        "typescript": "2.5.3",
+        "useragent": "2.2.1"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
+          "integrity": "sha1-IJSvhCHhkVIVDViT62QWsxLZoi8=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "5.0.15",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+          "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+          "dev": true,
+          "requires": {
+            "pinkie": "1.0.0"
+          },
+          "dependencies": {
+            "pinkie": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+              "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+              "dev": true
+            }
+          }
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "tmp": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        }
+      }
+    },
+    "testcafe-browser-tools": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-1.4.6.tgz",
+      "integrity": "sha512-kBderW2L9u+ecAFp9przMPHLwrMPHfAq4tIHeFqykGHL/8K+ydOXYerfKKNrxiSvmvSHs+aWLlr/+/4q+TE+kg==",
+      "dev": true,
+      "requires": {
+        "array-find": "1.0.0",
+        "babel-runtime": "5.8.38",
+        "graceful-fs": "4.1.11",
+        "linux-platform-info": "0.0.3",
+        "mkdirp": "0.5.1",
+        "mustache": "2.3.0",
+        "os-family": "1.0.0",
+        "pify": "2.3.0",
+        "pinkie": "2.0.4",
+        "read-file-relative": "1.2.0",
+        "which-promise": "1.0.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
+    },
+    "testcafe-hammerhead": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-12.0.0.tgz",
+      "integrity": "sha1-KfIUvkqaNdTli6V10XAzQ9GEQhw=",
+      "dev": true,
+      "requires": {
+        "bowser": "1.6.0",
+        "brotli": "1.3.2",
+        "crypto-md5": "1.0.0",
+        "css": "2.2.1",
+        "dedent": "0.4.0",
+        "iconv-lite": "0.4.11",
+        "lodash": "4.16.4",
+        "lru-cache": "2.6.3",
+        "mime": "1.4.1",
+        "mustache": "2.3.0",
+        "os-family": "1.0.0",
+        "parse5": "1.5.1",
+        "pify": "2.3.0",
+        "pinkie": "1.0.0",
+        "read-file-relative": "1.2.0",
+        "shortid": "2.2.8",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "webauth": "1.1.0",
+        "yakaa": "1.0.1"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+          "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.16.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+          "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz",
+          "integrity": "sha1-UczQtPwMhDWH16VwnOTTt2Kb7cU=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "testcafe-legacy-api": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-3.1.1.tgz",
+      "integrity": "sha512-bLu5eK+or4MMBk7LXYKuBOTHZRTpIOODBxxwXcZesXRsykHhURwp1EHrm0uqyP7yN9pTMPnCpcCAINuVen/rRw==",
+      "dev": true,
+      "requires": {
+        "async": "0.2.6",
+        "babel-runtime": "5.8.38",
+        "dedent": "0.6.0",
+        "highlight-es": "1.0.1",
+        "lodash": "4.17.4",
+        "moment": "2.18.1",
+        "mustache": "2.3.0",
+        "os-family": "1.0.0",
+        "parse5": "2.2.3",
+        "pify": "2.3.0",
+        "pinkie": "2.0.4",
+        "strip-bom": "2.0.0",
+        "uglify-js": "1.2.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
+          "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=",
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "dedent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
+          "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
+          "dev": true
+        },
+        "parse5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
+          "integrity": "sha1-01Sy08HPEOvBj6eMEaKL3ZzhWA0=",
+          "dev": true
+        }
+      }
+    },
+    "testcafe-react-selectors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/testcafe-react-selectors/-/testcafe-react-selectors-1.0.2.tgz",
+      "integrity": "sha1-cA+fC5Y3RA4vuMiKwO6G88hu2XE=",
+      "dev": true
+    },
+    "testcafe-reporter-json": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-json/-/testcafe-reporter-json-2.1.0.tgz",
+      "integrity": "sha1-gLm1pt/y7h3h+R4mcHBsFHLmQAY=",
+      "dev": true
+    },
+    "testcafe-reporter-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-list/-/testcafe-reporter-list-2.1.0.tgz",
+      "integrity": "sha1-n6ifcbl9Pf5ktDAtXiJ97mmuxrk=",
+      "dev": true
+    },
+    "testcafe-reporter-minimal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-minimal/-/testcafe-reporter-minimal-2.1.0.tgz",
+      "integrity": "sha1-Z28DVHY0FDxurzq1KGgnOkvr9CE=",
+      "dev": true
+    },
+    "testcafe-reporter-spec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-spec/-/testcafe-reporter-spec-2.1.1.tgz",
+      "integrity": "sha1-gVb87Q9RMkhlWa1WC8gGdkaSdew=",
+      "dev": true
+    },
+    "testcafe-reporter-xunit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz",
+      "integrity": "sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -10220,6 +11112,12 @@
         }
       }
     },
+    "time-limit-promise": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/time-limit-promise/-/time-limit-promise-1.0.2.tgz",
+      "integrity": "sha1-IX/cXDMfEdGx6w+CjJX3wpuuXOQ=",
+      "dev": true
+    },
     "time-stamp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
@@ -10285,6 +11183,12 @@
         "punycode": "1.4.1"
       }
     },
+    "tree-kill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
+      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -10303,6 +11207,15 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "1.0.4"
+      }
     },
     "tryit": {
       "version": "1.0.3",
@@ -10336,6 +11249,12 @@
         "prelude-ls": "1.1.2"
       }
     },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -10349,6 +11268,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.14",
@@ -10427,6 +11352,12 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -10503,6 +11434,12 @@
           "dev": true
         }
       }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+      "dev": true
     },
     "util": {
       "version": "0.10.3",
@@ -10733,6 +11670,12 @@
         "graceful-fs": "4.1.11"
       }
     },
+    "webauth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webauth/-/webauth-1.1.0.tgz",
+      "integrity": "sha1-ZHBPa4AmmGYFvDymKZUubib90QA=",
+      "dev": true
+    },
     "webpack": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
@@ -10899,6 +11842,34 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
+    "which-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-promise/-/which-promise-1.0.0.tgz",
+      "integrity": "sha1-ILch3wWzW3Bhdv+hCwkJq6RgMDU=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0",
+        "pinkie-promise": "1.0.0",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+          "dev": true,
+          "requires": {
+            "pinkie": "1.0.0"
+          }
+        }
+      }
+    },
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
@@ -10985,6 +11956,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yakaa": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/yakaa/-/yakaa-1.0.1.tgz",
+      "integrity": "sha1-PsqucvPQidpYCJQDEmIEzsdy5go=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,11 +74,35 @@
         }
       }
     },
+    "adm-zip": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+      "dev": true
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
+    },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        }
+      }
     },
     "ajv": {
       "version": "4.11.8",
@@ -160,6 +184,129 @@
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "requires": {
         "file-type": "3.9.0"
+      }
+    },
+    "archiver": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+      "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "async": "2.5.0",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3",
+        "tar-stream": "1.5.4",
+        "walkdir": "0.0.11",
+        "zip-stream": "1.2.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.4",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "are-we-there-yet": {
@@ -2237,6 +2384,50 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "compressible": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
@@ -2451,6 +2642,54 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
+      "dev": true
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "dev": true,
+      "requires": {
+        "crc": "3.5.0",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -3027,6 +3266,15 @@
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
+      }
+    },
+    "desired-capabilities": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/desired-capabilities/-/desired-capabilities-0.1.0.tgz",
+      "integrity": "sha1-84YNEu3g2sgZpHzJWaaMULqbqD4=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1"
       }
     },
     "destroy": {
@@ -5391,6 +5639,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.8",
+        "extend": "3.0.1"
+      }
     },
     "icepick": {
       "version": "1.3.0",
@@ -9682,6 +9941,53 @@
         }
       }
     },
+    "sauce-connect-launcher": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.3.tgz",
+      "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
+      "dev": true,
+      "requires": {
+        "adm-zip": "0.4.7",
+        "async": "2.5.0",
+        "https-proxy-agent": "1.0.0",
+        "lodash": "4.17.4",
+        "rimraf": "2.6.1"
+      }
+    },
+    "saucelabs-connector": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/saucelabs-connector/-/saucelabs-connector-0.2.3.tgz",
+      "integrity": "sha1-jLkO2shnE0rjI/ZKbmVwAqeAOaM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "5.8.38",
+        "lodash": "4.17.4",
+        "os-family": "1.0.0",
+        "pify": "2.3.0",
+        "pinkie": "2.0.4",
+        "read-file-relative": "1.2.0",
+        "request": "2.81.0",
+        "sauce-connect-launcher": "1.2.3",
+        "wd": "1.4.1"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -10832,6 +11138,21 @@
         }
       }
     },
+    "testcafe-browser-provider-saucelabs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-provider-saucelabs/-/testcafe-browser-provider-saucelabs-1.3.0.tgz",
+      "integrity": "sha1-uPD55Dne8WYS+EAFqsd168m2z88=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "desired-capabilities": "0.1.0",
+        "lodash": "4.17.4",
+        "pify": "2.3.0",
+        "pinkie": "2.0.4",
+        "request": "2.81.0",
+        "saucelabs-connector": "0.2.3"
+      }
+    },
     "testcafe-browser-tools": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-1.4.6.tgz",
@@ -11307,6 +11628,16 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -11490,6 +11821,12 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "vargs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+      "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
+      "dev": true
+    },
     "vary": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
@@ -11644,6 +11981,12 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+      "dev": true
+    },
     "ware": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
@@ -11668,6 +12011,103 @@
         "async": "2.5.0",
         "chokidar": "1.7.0",
         "graceful-fs": "4.1.11"
+      }
+    },
+    "wd": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.4.1.tgz",
+      "integrity": "sha512-C0wWd2X4SWWcyx5qxaixiZE4Vb07sl0yDfWHPeml8lDHSbmI9erE9BmTHIqOGoDxGgJ3/hkFmODQ7ZLKiF8+8Q==",
+      "dev": true,
+      "requires": {
+        "archiver": "1.3.0",
+        "async": "2.0.1",
+        "lodash": "4.16.2",
+        "mkdirp": "0.5.1",
+        "q": "1.4.1",
+        "request": "2.79.0",
+        "underscore.string": "3.3.4",
+        "vargs": "0.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.16.2"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.16.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
+          "integrity": "sha1-PmJtuCcEimmSgaihJSJjJs/A5lI=",
+          "dev": true
+        },
+        "q": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true
+        }
       }
     },
     "webauth": {
@@ -12035,6 +12475,50 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "lint": "eslint app/",
     "postinstall": "npm run build",
     "build": "cross-env NODE_ENV=production webpack",
-    "dev": "webpack-dev-server --inline --open"
+    "dev": "webpack-dev-server --inline --open",
+    "testcafe": "testcafe"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "react-icons": "^2.0.1",
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1",
+    "testcafe": "^0.18.2",
+    "testcafe-react-selectors": "^1.0.2",
     "webpack": "^1.13.0",
     "webpack-dev-server": "1.14.1"
   },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "sass-loader": "^3.2.0",
     "style-loader": "^0.13.1",
     "testcafe": "^0.18.2",
+    "testcafe-browser-provider-saucelabs": "^1.3.0",
     "testcafe-react-selectors": "^1.0.2",
     "webpack": "^1.13.0",
     "webpack-dev-server": "1.14.1"

--- a/testcafe/config.js
+++ b/testcafe/config.js
@@ -1,0 +1,3 @@
+export default {
+  baseUrl: process.env.BASE_URL || 'http://localhost:8080'
+};

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -1,0 +1,107 @@
+import config from './config';
+import ResourcePage from './pages/ResourcePage';
+import EditPage from './pages/EditPage';
+
+const resourcePage = new ResourcePage();
+const editPage = new EditPage();
+
+fixture `Edit Resource`
+  .page `${config.baseUrl}/resource?id=1`;
+
+test('Edit resource name', async t => {
+  const newName = 'New Resource Name';
+  await t
+    .click(resourcePage.editButton)
+    .typeText(editPage.name, newName, { replace: true })
+    .click(editPage.saveButton)
+    .expect(resourcePage.resourceName.textContent).contains(newName)
+    ;
+});
+
+
+test('Edit resource address', async t => {
+  const newProps = {
+    address1: '123 Fake St.',
+    address2: 'Suite 456',
+    address3: 'Room 789',
+    address4: 'Desk 10',
+    city: 'Springfield',
+    stateOrProvince: 'Illinois',
+    country: 'United States',
+    postalCode: '62701',
+  }
+  // TODO: Some fields are not displayed on the show page
+  const notVisibleOnShowPage = ['address3', 'address4', 'country'];
+
+  // Make edits
+  await t.click(resourcePage.editButton);
+  for (const prop in newProps) {
+    await t.typeText(editPage.address[prop], newProps[prop], { replace: true });
+  }
+  await t.click(editPage.saveButton);
+
+  // Check visibility of edits on show page
+  for (const prop in newProps) {
+    if (notVisibleOnShowPage.includes(prop)) continue;
+    await t.expect(resourcePage.address.textContent).contains(newProps[prop]);
+  }
+
+  // Check visibility of edits on edit page
+  await t.click(resourcePage.editButton);
+  for (const prop in newProps) {
+    await t.expect(editPage.address[prop].value).eql(newProps[prop]);
+  }
+});
+
+
+test('Edit resource phone number', async t => {
+  const newNumber = '415-555-5555';
+  const newFormattedNumber = '(415) 555-5555';
+  const newServiceType = 'Main number';
+
+  // Make edits
+  await t.click(resourcePage.editButton);
+  const phone = editPage.getPhone(0);
+  await t
+    .typeText(phone.number, newNumber, { replace: true })
+    .typeText(phone.serviceType, newServiceType, { replace: true })
+    .click(editPage.saveButton)
+    ;
+
+  // Check visibility of edits on show page
+  await t
+    .expect(resourcePage.phones.parent().textContent).contains(newFormattedNumber)
+    .expect(resourcePage.phones.parent().textContent).contains(newServiceType)
+    ;
+});
+
+
+// TODO: Stop skipping once feature actually works.
+test.skip('Add resource phone number', async t => {
+  const newNumber = '415-555-5556';
+  const newFormattedNumber = '(415) 555-5556';
+  const newServiceType = 'Added number';
+
+  // Wait for page to load before counting phone numbers by using hover action.
+  await t.hover(resourcePage.phones);
+  const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
+
+  // Make edits
+  await t
+    .click(resourcePage.editButton)
+    .click(editPage.addPhoneButton)
+    ;
+  const phone = editPage.getPhone(-1);
+  await t
+    .typeText(phone.number, newNumber, { replace: true })
+    .typeText(phone.serviceType, newServiceType, { replace: true })
+    .click(editPage.saveButton)
+    ;
+
+  // Check visibility of edits on show page
+  await t
+    .expect(resourcePage.phones.parent().textContent).contains(newFormattedNumber)
+    .expect(resourcePage.phones.parent().textContent).contains(newServiceType)
+    .expect(resourcePage.phones.count).eql(originalCount + 1)
+    ;
+});

--- a/testcafe/home.js
+++ b/testcafe/home.js
@@ -1,0 +1,20 @@
+import config from './config';
+import FindPage from './pages/FindPage';
+import SearchPage from './pages/SearchPage';
+import ResourcePage from './pages/ResourcePage';
+
+const findPage = new FindPage();
+const searchPage = new SearchPage();
+const resourcePage = new ResourcePage();
+
+fixture `Home Page`
+  .page `${config.baseUrl}`;
+
+test('Basic navigation test', async t => {
+  await t
+    .click(findPage.categoryButton.withText('Food'))
+    .expect(searchPage.resultsCount.textContent).contains('Total Results')
+    .click(searchPage.resultEntry)
+    .expect(resourcePage.description.textContent).contains('About this resource')
+    ;
+});

--- a/testcafe/pages/EditPage.js
+++ b/testcafe/pages/EditPage.js
@@ -1,0 +1,38 @@
+import ReactSelector from 'testcafe-react-selectors';
+
+class EditAddress {
+  constructor() {
+    const baseSelector = ReactSelector('EditAddress');
+    this.address1 = baseSelector.find('input').withAttribute('data-field', 'address_1');
+    this.address2 = baseSelector.find('input').withAttribute('data-field', 'address_2');
+    this.address3 = baseSelector.find('input').withAttribute('data-field', 'address_3');
+    this.address4 = baseSelector.find('input').withAttribute('data-field', 'address_4');
+    this.city = baseSelector.find('input').withAttribute('data-field', 'city');
+    this.stateOrProvince = baseSelector.find('input').withAttribute('data-field', 'state_province');
+    this.country = baseSelector.find('input').withAttribute('data-field', 'country');
+    this.postalCode = baseSelector.find('input').withAttribute('data-field', 'postal_code');
+  }
+}
+
+class EditPhone {
+  constructor(index) {
+    const baseSelector = ReactSelector('EditPhone').nth(index);
+    this.number = baseSelector.find('input').withAttribute('data-field', 'number');
+    this.serviceType = baseSelector.find('input').withAttribute('data-field', 'service_type');
+  }
+}
+
+export default class EditPage {
+  constructor() {
+    const baseSelectorName = 'EditSections';
+    const baseSelector = ReactSelector(baseSelectorName);
+    this.name = baseSelector.find('#edit-name-input');
+    this.address = new EditAddress();
+    this.addPhoneButton = ReactSelector('EditPhones').find('.edit--section--list--item--button');
+    this.saveButton = baseSelector.find('.edit--aside--content--submit');
+  }
+
+  getPhone(index) {
+    return new EditPhone(index);
+  }
+}

--- a/testcafe/pages/FindPage.js
+++ b/testcafe/pages/FindPage.js
@@ -1,0 +1,7 @@
+import ReactSelector from 'testcafe-react-selectors';
+
+export default class FindPage {
+  constructor() {
+    this.categoryButton = ReactSelector('ContentPage CategoryItem');
+  }
+}

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -1,0 +1,18 @@
+import ReactSelector from 'testcafe-react-selectors';
+
+export default class ResourcePage {
+  constructor() {
+    const baseSelectorName = 'Resource';
+    const baseSelector = ReactSelector(baseSelectorName);
+    this.resourceName = baseSelector.find('.org--main--header--title');
+    this.description = baseSelector.find('.org--main--header--description');
+    this.address = ReactSelector(`${baseSelectorName} AddressInfo`);
+    // TODO: Can't use nested React component name PhoneNumber because it is
+    // instantiated in both the header and the body of the page and because the
+    // testcafe-react-selectors plugin is currently unable to mix CSS selectors
+    // in between React component names.
+    // https://github.com/DevExpress/testcafe-react-selectors/issues/51
+    this.phones = baseSelector.find('.org--main--header--phone .phone p');
+    this.editButton = baseSelector.find('.edit-button');
+  }
+}

--- a/testcafe/pages/SearchPage.js
+++ b/testcafe/pages/SearchPage.js
@@ -1,0 +1,8 @@
+import ReactSelector from 'testcafe-react-selectors';
+
+export default class SearchPage {
+  constructor() {
+    this.resultsCount = ReactSelector('ResourcesTable').find('.results-count');
+    this.resultEntry = ReactSelector('ResourcesTable ResourcesRow');
+  }
+}

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -ex
+
+cleanup() {
+  docker stop $(docker ps -a -q)
+  if [[ $WEB_PID != "" ]]; then
+    kill $WEB_PID
+  fi
+}
+
+#trap cleanup EXIT
+
+docker network create --driver bridge askdarcel
+docker run -d --network=askdarcel --name=db postgres:9.5
+# 1) rake db:populate refuses to run in the production environment, so we
+#    override RAILS_ENV to development.
+# 2) rake will fail to run on the development environment unless if the
+#    development gems are installed, so we install the development gems into the
+#    production image.
+docker run -d \
+  -e DATABASE_URL=postgres://postgres@db/askdarcel_development \
+  -e TEST_DATABASE_URL=postgres://postgres@db/askdarcel_test \
+  -e SECRET_KEY_BASE=notasecret \
+  -e RAILS_ENV=development \
+  --network=askdarcel \
+  --name=api \
+  -p 3000:3000 \
+  sheltertechsf/askdarcel-api:latest bash -c 'bundle install --with=development && bundle exec rake db:setup db:populate && bundle exec rails server --binding=0.0.0.0'
+npm run build
+npm run dev &
+WEB_PID=$!
+
+# Wait long enough for npm run dev to finish compiling and for Rails to start
+# running.
+sleep 60
+
+# Print out container logs in case if an error occurs
+docker logs api
+
+npm run testcafe -- chromium \
+  --quarantine-mode \
+  --skip-js-errors \
+  --assertion-timeout 50000 \
+  --page-load-timeout 15000 \
+  --selector-timeout 15000 \
+  testcafe/*.js

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -38,7 +38,7 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- chromium \
+npm run testcafe -- 'saucelabs:Chrome@beta:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \


### PR DESCRIPTION
Don't merge yet, still working out the kinks with getting it working in Travis.

In case if you want to try using these for the QA party tonight, here's my branch where I've added [TestCafe](https://devexpress.github.io/testcafe/) end-to-end tests.

### Quick summary of what TestCafe is and how it works
It's a framework for running end-to-end tests (read: real browser tests) that injects your tests onto an existing web page. Architecturally, they spin up a lightweight proxy server that wraps your web page, and when you connect a browser to the proxy server, it serves the requested page with the test driver injected into it.

It's essentially an alternative to writing Selenium tests, and I've found it nice to use because it mimics many of the common HTML5 DOM APIs and because they've added a lot of reasonable default behavior that Selenium lacks, such as properly waiting for events to finish running and for elements to appear before running your assertions.

### How to run
If you are *not* using Docker and all the services are bound to localhost, then you should just be able to run:

```sh
$ npm run testcafe -- --skip-js-errors chrome testcafe/*.js
```

If you are using Docker, then you'll need to run it somewhat like this:

```sh
$ docker run --rm -v $PWD:/usr/src/app -p 1337:1337 -e BASE_URL=>URL_TO_ASKDARCEL_WEB> -w /usr/src/app node npm run testcafe -- --skip-js-errors remote --skip-js-errors --hostname localhost --ports 1337,1338
```

This will spin up a web server at http://localhost:1337/ and print out a URL to use. You should manually enter it into your browser to start the tests.