### PR TITLE
Test editing and viewing resource fields

### DIFF
--- a/app/components/Resource/Resource.jsx
+++ b/app/components/Resource/Resource.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
-import { AddressInfo, TodaysHours, PhoneNumber, ResourceCategories, Website, StreetView } from './ResourceInfos';
+import { AddressInfo, TodaysHours, PhoneNumber, ResourceCategories, Website, Email, StreetView } from './ResourceInfos';
 import DetailedHours from './DetailedHours';
 import Services from './Services';
 import Notes from './Notes';
@@ -120,9 +120,7 @@ class Resource extends Component {
                   <AddressInfo address={resource.address} />
                   <PhoneNumber phones={resource.phones} />
                   <Website website={resource.website} />
-                  <span className="website">
-                    <a href={`mailto:${this.state.resource.email}`} target="_blank" rel="noopener noreferrer">{this.state.resource.email}</a>
-                  </span>
+                  <Email email={resource.email} />
                 </div>
                 <div className="info--column">
                   <DetailedHours schedule={resource.schedule.schedule_days} />

--- a/app/components/Resource/ResourceInfos.jsx
+++ b/app/components/Resource/ResourceInfos.jsx
@@ -136,13 +136,22 @@ PhoneNumber.propTypes = {
 };
 
 
+function ExternalLink(props) {
+  return <a href={props.to} target="_blank" rel="noopener noreferrer">{props.children}</a>;
+}
+
+ExternalLink.propTypes = {
+  to: PropTypes.string.isRequired,
+};
+
+
 function Website(props) {
   if (!props.website) {
     return null;
   }
   return (
     <span className="website">
-      <a href={props.website} target="_blank" rel="noopener noreferrer">{props.website}</a>
+      <ExternalLink href={props.website}>{props.website}</ExternalLink>
     </span>
   );
 }
@@ -153,6 +162,26 @@ Website.propTypes = {
 
 Website.defaultProps = {
   website: null,
+};
+
+
+function Email(props) {
+  if (!props.email) {
+    return null;
+  }
+  return (
+    <span className="email">
+      <ExternalLink to={`mailto:${props.email}`}>{props.email}</ExternalLink>
+    </span>
+  );
+}
+
+Email.propTypes = {
+  email: PropTypes.string,
+};
+
+Email.defaultProps = {
+  email: null,
 };
 
 
@@ -194,4 +223,13 @@ StreetView.defaultProps = {
   address: null,
 };
 
-export { Cat, AddressInfo, TodaysHours, PhoneNumber, ResourceCategories, Website, StreetView };
+export {
+  Cat,
+  AddressInfo,
+  TodaysHours,
+  PhoneNumber,
+  ResourceCategories,
+  Website,
+  Email,
+  StreetView,
+};

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -5,7 +5,7 @@ const resourcePage = new ResourcePage();
 const editResourcePage = new EditResourcePage();
 
 fixture `Edit Resource`
-  .page(EditResourcePage.url(1));
+  .page(ResourcePage.url(1));
 
 test('Edit resource name', async (t) => {
   const newName = 'New Resource Name';

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -7,15 +7,19 @@ const editResourcePage = new EditResourcePage();
 fixture `Edit Resource`
   .page(ResourcePage.url(1));
 
-test('Edit resource name', async (t) => {
-  const newName = 'New Resource Name';
+
+async function testEditTextProperty(t, showPageSelector, editPageSelector, newValue) {
   await t
     .click(resourcePage.editButton)
-    .typeText(editResourcePage.name, newName, { replace: true })
+    .typeText(editPageSelector, newValue, { replace: true })
     .click(editResourcePage.saveButton)
-    .expect(resourcePage.resourceName.textContent)
-    .contains(newName)
+    .expect(showPageSelector.textContent)
+    .contains(newValue)
     ;
+}
+
+test('Edit resource name', async (t) => {
+  await testEditTextProperty(t, resourcePage.resourceName, editResourcePage.name, 'New Resource Name');
 });
 
 
@@ -122,4 +126,31 @@ test('Delete resource phone number', async (t) => {
     .expect(resourcePage.phones.count)
     .eql(originalCount - 1)
     ;
+});
+
+test('Edit resource website', async (t) => {
+  await testEditTextProperty(
+    t,
+    resourcePage.website,
+    editResourcePage.website,
+    'http://www.example.com/',
+  );
+});
+
+test('Edit resource email', async (t) => {
+  await testEditTextProperty(
+    t,
+    resourcePage.email,
+    editResourcePage.email,
+    'example@example.com',
+  );
+});
+
+test('Edit resource description', async (t) => {
+  await testEditTextProperty(
+    t,
+    resourcePage.description,
+    editResourcePage.description,
+    'This is my new description',
+  );
 });

--- a/testcafe/pages/EditPage.js
+++ b/testcafe/pages/EditPage.js
@@ -29,6 +29,9 @@ export default class EditPage {
     this.name = baseSelector.find('#edit-name-input');
     this.address = new EditAddress();
     this.addPhoneButton = ReactSelector('EditPhones').find('.edit--section--list--item--button');
+    this.website = baseSelector.find('#edit-website-input');
+    this.email = baseSelector.find('#edit-email-input');
+    this.description = baseSelector.find('#edit-description-input');
     this.deletePhoneButton = ReactSelector('EditPhones').find('.trash-button');
     this.saveButton = baseSelector.find('.edit--aside--content--button');
   }

--- a/testcafe/pages/EditResourcePage.js
+++ b/testcafe/pages/EditResourcePage.js
@@ -4,6 +4,6 @@ import EditPage from './EditPage';
 
 export default class EditResourcePage extends EditPage {
   static url(resourceId) {
-    return `${config.baseUrl}/resource?id=${resourceId}`;
+    return `${config.baseUrl}/resource/edit?id=${resourceId}`;
   }
 }

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -1,4 +1,5 @@
 import { ReactSelector } from 'testcafe-react-selectors';
+import config from '../config';
 
 export default class ResourcePage {
   constructor() {
@@ -14,5 +15,9 @@ export default class ResourcePage {
     // https://github.com/DevExpress/testcafe-react-selectors/issues/51
     this.phones = baseSelector.find('.org--main--header--phone .phone p');
     this.editButton = baseSelector.find('.edit-button');
+  }
+
+  static url(resourceId) {
+    return `${config.baseUrl}/resource?id=${resourceId}`;
   }
 }

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -14,6 +14,8 @@ export default class ResourcePage {
     // in between React component names.
     // https://github.com/DevExpress/testcafe-react-selectors/issues/51
     this.phones = baseSelector.find('.org--main--header--phone .phone p');
+    this.website = baseSelector.findReact('Website');
+    this.email = baseSelector.findReact('Email');
     this.editButton = baseSelector.find('.edit-button');
   }
 


### PR DESCRIPTION
Fixes #419 and #428, except I'm going to claim that some of the things mentioned in those tickets are better done with other TestCafe tickets.

## Justification for rescoping these tickets
From #419:

> --Open status (either as "Open until x" or "Closed")

Should be done with one of the tickets related to schedule days.

> --Each address associated with the resource
> --Each phone number associated with the resource

Already done previously.

From #428:

> --Address and related fields

Already done previously.

> --Phone(s) (number and service type)

This should be done with some of the other tickets related to adding/removing phone numbers.

## Actual changes made
The email on a resource wasn't easy to select because the DOM element it is in has the class "website"  for some reason. I did a bit of refactoring so that there's an Email component, similar to the Website component, and I pulled out the common bits between that and the Website component into an ExternalLink component.

Aside from that, I added tests for checking that the website, email, and description fields can be modified and that the modifications show up on the show page. Note that the Alternative Name does not seem to actually appear on the show page, so I left that out.