### PR TITLE
Use fixed version of Chrome.

### DIFF
--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -51,7 +51,7 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- 'saucelabs:chrome@latest:Windows 10' \
+npm run testcafe -- 'saucelabs:Chrome@latest:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -51,7 +51,13 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- 'saucelabs:Chrome@latest-1:Windows 10' \
+# Note: The version number needs to be periodically updated as new versions come
+# out.
+# TODO: SauceLabs does seem to allow for the version string "latest" to be an
+# alias for the latest stable release, but it appears that the TestCafe
+# plugin doesn't seem to support it. See
+# https://github.com/DevExpress/testcafe-browser-provider-saucelabs/issues/42
+npm run testcafe -- 'saucelabs:Chrome@73.0:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -51,7 +51,7 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- 'saucelabs:Chrome@latest:Windows 10' \
+npm run testcafe -- 'saucelabs:Chrome@73.0:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -51,7 +51,7 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- 'saucelabs:Chrome@latest:Windows 10' \
+npm run testcafe -- 'saucelabs:chrome@latest:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -51,7 +51,7 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- 'saucelabs:Chrome@beta:Windows 10' \
+npm run testcafe -- 'saucelabs:Chrome@latest:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \

--- a/travis-testcafe.sh
+++ b/travis-testcafe.sh
@@ -51,7 +51,7 @@ sleep 60
 # Print out container logs in case if an error occurs
 docker logs api
 
-npm run testcafe -- 'saucelabs:Chrome@73.0:Windows 10' \
+npm run testcafe -- 'saucelabs:Chrome@latest-1:Windows 10' \
   --quarantine-mode \
   --skip-js-errors \
   --assertion-timeout 50000 \


### PR DESCRIPTION
I think the SauceLabs/Travis tests are failing because SauceLabs slightly changed their API. Previously we were telling SauceLabs to use the `beta` version of Chrome, which would allow us to always be running on a new version of Chrome. At the time the only alternative was to run on a fixed version of Chrome.

It seems that since then, you are now able to specify `latest`, `latest-1`, or `latest-2` for the latest, second to latest, or third to latest versions of Chrome, so now I've updated our TravisCI script to run on the latest version: https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options