### PR TITLE
573 Restore TestCafe tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+env:
+  - ALGOLIA_INDEX_PREFIX=travisci
 before_install:
 - cp config.example.yml config.yml
 - export CHROME_BIN=chromium-browser

--- a/config.example.yml
+++ b/config.example.yml
@@ -2,7 +2,12 @@
 # Environment variables will override this config if they exist
 # You need to create a config.yml file with your own values to run locally
 
-GOOGLE_API_KEY: 'AIzaSyCZxTONKtTHyz3qp-x4tJlH4c6VUKn9sd4'
+# This key needs access to the following APIs:
+# - Maps JavaScript API
+# - Street View API
+# Note that the settings for this key are in Google Cloud Platform under the
+# AskDarcel Staging project
+GOOGLE_API_KEY: 'AIzaSyBeryKXoJ8TRlRCC4NLM5tBi0vZWB-Ft5c'
 
 ALGOLIA_INDEX_PREFIX: '<ENTER_YOUR_GITHUB_USERNAME_HERE>'
 ALGOLIA_APPLICATION_ID: 'J8TVT53HPZ'

--- a/testcafe/listings.js
+++ b/testcafe/listings.js
@@ -3,25 +3,25 @@ import SearchPage from './pages/SearchPage';
 
 const searchPage = new SearchPage();
 
+// Test_Category_Top_Level is part of the rake db:populate fixtures
 fixture `Listings Page`
-  .page `${config.baseUrl}/resources?categoryid=234`;
+  .page `${config.baseUrl}/search?refinementList[categories][0]=Test_Category_Top_Level`;
 
 test('Confirm listings page describes resources/services correctly', async t => {
-  const numResults = '1 Total Results';
-  const walkingDistance = ' walking';
-  const resourceName = 'A Test Resource';
+  const organizationName = 'A Test Resource';
+  const organizationDesc = 'I am a long description of a resource.';
   const serviceName = 'A Test Service';
-  const serviceDesc = 'I am a long description of a resource.';
-  const hoursRegEx = /\bOpen until .*M|Closed\b/;
+  const serviceDesc = 'I am a long description of a service.';
+  // const hoursRegEx = /\bOpen until .*M|Closed\b/;
   await t
-       .expect(searchPage.resultsCount.textContent)
-       .contains(numResults)
+       .expect(searchPage.searchRows.count)
+       .eql(2) // One for the resource, one for the service
 
-       .expect(searchPage.firstResultName.textContent)
-       .contains(resourceName)
+       .expect(searchPage.firstOrganizationName.textContent)
+       .contains(organizationName)
 
-       .expect(searchPage.firstResultAddress.textContent)
-       .contains(walkingDistance)
+       .expect(searchPage.firstOrganizationDesc.textContent)
+       .contains(organizationDesc)
 
        .expect(searchPage.firstServiceName.textContent)
        .contains(serviceName)
@@ -29,7 +29,8 @@ test('Confirm listings page describes resources/services correctly', async t => 
        .expect(searchPage.firstServiceDesc.textContent)
        .contains(serviceDesc)
 
-       .expect(searchPage.openHours.textContent)
-       .match(hoursRegEx)
+       // TODO: Uncomment once service hours are back
+       // .expect(searchPage.openHours.textContent)
+       // .match(hoursRegEx)
   ;
 });

--- a/testcafe/pages/EditPage.js
+++ b/testcafe/pages/EditPage.js
@@ -24,7 +24,7 @@ class EditPhone {
 
 export default class EditPage {
   constructor() {
-    const baseSelectorName = 'EditSections';
+    const baseSelectorName = 'OrganizationEditPage';
     const baseSelector = ReactSelector(baseSelectorName);
     this.name = baseSelector.find('#edit-name-input');
     this.address = new EditAddress();

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -3,7 +3,7 @@ import config from '../config';
 
 export default class ResourcePage {
   constructor() {
-    const baseSelectorName = 'Resource';
+    const baseSelectorName = 'OrganizationListingPage';
     const baseSelector = ReactSelector(baseSelectorName);
     this.resourceName = baseSelector.find('.org--main--header--title');
     this.description = baseSelector.find('.org--main--header--description');

--- a/testcafe/pages/SearchPage.js
+++ b/testcafe/pages/SearchPage.js
@@ -2,16 +2,18 @@ import { ReactSelector } from 'testcafe-react-selectors';
 
 export default class SearchPage {
   constructor() {
-    const baseSelector = ReactSelector('ResourcesTable');
-    this.resultsCount = baseSelector.find('.results-count');
-    this.resultEntry = baseSelector.findReact('ResourcesRow');
-    this.firstServiceName = baseSelector.find('.entry-organization');
-    this.firstServiceDesc = baseSelector.find('.entry-description');
-    this.firstResultName = baseSelector.find('.entry-headline');
-    this.firstResultAddress = baseSelector.find('.entry-distance');
+    const baseSelector = ReactSelector('SearchTable');
+    this.searchRows = baseSelector.findReact('SearchRow');
+
+    this.firstOrganization = baseSelector.findReact('ResourceEntry');
+    this.firstOrganizationName = this.firstOrganization.find('.entry-headline');
+    this.firstOrganizationDesc = this.firstOrganization.find('.entry-body');
+
+    this.firstService = baseSelector.findReact('ServiceEntry');
+    this.firstServiceName = this.firstService.find('.entry-headline');
+    this.firstServiceDesc = this.firstService.find('.service-entry-body');
+
     this.openHours = baseSelector.find('.entry-hours');
     this.pagination = ReactSelector('InstantSearch').find('.ais-Pagination');
-    this.serviceEntry = ReactSelector('Hits ServiceEntry');
-    this.resourceEntry = ReactSelector('Hits ResourceEntry');
   }
 }

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -47,3 +47,11 @@ sleep 60
 
 # Print out container logs in case if an error occurs
 docker logs api
+
+npm run testcafe -- 'saucelabs:Chrome@beta:Windows 10' \
+  --quarantine-mode \
+  --skip-js-errors \
+  --assertion-timeout 50000 \
+  --page-load-timeout 15000 \
+  --selector-timeout 15000 \
+  testcafe/*.js

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -32,6 +32,9 @@ docker run -d \
   -e DATABASE_URL=postgres://postgres@db/askdarcel_development \
   -e TEST_DATABASE_URL=postgres://postgres@db/askdarcel_test \
   -e SECRET_KEY_BASE=notasecret \
+  -e ALGOLIA_APPLICATION_ID=$ALGOLIA_APPLICATION_ID \
+  -e ALGOLIA_API_KEY=$ALGOLIA_API_KEY \
+  -e ALGOLIA_INDEX_PREFIX=$ALGOLIA_INDEX_PREFIX \
   -e RAILS_ENV=development \
   --network=askdarcel \
   --name=api \


### PR DESCRIPTION
This PR is basically two main changes:

1. Adding a new Google API for use in development/staging which can access the Google Maps APIs
2. Fixing the TestCafe tests that have been broken while we weren't running them, since the structure of the pages has changed.

Note: I did make one major change to our Travis CI settings (from the web UI, not .travis.yml), which was to remove the `ALGOLIA_INDEX_PREFIX`, which was previously set to `production`. I needed to make this change in order to ensure that the web and api instances that run in Travis are actually using the same Algolia index, which is now required because we got rid of some of the legacy endpoints that allowed us to bypass Algolia search.

This shouldn't be necessary anymore because the web Docker images can now read that value from the environment instead of baking it in, but we should be careful next time we deploy to make sure that we're reading from the correct Algolia index.