### PR TITLE
Open now filter fix

### DIFF
--- a/app/components/Search/ResourcesRow.jsx
+++ b/app/components/Search/ResourcesRow.jsx
@@ -44,6 +44,14 @@ class ResourcesRow extends Component {
     let closingOpeningTimes = {};
     let currDay = days[day];
     let result = { open: false };
+    let resource = this.props.resource;
+
+    if (resource.isOpen) {
+      return {
+        open: true,
+        time: timeToString(resource.openUntil),
+      };
+    }
 
     schedule.forEach(item => {
       closingOpeningTimes[item.day.replace(/,/g, '')] = {
@@ -53,35 +61,28 @@ class ResourcesRow extends Component {
     });
 
 
-    if(closingOpeningTimes[currDay] && currTime < closingOpeningTimes[currDay].close) {
-      return {
-        open:true,
-        time: timeToString(closingOpeningTimes[currDay].close)
-      };
-    } else {
-      let remainingDays = days.splice(day+1);
-      remainingDays.some(d => {
-        if(closingOpeningTimes[d]) {
-          result = {
-            open: false,
-            time: `${timeToString(closingOpeningTimes[d].open)} ${d}`
-          };
-          return true;
-        }
-      });
+    let remainingDays = days.splice(day+1);
+    remainingDays.some(d => {
+      if(closingOpeningTimes[d]) {
+        result = {
+          open: false,
+          time: `${timeToString(closingOpeningTimes[d].open)} ${d}`
+        };
+        return true;
+      }
+    });
 
-      if(result.time) return result;
+    if(result.time) return result;
 
-      days.some(d => {
-        if(closingOpeningTimes[d]) {
-          result =  {
-            open: false,
-            time: `${timeToString(closingOpeningTimes[d].open)} ${d}`
-          };
-          return true;
-        }
-      })
-    }
+    days.some(d => {
+      if(closingOpeningTimes[d]) {
+        result =  {
+          open: false,
+          time: `${timeToString(closingOpeningTimes[d].open)} ${d}`
+        };
+        return true;
+      }
+    })
 
     return result;
   }
@@ -147,7 +148,7 @@ class ResourcesRow extends Component {
             <div className="entry-meta">
               <p className="entry-organization">{serviceName}</p>
               <p className="entry-description">{resourceDescription}</p>
-              <p className="entry-hours">{open ? `Open until ${time}` : time ? `Closed until ${time}` : 'No hours found for this location'}</p>
+              <p className="entry-hours">{open ? `Open until ${time}` : time ? `Closed` : 'No hours found for this location'}</p>
             </div>
           </Link>
         </li>

--- a/app/components/Search/ResourcesTable.js
+++ b/app/components/Search/ResourcesTable.js
@@ -33,8 +33,11 @@ class ResourcesTable extends Component {
       openFilter: false,
       currentPage: [],
       page: 0,
-      categoryId: null
+      categoryId: null,
+      newResources: [],
     };
+
+    this.prepOpenResources = this.prepOpenResources.bind(this);
   }
 
   loadResourcesFromServer(userLocation) {
@@ -63,17 +66,13 @@ class ResourcesTable extends Component {
     let url = path + '?' + queryString.stringify(params);
     fetch(url,{ credentials: 'include' }).then(r => r.json())
       .then(data => {
-        let openResources = data.resources.filter(resource => {
-          let hours = openHours(resource.schedule.schedule_days);
-          if(hours) {
-            return resource;
-          }
-        });
+        let openResources = this.prepOpenResources(data.resources);
+        
         this.setState({
           allResources: data.resources,
           resources: data.resources,
-          currentPage: data.resources.slice(0,resultsPerPage),
-          openResources: openResources
+          currentPage: data.resources.slice(0, resultsPerPage),
+          openResources: openResources,
         });
       });
   }
@@ -139,6 +138,22 @@ class ResourcesTable extends Component {
     if (nextProps.userLocation) {
       this.loadResourcesFromServer(nextProps.userLocation);
     }
+  }
+
+  prepOpenResources(resources) {
+    let preparedOpenResources = [];
+
+    resources.forEach(resource => {
+
+      let { openUntil, isOpen } = getTimes(resource.schedule.schedule_days);
+      resource.openUntil = openUntil;
+      resource.isOpen = isOpen;
+
+      if (isOpen) {
+        preparedOpenResources.push(resource);
+      }
+    });
+    return preparedOpenResources;
   }
 
   render() {
@@ -263,11 +278,11 @@ function openHours(scheduleDays) {
 
   const currentTime = parseInt(moment().format("HHMM"));
   let hours = null;
-  let currDayHours = [];
-  let prevDayHoursPastMidnight = [];
   let days = [];
-  debugger;
 
+  // Logic to determine if the current resource is open
+  // includes special logic for when a resource is open past midnight
+  // on the previous day
   scheduleDays.forEach(scheduleDay => {
     let day = scheduleDay ? scheduleDay.day.replace(/,/g, '') : null;
     let opensAt = scheduleDay.opens_at;
@@ -275,14 +290,12 @@ function openHours(scheduleDays) {
 
      if (day) {
       if (day === daysOfTheWeek()[currentDate.getDay()]) {
-        currDayHours.push(scheduleDay);
         if(currentTime > opensAt && currentTime < closesAt) {
           days.push(scheduleDay);
         }
       }
 
       if (day === daysOfTheWeek()[yesterday.getDay()] && closesAt > 1200) {
-        prevDayHoursPastMidnight.push(scheduleDay);
         if(currentTime > opensAt && currentTime < closesAt) {
           days.push(scheduleDay);
         }
@@ -292,6 +305,44 @@ function openHours(scheduleDays) {
 
   if (days.length > 0) {
     return days;
+  }
+}
+
+function getTimes(scheduleDays) {
+  const currentDate = new Date();
+  let yesterday = new Date(currentDate);
+  yesterday.setDate(currentDate.getDate() - 1);
+
+  const currentTime = parseInt(moment().format("hhmm"));
+  let hours = null;
+  let openUntil = null;
+  // Logic to determine if the current resource is open
+  // includes special logic for when a resource is open past midnight
+  // on the previous day
+  scheduleDays.forEach(scheduleDay => {
+    let day = scheduleDay ? scheduleDay.day.replace(/,/g, '') : null;
+    let opensAt = scheduleDay.opens_at;
+    let closesAt = scheduleDay.closes_at;
+
+     if (day) {
+      if (day === daysOfTheWeek()[currentDate.getDay()]) {
+        if(currentTime > opensAt && currentTime < closesAt) {
+          openUntil = closesAt;
+        }
+      }
+
+      if (day === daysOfTheWeek()[yesterday.getDay()] && closesAt < opensAt) {
+        if(currentTime < closesAt) {
+          openUntil = closesAt;
+        }
+      }
+     }
+  });
+
+  if (openUntil) {
+    return { openUntil, isOpen: true };
+  } else {
+    return { openUntil, isOpen: false };
   }
 }
 

--- a/app/components/Search/ResourcesTable.js
+++ b/app/components/Search/ResourcesTable.js
@@ -6,6 +6,7 @@ import Loader from '../Loader';
 import queryString from 'query-string';
 import ResourcesList from './ResourcesList'
 import { timeToString, stringToTime, daysOfTheWeek } from '../../utils/index';
+import moment from 'moment';
 
 // Show the span of results (11 - 20 for example rather than the #10)
 // Make the map update with proper markers
@@ -260,11 +261,12 @@ function openHours(scheduleDays) {
   let yesterday = new Date(currentDate);
   yesterday.setDate(currentDate.getDate() - 1);
 
-  const currentHour = currentDate.getHours();
+  const currentTime = parseInt(moment().format("HHMM"));
   let hours = null;
   let currDayHours = [];
   let prevDayHoursPastMidnight = [];
   let days = [];
+  debugger;
 
   scheduleDays.forEach(scheduleDay => {
     let day = scheduleDay ? scheduleDay.day.replace(/,/g, '') : null;
@@ -274,14 +276,14 @@ function openHours(scheduleDays) {
      if (day) {
       if (day === daysOfTheWeek()[currentDate.getDay()]) {
         currDayHours.push(scheduleDay);
-        if(currentHour > opensAt && currentHour < closesAt) {
-          days.push(scheduleDay)
+        if(currentTime > opensAt && currentTime < closesAt) {
+          days.push(scheduleDay);
         }
       }
 
       if (day === daysOfTheWeek()[yesterday.getDay()] && closesAt > 1200) {
         prevDayHoursPastMidnight.push(scheduleDay);
-        if(currentHour < closesAt) {
+        if(currentTime > opensAt && currentTime < closesAt) {
           days.push(scheduleDay);
         }
       }

--- a/app/components/Search/ResourcesTable.js
+++ b/app/components/Search/ResourcesTable.js
@@ -257,26 +257,40 @@ function buildImgURL(address) {
 // Returns the open hours today or null if closed
 function openHours(scheduleDays) {
   const currentDate = new Date();
+  let yesterday = new Date(currentDate);
+  yesterday.setDate(currentDate.getDate() - 1);
+
   const currentHour = currentDate.getHours();
   let hours = null;
+  let currDayHours = [];
+  let prevDayHoursPastMidnight = [];
+  let days = [];
 
-  const days = scheduleDays.filter(scheduleDay => {
+  scheduleDays.forEach(scheduleDay => {
     let day = scheduleDay ? scheduleDay.day.replace(/,/g, '') : null;
-    return (day && day === daysOfTheWeek()[currentDate.getDay()] &&
-            currentHour > scheduleDay.opens_at && currentHour < scheduleDay.closes_at);
+    let opensAt = scheduleDay.opens_at;
+    let closesAt = scheduleDay.closes_at;
+
+     if (day) {
+      if (day === daysOfTheWeek()[currentDate.getDay()]) {
+        currDayHours.push(scheduleDay);
+        if(currentHour > opensAt && currentHour < closesAt) {
+          days.push(scheduleDay)
+        }
+      }
+
+      if (day === daysOfTheWeek()[yesterday.getDay()] && closesAt > 1200) {
+        prevDayHoursPastMidnight.push(scheduleDay);
+        if(currentHour < closesAt) {
+          days.push(scheduleDay);
+        }
+      }
+     }
   });
 
-  if(days.length) {
-    for(let i = 0; i < days.length; i++) {
-      let day = days[i];
-      hours = "open: " + timeToString(day.opens_at) + "-" + timeToString(day.closes_at);
-      if(i != days.length - 1) {
-        hours += ", ";
-      }
-    }
+  if (days.length > 0) {
+    return days;
   }
-
-  return hours;
 }
 
 export default ResourcesTable;


### PR DESCRIPTION
In the past, the `Open Now` filter on the resource list page did not account for when a resource was open past midnight on a particular day. 

For example, imagine it's Sunday at 2am and the current resource is open from 8pm-4am on Saturday. In this case, we would still want to display the resource as open even if the schedule is for the day before (Saturday). 

Now, I've added special logic to handle this case and confirmed that this is now working as intended.