### PR TITLE
Add Travis and Sauce Labs badges to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# ShelterTech Web App
+# ShelterTech Web App [![Travis CI Status](https://travis-ci.org/ShelterTechSF/askdarcel-web.svg?branch=master)](https://travis-ci.org/ShelterTechSF/askdarcel-web)
 
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/askdarcel-web-master.svg)](https://saucelabs.com/u/askdarcel-web-master)
 
 ## Installation
 

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -9,7 +9,17 @@ cleanup() {
   fi
 }
 
-#trap cleanup EXIT
+trap cleanup EXIT
+
+# Use master branch credentials so that build status badges are tied to only the
+# master branch.
+if [[ $TRAVIS_BRANCH = "master" ]]; then
+  export SAUCE_ACCESS_KEY=$SAUCE_MASTER_ACCESS_KEY
+  export SAUCE_USERNAME=$SAUCE_MASTER_USERNAME
+fi
+
+export SAUCE_JOB="all"
+export SAUCE_BUILD="build-$TRAVIS_JOB_NUMBER"
 
 docker network create --driver bridge askdarcel
 docker run -d --network=askdarcel --name=db postgres:9.5


### PR DESCRIPTION
Did a little bit of cleanup by adding build status badges to the README. For Sauce Labs, I had to create a subaccount with separate credentials so that PR builds aren't mixed in with builds from master. I tested this by pushing a temporary commit that ran the master branch credentials on a normal pull request and checking that the badge shows up fine (https://github.com/ShelterTechSF/askdarcel-web/blob/a602b1ef736d8b68cd8a96bf6f8780b2eec4ad34/README.md).