### PR TITLE
Add linting to TestCafe tests and fix style violations.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,34 @@
 module.exports = {
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "plugin:testcafe/recommended",
+  ],
   "plugins": [
     "react",
     "jsx-a11y",
     "import",
+    "testcafe",
   ],
   "env": {
     "browser": true,
   },
   "rules": {
+    "camelcase": 0,
+    "no-unused-expressions": [
+      "error",
+      {
+        "allowTaggedTemplates": true,
+      }
+    ],
+    "no-underscore-dangle": 0,
     "react/jsx-filename-extension": 0,
     "react/forbid-prop-types": 0,
-    "no-underscore-dangle": 0,
-    "camelcase": 0,
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": ['testcafe/**/*.js'],
+      },
+    ],
   },
   "settings": {
     "import/resolver": "webpack",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4326,6 +4326,12 @@
         }
       }
     },
+    "eslint-plugin-testcafe": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testcafe/-/eslint-plugin-testcafe-0.2.1.tgz",
+      "integrity": "sha1-QIn2RtrbabE3agHX5ggYSQfmA2s=",
+      "dev": true
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.1",
+    "eslint-plugin-testcafe": "^0.2.1",
     "extended-define-webpack-plugin": "^0.1.3",
     "jasmine-core": "^2.4.1",
     "js-yaml": "^3.9.0",
@@ -74,7 +75,7 @@
   "scripts": {
     "testserver": "cross-env NODE_ENV=test karma start internals/testing/karma.conf.js",
     "test": "cross-env NODE_ENV=test karma start internals/testing/karma.conf.js --single-run",
-    "lint": "eslint app/",
+    "lint": "eslint app/ testcafe/",
     "postinstall": "npm run build",
     "build": "cross-env NODE_ENV=production webpack",
     "dev": "webpack-dev-server --inline --open",

--- a/testcafe/config.js
+++ b/testcafe/config.js
@@ -1,3 +1,3 @@
 export default {
-  baseUrl: process.env.BASE_URL || 'http://localhost:8080'
+  baseUrl: process.env.BASE_URL || 'http://localhost:8080',
 };

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -8,18 +8,19 @@ const editPage = new EditPage();
 fixture `Edit Resource`
   .page `${config.baseUrl}/resource?id=1`;
 
-test('Edit resource name', async t => {
+test('Edit resource name', async (t) => {
   const newName = 'New Resource Name';
   await t
     .click(resourcePage.editButton)
     .typeText(editPage.name, newName, { replace: true })
     .click(editPage.saveButton)
-    .expect(resourcePage.resourceName.textContent).contains(newName)
+    .expect(resourcePage.resourceName.textContent)
+    .contains(newName)
     ;
 });
 
 
-test('Edit resource address', async t => {
+test('Edit resource address', async (t) => {
   const newProps = {
     address1: '123 Fake St.',
     address2: 'Suite 456',
@@ -29,39 +30,41 @@ test('Edit resource address', async t => {
     stateOrProvince: 'Illinois',
     country: 'United States',
     postalCode: '62701',
-  }
+  };
   // TODO: Some fields are not displayed on the show page
   const notVisibleOnShowPage = ['address3', 'address4', 'country'];
 
   // Make edits
   await t.click(resourcePage.editButton);
-  for (const prop in newProps) {
-    await t.typeText(editPage.address[prop], newProps[prop], { replace: true });
-  }
+  await Promise.all(
+    Object.keys(newProps)
+    .map(prop => t.typeText(editPage.address[prop], newProps[prop], { replace: true })),
+  );
   await t.click(editPage.saveButton);
 
   // Check visibility of edits on show page
-  for (const prop in newProps) {
-    if (notVisibleOnShowPage.includes(prop)) continue;
-    await t.expect(resourcePage.address.textContent).contains(newProps[prop]);
-  }
+  await Promise.all(
+    Object.keys(newProps)
+    .filter(prop => !notVisibleOnShowPage.includes(prop))
+    .map(prop => t.expect(resourcePage.address.textContent).contains(newProps[prop])),
+  );
 
   // Check visibility of edits on edit page
   await t.click(resourcePage.editButton);
-  for (const prop in newProps) {
-    await t.expect(editPage.address[prop].value).eql(newProps[prop]);
-  }
+  await Promise.all(Object.keys(newProps).map(
+    prop => t.expect(editPage.address[prop].value).eql(newProps[prop]),
+  ));
 });
 
 
-test('Edit resource phone number', async t => {
+test('Edit resource phone number', async (t) => {
   const newNumber = '415-555-5555';
   const newFormattedNumber = '(415) 555-5555';
   const newServiceType = 'Main number';
 
   // Make edits
   await t.click(resourcePage.editButton);
-  const phone = editPage.getPhone(0);
+  const phone = EditPage.getPhone(0);
   await t
     .typeText(phone.number, newNumber, { replace: true })
     .typeText(phone.serviceType, newServiceType, { replace: true })
@@ -76,7 +79,7 @@ test('Edit resource phone number', async t => {
 });
 
 
-test('Add resource phone number', async t => {
+test('Add resource phone number', async (t) => {
   const newNumber = '415-555-5556';
   const newFormattedNumber = '(415) 555-5556';
   const newServiceType = 'Added number';
@@ -90,7 +93,7 @@ test('Add resource phone number', async t => {
     .click(resourcePage.editButton)
     .click(editPage.addPhoneButton)
     ;
-  const phone = editPage.getPhone(-1);
+  const phone = EditPage.getPhone(-1);
   await t
     .typeText(phone.number, newNumber, { replace: true })
     .typeText(phone.serviceType, newServiceType, { replace: true })
@@ -101,6 +104,7 @@ test('Add resource phone number', async t => {
   await t
     .expect(resourcePage.phones.parent().textContent).contains(newFormattedNumber)
     .expect(resourcePage.phones.parent().textContent).contains(newServiceType)
-    .expect(resourcePage.phones.count).eql(originalCount + 1)
+    .expect(resourcePage.phones.count)
+    .eql(originalCount + 1)
     ;
 });

--- a/testcafe/home.js
+++ b/testcafe/home.js
@@ -10,16 +10,17 @@ const resourcePage = new ResourcePage();
 fixture `Home Page`
   .page `${config.baseUrl}`;
 
-test('Basic navigation test', async t => {
+test('Basic navigation test', async (t) => {
   await t
     .click(findPage.categoryButton.withText('Food'))
     .expect(searchPage.resultsCount.textContent).contains('Total Results')
     .click(searchPage.resultEntry)
-    .expect(resourcePage.description.textContent).contains('About this resource')
+    .expect(resourcePage.description.textContent)
+    .contains('About this resource')
     ;
 });
 
-test('Basic search test', async t => {
+test('Basic search test', async (t) => {
   await t
     .typeText(findPage.searchBox, 'Food')
     .pressKey('enter')

--- a/testcafe/pages/EditPage.js
+++ b/testcafe/pages/EditPage.js
@@ -32,7 +32,7 @@ export default class EditPage {
     this.saveButton = baseSelector.find('.edit--aside--content--button');
   }
 
-  getPhone(index) {
+  static getPhone(index) {
     return new EditPhone(index);
   }
 }


### PR DESCRIPTION
I noticed that we're not linting the TestCafe tests, since they're located in a different directory from the normal app files. This adds them to ESLint, and also includes a bunch of corrections to the style in order to pass linting. I want to get this in before we add more TestCafe tests, before we start proliferating more bad style 😛.