### PR TITLE
Hoist state out of FormTextArea

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,9 +8,7 @@ app/components/edit/EditCollection.jsx
 app/components/edit/EditNotes.jsx
 app/components/edit/EditPhones.jsx
 app/components/edit/EditSidebar.jsx
-app/components/edit/FormTextArea.jsx
 app/components/edit/MultiSelectDropdown.jsx
-app/components/edit/ProvidedService.jsx
 app/components/layout/CategoryItem.jsx
 app/components/layout/CategoryList.jsx
 app/components/layout/FindHeader.jsx

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,6 @@ app/components/edit/EditAddress.jsx
 app/components/edit/EditCollection.jsx
 app/components/edit/EditNotes.jsx
 app/components/edit/EditPhones.jsx
-app/components/edit/EditServices.jsx
 app/components/edit/EditSidebar.jsx
 app/components/edit/FormTextArea.jsx
 app/components/edit/MultiSelectDropdown.jsx

--- a/app/components/edit/EditServices.jsx
+++ b/app/components/edit/EditServices.jsx
@@ -32,12 +32,13 @@ class EditServices extends Component {
    * @returns {void}
    */
   handleServiceChange(key, service) {
+    const { handleServiceChange } = this.props;
     const { services } = this.state;
     services[key] = service;
     this.setState({
       services,
     }, () => {
-      this.props.handleServiceChange(this.state);
+      handleServiceChange(this.state);
     });
   }
 
@@ -45,8 +46,8 @@ class EditServices extends Component {
    * @description Creates a brand new service
    */
   addService() {
-    const { existingServices } = this.state;
-    const newUUID = this.state.uuid - 1;
+    const { existingServices, uuid } = this.state;
+    const newUUID = uuid - 1;
 
     existingServices.push({
       id: newUUID,
@@ -63,22 +64,25 @@ class EditServices extends Component {
   }
 
   render() {
+    const { handleDeactivation } = this.props;
+    const { existingServices } = this.state;
     return (
       <li className="edit--section--list--item">
         <ul className="edit--section--list--item--sublist edit--service--list">
           {
-            this.state.existingServices.map((service, index) => (
+            existingServices.map((service, index) => (
               <ProvidedService
                 key={service.key}
                 index={index}
                 service={service}
                 handleChange={this.handleServiceChange}
-                handleDeactivation={this.props.handleDeactivation}
+                handleDeactivation={handleDeactivation}
               />
             ))
           }
         </ul>
         <button
+          type="button"
           className="edit--section--list--item--button new-service"
           id="new-service-button"
           onClick={this.addService}

--- a/app/components/edit/FormTextArea.jsx
+++ b/app/components/edit/FormTextArea.jsx
@@ -1,29 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const FormTextArea = props => {
-  const {
-    label, placeholder, field, defaultValue, onChange,
-  } = props;
-  return (
-    <li className="edit--section--list--item">
-      <label htmlFor="textarea">{label}</label>
-      <textarea
-        placeholder={placeholder}
-        data-field={field}
-        defaultValue={defaultValue}
-        onChange={onChange}
-      />
-    </li>
-  );
-};
+const FormTextArea = ({
+  label, placeholder, field, value, onChange,
+}) => (
+  <li className="edit--section--list--item">
+    <label htmlFor="textarea">{label}</label>
+    <textarea
+      placeholder={placeholder}
+      data-field={field}
+      value={value}
+      onChange={onChange}
+    />
+  </li>
+);
 
 FormTextArea.propTypes = {
   label: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
   field: PropTypes.string.isRequired,
-  defaultValue: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default FormTextArea;

--- a/app/components/edit/FormTextArea.jsx
+++ b/app/components/edit/FormTextArea.jsx
@@ -2,15 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const FormTextArea = ({
-  label, placeholder, field, value, onChange,
+  label, placeholder, value, setValue,
 }) => (
   <li className="edit--section--list--item">
     <label htmlFor="textarea">{label}</label>
     <textarea
       placeholder={placeholder}
-      data-field={field}
       value={value}
-      onChange={onChange}
+      onChange={evt => setValue(evt.target.value)}
     />
   </li>
 );
@@ -18,9 +17,8 @@ const FormTextArea = ({
 FormTextArea.propTypes = {
   label: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
-  field: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
+  setValue: PropTypes.func.isRequired, // A function to call when setting a new value
 };
 
 export default FormTextArea;

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -13,26 +13,28 @@ class ProvidedService extends Component {
       service: {},
     };
 
+    const { service } = this.props;
+
     this.textAreas = [
       {
         label: 'Service Description',
         placeholder: "Describe what you'll receive from this service in a few sentences.",
         field: 'long_description',
-        defaultValue: this.props.service.long_description,
+        defaultValue: service.long_description,
         onChange: this.handleFieldChange.bind(this),
       },
       {
         label: 'Application Process',
         placeholder: 'How do you apply for this service?',
         field: 'application_process',
-        defaultValue: this.props.service.application_process,
+        defaultValue: service.application_process,
         onChange: this.handleFieldChange.bind(this),
       },
       {
         label: 'Required Documents',
         placeholder: 'What documents do you need to bring to apply?',
         field: 'required_documents',
-        defaultValue: this.props.service.required_documents,
+        defaultValue: service.required_documents,
         onChange: this.handleFieldChange.bind(this),
       },
       {
@@ -41,7 +43,7 @@ class ProvidedService extends Component {
         label: 'Interpretation Services',
         placeholder: 'What interpretation services do they offer?',
         field: 'interpretation_services',
-        defaultValue: this.props.service.interpretation_services,
+        defaultValue: service.interpretation_services,
         onChange: this.handleFieldChange.bind(this),
       },
     ];
@@ -55,7 +57,8 @@ class ProvidedService extends Component {
 
   handleChange(service) {
     this.setState({ service }, () => {
-      this.props.handleChange(this.props.service.key, service);
+      const { service: { key }, handleChange } = this.props;
+      handleChange(key, service);
     });
   }
 
@@ -90,20 +93,20 @@ class ProvidedService extends Component {
   }
 
   render() {
+    const { handleDeactivation, index, service } = this.props;
+    const { submitting } = this.state;
     return (
-      <li id={`${this.props.service.id}`} className="edit--service edit--section">
+      <li id={`${service.id}`} className="edit--service edit--section">
         <header className="edit--section--header">
           <h4>
-Service
-            {this.props.index + 1}
-:
-            {this.props.service.name}
+            {`Service ${index + 1}: ${service.name}`}
           </h4>
           <button
             className="remove-item"
+            type="button"
             id="service--deactivation"
-            disabled={this.state.submitting}
-            onClick={() => this.props.handleDeactivation('service', this.props.service.id)}
+            disabled={submitting}
+            onClick={() => handleDeactivation('service', service.id)}
           >
             Remove Service
           </button>
@@ -116,7 +119,7 @@ Service
               type="text"
               placeholder="What is this service called?"
               data-field="name"
-              defaultValue={this.props.service.name}
+              defaultValue={service.name}
               onChange={this.handleFieldChange}
             />
           </li>
@@ -127,7 +130,7 @@ Service
               type="text"
               placeholder="What it's known as in the community"
               data-field="alternate_name"
-              defaultValue={this.props.service.alternate_name}
+              defaultValue={service.alternate_name}
               onChange={this.handleFieldChange}
             />
           </li>
@@ -136,7 +139,7 @@ Service
             <label htmlFor="email">Service E-Mail</label>
             <input
               type="email"
-              defaultValue={this.props.service.email}
+              defaultValue={service.email}
               data-field="email"
               onChange={this.handleFieldChange}
             />
@@ -154,7 +157,7 @@ Service
 
           <li className="edit--section--list--item">
             <MultiSelectDropdown
-              selectedItems={this.props.service.eligibilities}
+              selectedItems={service.eligibilities}
               handleSelectChange={this.handleEligibilityChange}
               label="Eligibility"
               optionsRoute="eligibilities"
@@ -166,7 +169,7 @@ Service
             <input
               placeholder="How much does this service cost?"
               data-field="fee"
-              defaultValue={this.props.service.fee}
+              defaultValue={service.fee}
               onChange={this.handleFieldChange}
             />
           </li>
@@ -176,7 +179,7 @@ Service
             <input
               placeholder="Is there a waiting list or wait time?"
               data-field="wait_time"
-              defaultValue={this.props.service.wait_time}
+              defaultValue={service.wait_time}
               onChange={this.handleFieldChange}
             />
           </li>
@@ -186,21 +189,21 @@ Service
             <input
               placeholder="http://"
               data-field="url"
-              defaultValue={this.props.service.url}
+              defaultValue={service.url}
               onChange={this.handleFieldChange}
             />
           </li>
 
           <EditSchedule
             canInheritFromParent
-            schedule={this.props.service.schedule}
+            schedule={service.schedule}
             handleScheduleChange={this.handleScheduleChange}
           />
 
-          <EditNotes notes={this.props.service.notes} handleNotesChange={this.handleNotesChange} />
+          <EditNotes notes={service.notes} handleNotesChange={this.handleNotesChange} />
 
           <MultiSelectDropdown
-            selectedItems={this.props.service.categories}
+            selectedItems={service.categories}
             handleSelectChange={this.handleCategoryChange}
             label="Categories"
             optionsRoute="categories"

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -29,21 +29,18 @@ class ProvidedService extends Component {
         placeholder: "Describe what you'll receive from this service in a few sentences.",
         field: 'long_description',
         defaultValue: service.long_description,
-        onChange: this.handleFieldChange.bind(this),
       },
       {
         label: 'Application Process',
         placeholder: 'How do you apply for this service?',
         field: 'application_process',
         defaultValue: service.application_process,
-        onChange: this.handleFieldChange.bind(this),
       },
       {
         label: 'Required Documents',
         placeholder: 'What documents do you need to bring to apply?',
         field: 'required_documents',
         defaultValue: service.required_documents,
-        onChange: this.handleFieldChange.bind(this),
       },
       {
         // TODO: Make this a multiselectdropdown, create a new table in the DB for languages,
@@ -52,7 +49,6 @@ class ProvidedService extends Component {
         placeholder: 'What interpretation services do they offer?',
         field: 'interpretation_services',
         defaultValue: service.interpretation_services,
-        onChange: this.handleFieldChange.bind(this),
       },
     ];
 
@@ -61,6 +57,14 @@ class ProvidedService extends Component {
     this.handleScheduleChange = this.handleScheduleChange.bind(this);
     this.handleCategoryChange = this.handleCategoryChange.bind(this);
     this.handleEligibilityChange = this.handleEligibilityChange.bind(this);
+  }
+
+  // This is meant to gradually replace handleFieldChange in a way that does not
+  // depend on the caller necessarily being a DOM event.
+  handleServiceFieldChange = (field, value) => {
+    const { service } = this.state;
+    service[field] = value;
+    this.handleChange(service);
   }
 
   handleChange(service) {
@@ -157,9 +161,8 @@ class ProvidedService extends Component {
             <FormTextArea
               label={textArea.label}
               placeholder={textArea.placeholder}
-              field={textArea.field}
               value={stateService[textArea.field] || textArea.defaultValue || ''}
-              onChange={textArea.onChange}
+              setValue={value => this.handleServiceFieldChange(textArea.field, value)}
             />
           ))}
 

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -9,6 +9,14 @@ class ProvidedService extends Component {
   constructor(props) {
     super(props);
 
+    // Notice
+    // It's really unclear when to use the version of the service in the state
+    // vs. when to use the version in the props.
+    // Currently, it looks like the one in state only keeps track of changes
+    // that have been made to the service, and a missing key implies that there
+    // is no change to that field. A longer-term refactoring should involve
+    // keeping track of the deltas in one location rather than having the logic
+    // distributed throughout the whole application.
     this.state = {
       service: {},
     };
@@ -94,7 +102,7 @@ class ProvidedService extends Component {
 
   render() {
     const { handleDeactivation, index, service } = this.props;
-    const { submitting } = this.state;
+    const { service: stateService, submitting } = this.state;
     return (
       <li id={`${service.id}`} className="edit--service edit--section">
         <header className="edit--section--header">
@@ -150,7 +158,7 @@ class ProvidedService extends Component {
               label={textArea.label}
               placeholder={textArea.placeholder}
               field={textArea.field}
-              defaultValue={textArea.defaultValue}
+              value={stateService[textArea.field] || textArea.defaultValue || ''}
               onChange={textArea.onChange}
             />
           ))}


### PR DESCRIPTION
## Overview
As I continue with refactoring the frontend app in order to fix the schedule handling code, I've been trying to hoist state up the component hierarchy. I think a pretty big problem that we have with our current code is that there is React Component state that is duplicate at several different layers, and state changes have to be propagated upwards and applied at every layer.

## Main Change
This PR represents one step of the refactoring, where I've hoisted state out of the `<FormTextArea>` component. In this component the state is less obvious, but because we're using a normal HTML form element, there is actually implicit state on the `<textarea>` element. React does give you the ability to let a parent component manage the state of a form element, which is what they call a [controlled component](https://reactjs.org/docs/forms.html#controlled-components). This is done by simply passing in the `value` prop into the form element and having the `onChange` prop be in charge of updating the state from higher up.

## Cleaner Architecture
A second thing I am trying out is having a cleaner API for interacting between the different layers of the React components. We already have a pattern of passing around `handleChange` or `onChange` functions between components, but they are often coupled to the implementation details of the lower components.

For example, in this PR, `<ProvidedService>` is a parent of `<FormTextArea>`. `<ProvidedService>` previously had a `handleFieldChange()` method that looked like this:

```jsx
  handleFieldChange(e) {
    const { service } = this.state;
    service[e.target.dataset.field] = e.target.value;
    this.handleChange(service);
  }
```

This `handleFieldChange` would get passed to `<FormTextArea>` or other child components, and it was expected to be attached directly to the `onChange` prop of a form input element.

This is a fragile API because it's tightly coupled to a few things at the lower levels:

- It assumes that there is a single argument which is the DOM event (which is expected to have a `.target` attribute)
- It assumes that the form input element is the DOM event target
- It assumes that the form input element has a [`data-field` attribute](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) on it that holds the name of the key on the `service` state/prop corresponding to the field being updated. This is what that `.dataset.field` thing is.

I'm proposing a new convention which is modeled after the new [React Hooks](https://reactjs.org/docs/hooks-overview.html) API, even though it does not use React Hooks today. The idea is that you pass a function as a prop to the lower component which only takes in the new value of the state and does not have to do any "unpacking" of the event object. This is modeled after the `const [count, setCount] = useState()` API of React Hooks, where the `value` and `setValue()` always come in pairs. This is only slightly different than what we had before with the `handleFieldChange()` function described above, in that the arguments are a bit different, but I think it has major benefits:

Because the arguments are only the new field value, the lower component doesn't _have_ to use DOM event, and the DOM event is handled in the lower component so that the upper component doesn't have to deal with it. This offers a cleaner separation of responsibilities where the upper component doesn't even need to be aware of the DOM at all.

Most importantly, I think this nests much better than our previous approach, and this is probably how the React team came to this design. As I hoist more and more state to the top of the component hierarchy, we can just repeat this pattern where each layer doesn't need to know how the lower layer will implement the code, but provides the most minimal API for getting and setting state.