### PR TITLE
Fix service address on search results page

### DIFF
--- a/app/components/Search/ServiceEntry.jsx
+++ b/app/components/Search/ServiceEntry.jsx
@@ -56,7 +56,7 @@ class ServiceEntry extends Component {
             <div className="entry-subhead">
               <p className="entry-affiliated-resource">a service offered by <Link to={{ pathname: '/resource', query: { id: hit.resource_id } }}>{hit.service_of}</Link></p>
               <p>
-                { hit.address && hit.address.address_1 ? hit.address.address_1 : 'No address found' }
+                { hit.addresses && hit.addresses.address_1 ? hit.addresses.address_1 : 'No address found' }
                 { schedule ? ' • ' : null }
                 { schedule ? <RelativeOpeningTime schedule={schedule} /> : null }
               </p>


### PR DESCRIPTION
Currently, on the search results page, all services display "No address found". Turns out this is because we were trying to access the `.address` instead of `.addresses` property. The property itself is confusingly named because `.addresses` actually just points directly to a single Address instead of an array of addresses. Fixing this makes the page look right.