### PR TITLE
visual styling bugfix

### DIFF
--- a/app/components/Search/SearchResultsContainer.jsx
+++ b/app/components/Search/SearchResultsContainer.jsx
@@ -13,11 +13,11 @@ const searchResultsContainer = connectStateResults(
     if (!searchResults && searching) {
       output = <Loader />;
     } else if (searchResults && searchResults.nbHits === 0) {
-      output = <div>No results have been found for {searchState.query}</div>;
+      output = <div className="no-results">No results have been found for {searchState.query}</div>;
     } else if (searchResults) {
       output = (
         <div className="results">
-          <div>
+          <div className="results-table">
             <SearchTable />
             <div className="add-resource">
               <h4>Can&apos;t find the organization you&apos;re looking for? </h4>

--- a/app/styles/components/_search-result-table.scss
+++ b/app/styles/components/_search-result-table.scss
@@ -1,6 +1,9 @@
 // Map styles
 .results-map {
   flex: 1 1 auto;
+  @include r_max($break-tablet-s) {
+    display: none;
+  }
 }
 
 .map-wrapper {
@@ -78,15 +81,15 @@
 
 .results-table {
   @extend %flex-column;
-  max-width: calc-em(650px);
-  width: 100%;
+  width: 50%;
   box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.4);
   position: relative;
   z-index: 2;
-  background: $color-white;
+  background: #F3F5F7;
   height: 100%;
   @include r_max($break-tablet-s) {
     order: 2;
+    width: 100%;
   }
 
   > header {
@@ -114,7 +117,6 @@
   flex: 1 1 auto;
   padding: 20px 30px 20px 30px;
   background-color: #F3F5F7;
-  max-width: calc-em(840px);
 }
 
 .results-table-entry {
@@ -316,4 +318,11 @@
   .service-entry-body {
     @include result-body;
   }
+}
+
+.no-results {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 60px;
 }


### PR DESCRIPTION
fixed a visual bug if the returned search results had a very short description resulting in the results section to take less than half the screen.

improved the padding of the "no search results" text so it doesn't look broken.