### PR TITLE
Switched default search results tab from How to Apply to Description

### DIFF
--- a/app/components/search/SearchTabView.jsx
+++ b/app/components/search/SearchTabView.jsx
@@ -7,7 +7,7 @@ import { timeToString } from '../../utils/index';
 class SearchTabView extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { active: this.props.applicationProcess ? 'How to Apply' : 'Description' };
+    this.state = { active: 'Description' };
     // this.getSchedule = this.getSchedule.bind(this);
   }
 
@@ -37,8 +37,8 @@ class SearchTabView extends React.Component {
   getTabList() {
     const { applicationProcess, description, schedule } = this.props;
     const tabs = [];
-    if (applicationProcess) { tabs.push({ title: 'How to Apply', content: <p>{applicationProcess}</p> }); }
     tabs.push({ title: 'Description', content: <ReactMarkdown className="rendered-markdown" source={description} /> });
+    if (applicationProcess) { tabs.push({ title: 'How to Apply', content: <p>{applicationProcess}</p> }); }
     // tabs.push({ title: 'Hours', content: this.getSchedule(schedule) });
     return tabs;
   }

--- a/app/components/search/ServiceEntry.jsx
+++ b/app/components/search/ServiceEntry.jsx
@@ -47,7 +47,7 @@ class ServiceEntry extends Component {
             <h4 className="entry-headline"><Link to={{ pathname: `/services/${hit.service_id}` }}>{`${index + 1}.) ${hit.name}`}</Link></h4>
             <div className="entry-subhead">
               <p className="entry-affiliated-resource">
-a service offered by
+a service offered by&nbsp;
                 <Link to={{ pathname: '/resource', query: { id: hit.resource_id } }}>{hit.service_of}</Link>
               </p>
               <p>


### PR DESCRIPTION
Fixed the confusing search result item tab order from defaulting to "How to Apply" to defaulting to "Description"

Before:
![Screen Shot 2019-03-19 at 11 41 36](https://user-images.githubusercontent.com/2722783/54600002-19a13800-4a3c-11e9-8118-7f8aac5f9971.png)

After:
![Screen Shot 2019-03-19 at 11 42 50](https://user-images.githubusercontent.com/2722783/54600018-23c33680-4a3c-11e9-9545-f27503f2fb96.png)
