### PR TITLE
Change hardcoded URL base for landing page resources to a relative URL.

### DIFF
--- a/app/components/ui/LandingPageResourceBlock.jsx
+++ b/app/components/ui/LandingPageResourceBlock.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const HOST_QUERY = 'https://askdarcel.org/search?query=';
+const HOST_QUERY = '/search?query=';
 
 class LandingPageResourceBlock extends Component {
   render() {


### PR DESCRIPTION
This makes the links work properly locally.