### PR TITLE
Cleaning up HAP Certified functionality

### DIFF
--- a/app/components/Resource/DetailedHours.js
+++ b/app/components/Resource/DetailedHours.js
@@ -5,7 +5,6 @@ import { timeToString, sortScheduleDays } from '../../utils/index';
 export default function DetailedHours(props) {
   let { schedule } = props;
   schedule = sortScheduleDays(schedule);
-  console.log(schedule);
   const hoursList = schedule.map((item) => {
     if (item.opens_at === 0 && item.closes_at >= 2359) {
       return (

--- a/app/components/Resource/Resource.js
+++ b/app/components/Resource/Resource.js
@@ -22,6 +22,7 @@ class Resource extends Component {
     super(props);
     this.state = { resource: null };
     this.verifyResource = this.verifyResource.bind(this);
+    this.hapCertify = this.hapCertify.bind(this);
   }
 
   componentDidMount() {
@@ -45,6 +46,21 @@ class Resource extends Component {
         // TODO: Do not use alert() for user notifications.
         if (response.ok) {
           alert('Resource verified. Thanks!');  // eslint-disable-line no-alert
+        } else {
+          alert('Issue verifying resource. Please try again.');  // eslint-disable-line no-alert
+        }
+      });
+  }
+
+  hapCertify() {
+    dataService.post(`/api/resources/${this.state.resource.id}/certify`)
+      .then((response) => {
+        // TODO: Do not use alert() for user notifications.
+        if (response.ok) {
+          alert('HAP Certified. Thanks!');  // eslint-disable-line no-alert
+          const resource = this.state.resource;
+          resource.certified = response.ok;
+          this.setState({ resource });
         } else {
           alert('Issue verifying resource. Please try again.');  // eslint-disable-line no-alert
         }
@@ -96,7 +112,6 @@ class Resource extends Component {
               <div className="org--main--header--description">
                 <header>About this resource</header>
                 <p>{resource.long_description || resource.short_description || 'No Description available'}</p>
-                <pre>{JSON.stringify(resource, null, 2)}</pre>
               </div>
             </header>
 
@@ -151,6 +166,15 @@ class Resource extends Component {
               >
                 Mark Info as Correct
               </button>
+              {
+                !resource.certified &&
+                <button
+                  className="org--aside--content--button"
+                  onClick={this.hapCertify}
+                >
+                  HAP Approve
+                </button>
+              }
               <nav className="org--aside--content--nav">
                 <ul>
                   <li><a href="#resource">{resource.name}</a></li>


### PR DESCRIPTION
 For HAP Certified to hold some weight, needs to be restricted to authenticated users after implementation of a more general auth/login system #367 

- Removed old junk console log code
- Adds new `HAP Approve` button
- Unverified resource showing `HAP Approve` button:
![screenshot 2018-01-08 16 14 22 2](https://user-images.githubusercontent.com/5233309/34698876-4cbb2c5e-f48f-11e7-9f19-abf763ad6af1.png)
- After button is clicked, it disappears and `HAP CERTIFIED` icon appears:
![screenshot 2018-01-08 16 15 24 2](https://user-images.githubusercontent.com/5233309/34698889-62db4fa0-f48f-11e7-9e0f-431a47a52f1d.png)



  