### PR TITLE
Fix borked create new resource page when an error occurs

### DIFF
--- a/app/components/Edit/EditSections.js
+++ b/app/components/Edit/EditSections.js
@@ -284,6 +284,9 @@ class EditSections extends React.Component {
     // let newServices = this.prepServicesData(services.services);
 
     this.setState({ submitting: true });
+    const setNotSubmitting = () => {
+      this.setState({ submitting: false });
+    }
     dataService.post(requestString, { resources: [newResource] })
       .then((response) => {
         if (response.ok) {
@@ -296,6 +299,7 @@ class EditSections extends React.Component {
       .catch((error) => {
         alert('Issue creating resource, please try again.');
         console.log(error);
+        setNotSubmitting();
       });
   }
 

--- a/app/styles/components/_edit.scss
+++ b/app/styles/components/_edit.scss
@@ -87,13 +87,18 @@
 		width: 100%;
 		max-width: 12em;
 		&--button {
+			$button-color: #1C72E6;
 			color: #FFFFFF;
 			font-size: 17px;
 			font-weight: bold;
 			padding: calc-em(9px) calc-em(25px);
-			background: #1C72E6;
+			background: $button-color;
 			border-radius: 8px;
 			width: 70%;
+			&:disabled {
+				background: lighten(desaturate($button-color, 50%), 20%);
+				cursor: not-allowed;
+			}
 		}
 		&--nav {
 			margin: calc-em(30px) 0;


### PR DESCRIPTION
Fixes #534.

I figured out that the reason the submit button fails to work after you encounter an error on the create new resource page is that the button gets permanently disabled, due to setting the `submitting` state to true. Once the button is disabled, it's no longer possible for it to actually create a submit event. I fixed this by resetting the `submitting` state if an error occurs.

The second issue is that it's not obvious from a UI perspective that the button is actually disabled. Not only does the button not change appearance, but the cursor is still the `pointer` cursor, which makes it look like you can actually click it. To fix this, I added a bit more CSS to both change the color of the button and set the cursor to the `not-working` icon.

@derekfidler, LMK if this styling looks all right to you, or if you have an existing style for a disabled button somewhere:
<img width="239" alt="screen shot 2018-08-05 at 4 01 57 pm" src="https://user-images.githubusercontent.com/1002748/43691000-685b33e4-98c9-11e8-95b2-a5402fd1b1fc.png">

Unfortunately, I was not able to add a Testcafe test to cover this because it appears that Testcafe is able to click disabled buttons, even though a normal human would not be able to.