### PR TITLE
[648] Fixed service opening / closing days appearing in random order

### DIFF
--- a/app/components/listing/TableOfOpeningTimes.jsx
+++ b/app/components/listing/TableOfOpeningTimes.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { RelativeOpeningTime } from './RelativeOpeningTime';
+import { sortScheduleDays } from '../../utils';
 
 export class TableOfOpeningTimes extends React.Component {
   static getScheduleTimestamp(sched) {
@@ -24,7 +25,7 @@ export class TableOfOpeningTimes extends React.Component {
     return (
       <table className="compact">
         <tbody>
-          { schedule.schedule_days.map(sched => {
+          { sortScheduleDays(schedule.schedule_days).map(sched => {
             const { opens_at, closes_at } = TableOfOpeningTimes.getScheduleTimestamp(sched);
             return (
               <tr key={sched.id}>


### PR DESCRIPTION
Sorted table of opening times with a utils function.
Perhaps we could sort the data itself instead of just in this view, but I didn't see a common Schedule object in which to do that.