### PR TITLE
replaced about About Us link in header with Help

### DIFF
--- a/app/components/ui/Navigation.jsx
+++ b/app/components/ui/Navigation.jsx
@@ -72,8 +72,8 @@ class Navigation extends React.Component {
           </div>
           <ul className={styles.navRight}>
             <li>
-              <a href="https://www.sheltertech.org" target="_blank" rel="noopener noreferrer">
-                About Us
+              <a href="http://help.sfserviceguide.org/" target="_blank" rel="noopener noreferrer">
+                Help
               </a>
             </li>
             <li>


### PR DESCRIPTION
- Navigation.jsx : 'About Us' replaced with 'Help', existing link replaced with http://help.sfserviceguide.org/