### PR TITLE
Fix landing page on mobile.

### DIFF
--- a/app/components/ui/BasicNeedsBlockConfig.js
+++ b/app/components/ui/BasicNeedsBlockConfig.js
@@ -2,9 +2,9 @@ const BasicNeedsBlockConfig = {
   TITLE: {
     BEFORE_BLUE_WORD: 'Discover',
     BLUE_WORD: 'Basic Needs & Shelter',
-    AFTER_BLUE_WORD: 'Resources',
+    AFTER_BLUE_WORD: 'resources',
   },
-  FIRST_ROW: [
+  CARDS: [
     {
       title: 'Apply for the shelter system',
       content: 'Get a 24-hour, weekend, or a 90 day bed in San Francisco',
@@ -27,8 +27,6 @@ const BasicNeedsBlockConfig = {
       query: 'storage',
       imgClass: 'basic-block-lockers',
     },
-  ],
-  SECOND_ROW: [
     {
       title: 'Public toilets and showers',
       content: 'Toilets, showers, sharps disposal, and pet waste collection',

--- a/app/components/ui/LandingPageResourceBlock.jsx
+++ b/app/components/ui/LandingPageResourceBlock.jsx
@@ -10,35 +10,23 @@ class LandingPageResourceBlock extends Component {
         <div className="landing-page-resource-block__resources">
           {this.props.children}
           <div className="landing-page-resource-block__resources-title">
-            <h1>{this.props.config.TITLE.BEFORE_BLUE_WORD}</h1>
-            <h1 className="blue-word">{this.props.config.TITLE.BLUE_WORD}</h1>
-            <h1>{this.props.config.TITLE.AFTER_BLUE_WORD}</h1>
+            <h1>
+              {this.props.config.TITLE.BEFORE_BLUE_WORD}
+              <span className="blue-word"> {this.props.config.TITLE.BLUE_WORD} </span>
+              {this.props.config.TITLE.AFTER_BLUE_WORD}
+            </h1>
           </div>
           <div className="landing-page-resource-block__cards">
-            <div className="landing-page-resource-block__cards-first-row">
-              { this.props.config.FIRST_ROW.map(category => (
-                <LandingPageCard
-                  title={category.title}
-                  content={category.content}
-                  query={category.query ? HOST_QUERY + category.query : null}
-                  imgClass={category.imgClass}
-                  key={category.query || category.resource}
-                  resource={category.resource}
-                />
-              ))}
-            </div>
-            <div className="landing-page-resource-block__cards-second-row">
-              { this.props.config.SECOND_ROW.map(category => (
-                <LandingPageCard
-                  title={category.title}
-                  content={category.content}
-                  query={category.query ? HOST_QUERY + category.query : null}
-                  imgClass={category.imgClass}
-                  key={category.query || category.resource}
-                  resource={category.resource}
-                />
-              ))}
-            </div>
+            { this.props.config.CARDS.map(category => (
+              <LandingPageCard
+                title={category.title}
+                content={category.content}
+                query={category.query ? HOST_QUERY + category.query : null}
+                imgClass={category.imgClass}
+                key={category.query || category.resource}
+                resource={category.resource}
+              />
+            ))}
           </div>
         </div>
       </div>

--- a/app/components/ui/LegalBlockConfig.js
+++ b/app/components/ui/LegalBlockConfig.js
@@ -2,9 +2,9 @@ const LegalBlockConfig = {
   TITLE: {
     BEFORE_BLUE_WORD: 'Discover',
     BLUE_WORD: 'Legal',
-    AFTER_BLUE_WORD: 'Resources',
+    AFTER_BLUE_WORD: 'resources',
   },
-  FIRST_ROW: [
+  CARDS: [
     {
       title: 'Housing',
       content: 'Eviction defense, housing help, homeownership',
@@ -23,8 +23,6 @@ const LegalBlockConfig = {
       query: 'Family+Law',
       imgClass: 'legal-block-family',
     },
-  ],
-  SECOND_ROW: [
     {
       title: 'Criminal & Tickets',
       content: 'Criminal process questions, quality of life, record expungement',

--- a/app/styles/components/_landing-page-card.scss
+++ b/app/styles/components/_landing-page-card.scss
@@ -1,29 +1,42 @@
-$card-width: 305px;
-
 .landing-page-card {
   margin: 5px;
-  height: 305px;
+  height: 310px;
   background-color: white;
   display: flex;
+  flex: 0 0 305px;
   flex-direction: column;
   justify-content: space-around;
   z-index: 1;
+
+  @include r_max($break-tablet-p) {
+    flex-basis: 250px;
+    height: 267px;
+  }
 }
 
 .landing-page-card__title {
   font-size: 18px;
   color: #000;
-  padding-left: 5%;
-  padding-top: 3%;
+  padding: 20px;
+  flex: 0 0 65px;
+
+  @include r_max($break-tablet-p) {
+    font-size: 16px;
+    text-align: center;
+  }
 }
 
 .langing-page-card__image {
   background-repeat: no-repeat;
-  height: 50%;
-  width: 305px;
+  max-width: 100%;
+  flex: 0 0 150px;
+
+  @include r_max($break-tablet-p) {
+    flex-basis: 100px;
+  }
 }
 
 .landing-page-card__content {
-  padding-bottom: 5%;
-  padding-left: 5%;
+  flex: 0 0 95px;
+  padding: 15px 20px;
 }

--- a/app/styles/components/_landing-page-resource-block.scss
+++ b/app/styles/components/_landing-page-resource-block.scss
@@ -9,9 +9,9 @@
   padding-top: 50px;
   padding-bottom: 50px;
   position: relative;
-  width: 945px;
-  @include r_max($break-tablet-l) {
-    padding: 50px 0;
+  max-width: 945px;
+  @include r_max($break-tablet-p) {
+    padding: 50px 20px;
   }
 }
 
@@ -31,8 +31,8 @@
 .landing-page-resource-block__cards {
   display: flex;
   flex-wrap: wrap;
-}
-
-.landing-page-resource-block__cards-first-row, .landing-page-resource-block__cards-second-row {
-  display: flex;
+  @include r_max($break-tablet-p) {
+    flex-wrap: nowrap;
+    overflow-x: scroll;
+  }
 }


### PR DESCRIPTION
I noticed that the landing page wasn't displaying correctly on mobile since the widths of the "Discover X resources" sections were hardcoded and too large for mobile. I messed around with the HTML and the CSS to make it look good on both desktop and mobile.

Note that previously we had explicitly split the cards into two separate FIRST_ROW and SECOND_ROW arrays. I joined them into a single one and used flexbox to make them display in two rows on desktop and a single row that can scroll to the right on mobile, per the Figma mockups.


### Before

<img width="503" alt="screen shot 2019-02-10 at 2 19 00 pm" src="https://user-images.githubusercontent.com/1002748/52540525-33fe3c80-2d3f-11e9-9315-05af8b91b4ea.png">

(Note the gray area at the top that ends halfway horizontally is the true width of the page. Everything in white is past the screen on mobile.)

### After

<img width="607" alt="screen shot 2019-02-10 at 2 19 13 pm" src="https://user-images.githubusercontent.com/1002748/52540526-395b8700-2d3f-11e9-9a03-19140030568c.png">

