### PR TITLE
Add basic test for New Resource Page.

### DIFF
--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -1,19 +1,18 @@
-import config from './config';
 import ResourcePage from './pages/ResourcePage';
-import EditPage from './pages/EditPage';
+import EditResourcePage from './pages/EditResourcePage';
 
 const resourcePage = new ResourcePage();
-const editPage = new EditPage();
+const editResourcePage = new EditResourcePage();
 
 fixture `Edit Resource`
-  .page `${config.baseUrl}/resource?id=1`;
+  .page(EditResourcePage.url(1));
 
 test('Edit resource name', async (t) => {
   const newName = 'New Resource Name';
   await t
     .click(resourcePage.editButton)
-    .typeText(editPage.name, newName, { replace: true })
-    .click(editPage.saveButton)
+    .typeText(editResourcePage.name, newName, { replace: true })
+    .click(editResourcePage.saveButton)
     .expect(resourcePage.resourceName.textContent)
     .contains(newName)
     ;
@@ -38,9 +37,9 @@ test('Edit resource address', async (t) => {
   await t.click(resourcePage.editButton);
   await Promise.all(
     Object.keys(newProps)
-    .map(prop => t.typeText(editPage.address[prop], newProps[prop], { replace: true })),
+    .map(prop => t.typeText(editResourcePage.address[prop], newProps[prop], { replace: true })),
   );
-  await t.click(editPage.saveButton);
+  await t.click(editResourcePage.saveButton);
 
   // Check visibility of edits on show page
   await Promise.all(
@@ -52,7 +51,7 @@ test('Edit resource address', async (t) => {
   // Check visibility of edits on edit page
   await t.click(resourcePage.editButton);
   await Promise.all(Object.keys(newProps).map(
-    prop => t.expect(editPage.address[prop].value).eql(newProps[prop]),
+    prop => t.expect(editResourcePage.address[prop].value).eql(newProps[prop]),
   ));
 });
 
@@ -64,11 +63,11 @@ test('Edit resource phone number', async (t) => {
 
   // Make edits
   await t.click(resourcePage.editButton);
-  const phone = EditPage.getPhone(0);
+  const phone = EditResourcePage.getPhone(0);
   await t
     .typeText(phone.number, newNumber, { replace: true })
     .typeText(phone.serviceType, newServiceType, { replace: true })
-    .click(editPage.saveButton)
+    .click(editResourcePage.saveButton)
     ;
 
   // Check visibility of edits on show page
@@ -91,13 +90,13 @@ test('Add resource phone number', async (t) => {
   // Make edits
   await t
     .click(resourcePage.editButton)
-    .click(editPage.addPhoneButton)
+    .click(editResourcePage.addPhoneButton)
     ;
-  const phone = EditPage.getPhone(-1);
+  const phone = EditResourcePage.getPhone(-1);
   await t
     .typeText(phone.number, newNumber, { replace: true })
     .typeText(phone.serviceType, newServiceType, { replace: true })
-    .click(editPage.saveButton)
+    .click(editResourcePage.saveButton)
     ;
 
   // Check visibility of edits on show page
@@ -115,8 +114,8 @@ test('Delete resource phone number', async (t) => {
 
   await t
     .click(resourcePage.editButton)
-    .click(editPage.deletePhoneButton)
-    .click(editPage.saveButton)
+    .click(editResourcePage.deletePhoneButton)
+    .click(editResourcePage.saveButton)
     ;
 
   await t

--- a/testcafe/newResource.js
+++ b/testcafe/newResource.js
@@ -1,0 +1,40 @@
+import NewResourcePage from './pages/NewResourcePage';
+
+const newResourcePage = new NewResourcePage();
+
+fixture `Add New Resource`
+  .page(NewResourcePage.url());
+
+test('Add new resource, basic', async (t) => {
+  const newName = 'New Resource Name';
+  // TODO: These are all currently required, but should they be?
+  const newAddress = {
+    address1: '123 Fake St.',
+    city: 'San Francisco',
+    stateOrProvince: 'CA',
+    country: 'United States',
+    postalCode: '94110',
+  };
+  await t.typeText(newResourcePage.name, newName, { replace: true });
+  await Promise.all(
+    Object.keys(newAddress)
+    .map(prop => t.typeText(newResourcePage.address[prop], newAddress[prop], { replace: true })),
+  );
+
+  function dialogHandler(type, text) {
+    if (!text.includes('Resource successfuly created')) {
+      throw new Error(`Got unexpected dialog: ${text}`);
+    }
+  }
+  await t.setNativeDialogHandler(dialogHandler)
+    .click(newResourcePage.saveButton)
+    .setNativeDialogHandler(null)
+  ;
+
+  const dialogHistory = await t.getNativeDialogHistory();
+  await t.expect(dialogHistory.length).eql(1);
+
+  // TODO: Check that the View Resource page has the correct info, but since the
+  // Create New Resource page currently takes you to the home page, it's hard to
+  // navigate to the View Resource page.
+});

--- a/testcafe/pages/EditResourcePage.js
+++ b/testcafe/pages/EditResourcePage.js
@@ -1,0 +1,9 @@
+import config from '../config';
+import EditPage from './EditPage';
+
+
+export default class EditResourcePage extends EditPage {
+  static url(resourceId) {
+    return `${config.baseUrl}/resource?id=${resourceId}`;
+  }
+}

--- a/testcafe/pages/NewResourcePage.js
+++ b/testcafe/pages/NewResourcePage.js
@@ -1,0 +1,9 @@
+import config from '../config';
+import EditPage from './EditPage';
+
+
+export default class NewResourcePage extends EditPage {
+  static url() {
+    return `${config.baseUrl}/resource/new`;
+  }
+}


### PR DESCRIPTION
This sort of but not fully implements #427. It adds a basic test that visits the new resource page, fills out the minimum amount of information that won't trigger a server validation error, and hits the submit button.

What isn't easy for me to test is that the filled out information is actually present on the show page. This is because after you hit the submit button, it takes you to the home page, and it's not easy to find the show page for the resource you just created.

While I would prefer to ship what I have now and defer actual changes to the app to a separate PR, what you all think about changing the behavior of the submit button to redirect you to the show page of the resource that was just created? That would make testing a lot easier.