### PR TITLE
Update comment for Google API Key with expanded list of APIs required.

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -3,10 +3,12 @@
 # You need to create a config.yml file with your own values to run locally
 
 # This key needs access to the following APIs:
+# - Geolocation API
 # - Maps JavaScript API
 # - Street View API
 # Note that the settings for this key are in Google Cloud Platform under the
-# AskDarcel Staging project
+# AskDarcel Staging project > APIs & Services > Credentials > API Keys >
+# "Google Maps API Key"
 GOOGLE_API_KEY: 'AIzaSyBeryKXoJ8TRlRCC4NLM5tBi0vZWB-Ft5c'
 
 ALGOLIA_INDEX_PREFIX: '<ENTER_YOUR_GITHUB_USERNAME_HERE>'


### PR DESCRIPTION
This PR doesn't do anything but update a comment. However, it documents what I discovered in order to fix the failing TestCafe tests. We need to ensure that the Google API key has permissions to the Geolocation API. I already fixed this on the key listed in config.example.yml, so I think TestCafe should pass on Travis now.