### PR TITLE
Use delegated volume mount to increase Docker performance on macOS.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - '8080:8080'
     volumes:
-      - .:/usr/src/app
+      - .:/usr/src/app:delegated
     working_dir: /usr/src/app
 
 networks:


### PR DESCRIPTION
Newer versions of Docker for Mac support different caching options for macOS volume mounts. Using the `delegated` mount option allows the container and host to temporarily be out of sync, making the container's view authoritative, which can improve performance because writes within the container do not need to propagate to the host before they return.

Empirically, this slightly speed up the Webpack build from ~40s to ~35s on my MacBook Pro.

https://docs.docker.com/compose/compose-file/#caching-options-for-volume-mounts-docker-for-mac