### PR TITLE
#637 - Add ability for service to inherit schedule from parent resource

### DIFF
--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -192,6 +192,7 @@ Service
           </li>
 
           <EditSchedule
+            canInheritFromParent
             schedule={this.props.service.schedule}
             handleScheduleChange={this.handleScheduleChange}
           />

--- a/app/pages/OrganizationEditPage.scss
+++ b/app/pages/OrganizationEditPage.scss
@@ -134,6 +134,12 @@
 
 		&--sublist .edit--section--list--item {
 			margin-right: 0;
+      .inherit-schedule {
+        display: flex;
+        input {
+          width: auto;
+        }
+      }
 		}
 	}
 }


### PR DESCRIPTION
When editing a service, there will now be an option to have the service inherit its schedule from its parent:

<img width="1544" alt="Screen Shot 2019-04-13 at 9 42 06 AM" src="https://user-images.githubusercontent.com/7386336/56082720-e77fbd80-5dd0-11e9-8a07-5d52ae968a13.png">

When selected, the edit hours table will be hidden:
<img width="1544" alt="Screen Shot 2019-04-13 at 9 42 13 AM" src="https://user-images.githubusercontent.com/7386336/56082719-e77fbd80-5dd0-11e9-9adc-ca0c03c6ce7e.png">


Note that resources (top level) won't have this option.

<img width="1544" alt="Screen Shot 2019-04-13 at 9 42 19 AM" src="https://user-images.githubusercontent.com/7386336/56082726-f8303380-5dd0-11e9-99ab-081c51a440c3.png">
