### PR TITLE
[658] Added hyperlink from Service header in Resource page to Service page.

### DIFF
--- a/app/components/listing/Services.jsx
+++ b/app/components/listing/Services.jsx
@@ -50,7 +50,11 @@ updated
             {service.updated_date}
           </p>
         </div>
-        <h2 className="service--header">{service.name}</h2>
+        <h2 className="service--header">
+          <a href={`/services/${service.id}`}>
+            {service.name}
+          </a>
+        </h2>
         <ReactMarkdown className="rendered-markdown service--description" source={service.long_description} />
         <div
           className="service--details-toggle"

--- a/app/styles/components/_org-page.scss
+++ b/app/styles/components/_org-page.scss
@@ -157,7 +157,12 @@
 	&--header {
 		@extend %font-size-large;
 		font-weight: 600;
-		color: #333333;
+		a {
+			color: #333333;
+			&:hover {
+				color: #1C72E6;
+			}
+		}
 	}
 	&--description {
 		margin-top: calc-em(15px);


### PR DESCRIPTION
Added a simple link around the header text. This follows the same styling as the links in services nav section that links to the header elements. Let me know if you'd like an alternate style.
![2019-03-20 08 11 03](https://user-images.githubusercontent.com/834403/54695821-e7e5ab00-4ae7-11e9-84c8-3a4be6e9c8ab.gif)
