### PR TITLE
Add docker-compose.yml and Docker-based setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,43 @@
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/askdarcel-web-master.svg)](https://saucelabs.com/u/askdarcel-web-master)
 
-## Installation
+## Docker-based Development Set-up Instructions (Recommended)
+
+### Requirements
+
+Docker Community Edition (CE) >= 17.06
+Docker Compose >= 1.18
+
+Follow the [Docker installation instructions](https://www.docker.com/products/overview) for your OS.
+
+### Set up the project
+
+This is not a full guide to Docker and Docker Compose, so please consult other
+guides to learn more about those tools.
+
+The docker-compose.yml is configured to mount the git repo on your host
+filesystem into the Docker container so that any changes you make on your host
+machine will be synced into the container and vice versa.
+
+```sh
+# Install node dependencies
+# docker-compose run --rm web npm install
+
+# Build static assets bundle
+# docker-compose run --rm web npm build
+
+# Run dev server
+# docker-compose up
+```
+
+You should be able to view the web app in your browser at http://localhost:8080.
+
+By default, this assumes that you have also set up askdarcel-api project using
+the Docker setup instructions and that the API server is running. If you want to
+target a different instance of askdarcel-api, you can modify the `API_URL`
+environment variable in docker-compose.yml.
+
+## Non-Docker Set-up Instructions
 
 ### Installing Node.js and npm
 We recommend using [nvm](https://github.com/creationix/nvm) (Node Version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.5'
+services:
+  web:
+    command: npm -- run dev --host 0.0.0.0
+    environment:
+      API_URL: http://api:3000
+    image: node:8.4
+    networks:
+      - askdarcel
+    ports:
+      - '8080:8080'
+    volumes:
+      - .:/usr/src/app
+    working_dir: /usr/src/app
+
+networks:
+  # Used to connect to askdarcel-api in a different docker-compose instance
+  askdarcel:
+    name: askdarcel


### PR DESCRIPTION
Depends on https://github.com/ShelterTechSF/askdarcel-api/pull/272, since there needs to be a minor tweak to how networking is set up in the askdarcel-api docker-compose instance.

This adds a very simple docker-compose.yml file that is configured to allow you to run the askdarcel-web app and connect it to a Docker-based askdarcel-api instance. It's so simple that there isn't even a new Dockerfile; we just use the vanilla `node` Docker image.

The README has been updated with instructions on how to use the new Docker flow, which I've marked as the recommended setup.