### PR TITLE
Escape query parameter before using in URL.

### DIFF
--- a/app/components/layout/CategoryItem.jsx
+++ b/app/components/layout/CategoryItem.jsx
@@ -4,9 +4,10 @@ import { images } from '../../assets';
 
 class CategoryItem extends React.Component {
   render() {
+    const url = `/search?refinementList[categories][0]=${encodeURIComponent(this.props.name)}`;
     return (
       <li className="category-item">
-        <Link className="category-button" to={`/search?refinementList[categories][0]=${this.props.name}`} >
+        <Link className="category-button" to={url} >
           <div className="category-button-content">
             <div className="category-button-icon">
               <img


### PR DESCRIPTION
This fixes the bug where we weren't escaping the category name, and where having an & in the category name would mess up the search URL. Tested locally to make sure that clicking on a category with an ampersand in the name yields a page with actual search results.