### PR TITLE
Componentize resource listing actions bar

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,7 +16,6 @@ app/components/layout/CategoryItem.jsx
 app/components/layout/CategoryList.jsx
 app/components/layout/FindHeader.jsx
 app/components/layout/OrganizationCard.jsx
-app/components/listing/ActionSidebar.jsx
 app/components/listing/Notes.jsx
 app/components/listing/ResourceInfos.jsx
 app/components/listing/ResourceMap.jsx

--- a/app/components/listing/ActionSidebar.jsx
+++ b/app/components/listing/ActionSidebar.jsx
@@ -2,32 +2,46 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Link } from 'react-router';
+import { getResourceActions } from 'utils/ResourceActions';
+
+const getSidebarActions = resource => {
+  const resourceActions = getResourceActions(resource);
+  const sidebarActions = [
+    resourceActions.edit,
+    resourceActions.print,
+  ];
+  if (resource.address) {
+    sidebarActions.push(resourceActions.directions);
+  }
+  return sidebarActions;
+};
+
+const renderButtonContent = action => (
+  <span>
+    <i className="material-icons">{ action.icon }</i>
+    { action.name }
+  </span>
+);
 
 class ListPageSidebar extends React.Component {
-  renderButtonContent(action) {
-    return (
-      <span>
-        <i className="material-icons">{ action.icon }</i>
-        { action.name }
-      </span>
-    );
-  }
-
   render() {
+    const { resource } = this.props;
+    const actions = getSidebarActions(resource);
+
     return (
       <ul className="actions">
-        {this.props.actions.map(action => (
+        {actions.map(action => (
           <li key={action.name}>
             {
               action.to || action.handler
                 ? (
                   <Link to={action.to} onClick={action.handler} className={`listing--aside--${action.name.toLowerCase()}`}>
-                    { this.renderButtonContent(action) }
+                    { renderButtonContent(action) }
                   </Link>
                 )
                 : (
-                  <a href={action.link} target="_blank" className={`listing--aside--${action.name.toLowerCase()}`}>
-                    { this.renderButtonContent(action) }
+                  <a href={action.link} rel="noopener noreferrer" target="_blank" className={`listing--aside--${action.name.toLowerCase()}`}>
+                    { renderButtonContent(action) }
                   </a>
                 )
             }
@@ -39,13 +53,7 @@ class ListPageSidebar extends React.Component {
 }
 
 ListPageSidebar.propTypes = {
-  actions: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    icon: PropTypes.string.isRequired,
-    link: PropTypes.string,
-    to: PropTypes.string,
-    handler: PropTypes.function,
-  })).isRequired,
+  resource: PropTypes.object.isRequired,
 };
 
 export default ListPageSidebar;

--- a/app/components/listing/ActionSidebar.jsx
+++ b/app/components/listing/ActionSidebar.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { getResourceActions } from 'utils/ResourceActions';
 
+import './ActionSidebar.scss';
+
 const getSidebarActions = resource => {
   const resourceActions = getResourceActions(resource);
   const sidebarActions = [
@@ -29,18 +31,18 @@ class ListPageSidebar extends React.Component {
     const actions = getSidebarActions(resource);
 
     return (
-      <ul className="actions">
+      <ul className="action-sidebar">
         {actions.map(action => (
           <li key={action.name}>
             {
               action.to || action.handler
                 ? (
-                  <Link to={action.to} onClick={action.handler} className={`listing--aside--${action.name.toLowerCase()}`}>
+                  <Link to={action.to} onClick={action.handler} className={`action-sidebar--${action.name.toLowerCase()}`}>
                     { renderButtonContent(action) }
                   </Link>
                 )
                 : (
-                  <a href={action.link} rel="noopener noreferrer" target="_blank" className={`listing--aside--${action.name.toLowerCase()}`}>
+                  <a href={action.link} rel="noopener noreferrer" target="_blank" className={`action-sidebar--${action.name.toLowerCase()}`}>
                     { renderButtonContent(action) }
                   </a>
                 )

--- a/app/components/listing/ActionSidebar.scss
+++ b/app/components/listing/ActionSidebar.scss
@@ -1,0 +1,31 @@
+@import '../../styles/utils/helpers';
+
+.action-sidebar {
+  margin: $padding-xlarge 0;
+
+  li {
+    text-align: center;
+    border: 1px solid $color-grey2;
+    width: 128px;
+    height: 128px;
+
+    a {
+      color: $color-textfade;
+      padding: $padding-xlarge;
+      display: block;
+      width: 128px;
+      height: 128px;
+
+      .material-icons {
+        display: block;
+        margin: $padding-default $padding-default $padding-large;
+        font-size: $padding-xxlarge;
+      }
+    }
+
+    &:hover {
+      background: $color-grey2;
+      color: $color-title;
+    }
+  }
+}

--- a/app/components/listing/MobileActionBar.jsx
+++ b/app/components/listing/MobileActionBar.jsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router';
 import { getResourceActions } from 'utils/ResourceActions';
 import { images } from '../../assets';
 
+import './MobileActionBar.scss';
+
 const getMobileActions = resource => {
   const resourceActions = getResourceActions(resource);
   const mobileActions = [
@@ -20,11 +22,11 @@ const getMobileActions = resource => {
 };
 
 const renderButtonContent = action => (
-  <div key={action.name} className="listing-menu--button-content">
+  <div key={action.name} className="mobile-action-bar--button-content">
     <img
       src={images.icon(action.icon)}
       alt={action.icon}
-      className="listing-menu--button-icon"
+      className="mobile-action-bar--button-icon"
     />
     <span>{action.name}</span>
   </div>
@@ -36,9 +38,9 @@ export default class MobileActionBar extends React.Component {
     const actions = getMobileActions(resource);
 
     return (
-      <div className="listing-menu">
+      <div className="mobile-action-bar">
         {actions.map(action => (
-          <div key={action.name} className="listing-menu--button">
+          <div key={action.name} className="mobile-action-bar--button">
             {
               action.to || action.handler
                 ? (

--- a/app/components/listing/MobileActionBar.jsx
+++ b/app/components/listing/MobileActionBar.jsx
@@ -2,7 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Link } from 'react-router';
+import { getResourceActions } from 'utils/ResourceActions';
 import { images } from '../../assets';
+
+const getMobileActions = resource => {
+  const resourceActions = getResourceActions(resource);
+  const mobileActions = [
+    { ...resourceActions.edit, icon: 'edit-blue' },
+  ];
+  if (resource.address) {
+    mobileActions.unshift({ ...resourceActions.directions, icon: 'directions-blue' });
+  }
+  if (resource.phones && resource.phones.length > 0) {
+    mobileActions.unshift({ ...resourceActions.phone, icon: 'phone-blue' });
+  }
+  return mobileActions;
+};
 
 const renderButtonContent = action => (
   <div key={action.name} className="listing-menu--button-content">
@@ -17,7 +32,8 @@ const renderButtonContent = action => (
 
 export default class MobileActionBar extends React.Component {
   render() {
-    const { actions } = this.props;
+    const { resource } = this.props;
+    const actions = getMobileActions(resource);
 
     return (
       <div className="listing-menu">
@@ -44,11 +60,5 @@ export default class MobileActionBar extends React.Component {
 }
 
 MobileActionBar.propTypes = {
-  actions: PropTypes.arrayOf(PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    icon: PropTypes.string.isRequired,
-    link: PropTypes.string,
-    to: PropTypes.string,
-    handler: PropTypes.function,
-  })).isRequired,
+  resource: PropTypes.object.isRequired,
 };

--- a/app/components/listing/MobileActionBar.scss
+++ b/app/components/listing/MobileActionBar.scss
@@ -1,0 +1,21 @@
+@import '../../styles/utils/helpers';
+
+.mobile-action-bar {
+  display: none;
+  @include r_max($break-tablet-s) {
+    display: flex;
+    justify-content: space-between;
+    padding: calc-em(16px) calc-em(4px);
+    border-top: 1px solid #dddddd;
+    border-bottom: 1px solid #dddddd;
+  }
+  &--button {
+    &-content {
+      display: flex;
+      justify-content: center;
+    }
+    &-icon {
+      margin-right: calc-em(8px);
+    }
+  }
+}

--- a/app/pages/OrganizationListingPage.jsx
+++ b/app/pages/OrganizationListingPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import { Link } from 'react-router';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import {
@@ -192,9 +191,7 @@ export class OrganizationListingPage extends React.Component {
               </div>
 
               <div className="org--aside">
-                <div className="org--aside--content">
-                  <ActionSidebar resource={resource} />
-                </div>
+                <ActionSidebar resource={resource} />
               </div>
             </div>
           </article>

--- a/app/pages/OrganizationListingPage.jsx
+++ b/app/pages/OrganizationListingPage.jsx
@@ -11,6 +11,11 @@ import {
   Email,
   StreetView,
 } from 'components/listing/ResourceInfos';
+import {
+  ActionSidebar,
+  TableOfOpeningTimes,
+  MobileActionBar,
+} from 'components/listing';
 import { RelativeOpeningTime } from 'components/listing/RelativeOpeningTime';
 import Services from 'components/listing/Services';
 import Notes from 'components/listing/Notes';
@@ -19,16 +24,7 @@ import ResourceMap from 'components/listing/ResourceMap';
 import HAPcertified from '../assets/img/ic-hap.png';
 import MOHCDFunded from '../assets/img/ic-mohcd-funded-services.png';
 import * as dataService from '../utils/DataService';
-// import ServiceCard from '../components/layout/ServiceCard';
-import { TableOfOpeningTimes } from '../components/listing/TableOfOpeningTimes';
 import { isSFServiceGuideSite } from '../utils/whitelabel';
-
-function scrollToElement(selector) {
-  const elem = document.getElementById(selector);
-  if (elem) {
-    elem.scrollIntoView({ block: 'center', behaviour: 'smooth' });
-  }
-}
 
 export class OrganizationListingPage extends React.Component {
   constructor(props) {
@@ -161,6 +157,8 @@ export class OrganizationListingPage extends React.Component {
                   </div>
                 </header>
 
+                <MobileActionBar resource={resource} />
+
                 <section className="service--section" id="services">
                   <header className="service--section--header">
                     <h4>Services</h4>
@@ -195,51 +193,7 @@ export class OrganizationListingPage extends React.Component {
 
               <div className="org--aside">
                 <div className="org--aside--content">
-                  {
-                    resource.address && (
-                      <a href={`https://maps.google.com?saddr=Current+Location&daddr=${resource.address.latitude},${resource.address.longitude}&dirflg=w`} target="_blank" rel="noopener noreferrer" className="org--aside--content--button directions-button">
-                        Get Directions
-                      </a>
-                    )
-                  }
-                  <Link
-                    to={{
-                      pathname: '/resource/edit',
-                      query: {
-                        resourceid: resource.id,
-                      },
-                    }}
-                    className="org--aside--content--button edit-button"
-                  >
-                      Make Edits
-                  </Link>
-                  <button type="button" className="org--aside--content--button" onClick={this.verifyResource}>
-                      Mark Info as Correct
-                  </button>
-                  <nav className="org--aside--content--nav">
-                    <ul>
-                      <li>
-                        <a href="#resource">{resource.name}</a>
-                      </li>
-                      <li>
-                        <a href="#services">Services</a>
-                        <ul className="service--nav--list">
-                          {
-                            resource.services.map(service => (
-                              <li key={service.id}>
-                                <a href={`#service-${service.id}`} onClick={scrollToElement(`service-${service.id}`)}>
-                                  {service.name}
-                                </a>
-                              </li>
-                            ))
-                          }
-                        </ul>
-                      </li>
-                      <li>
-                        <a href="#info">Info</a>
-                      </li>
-                    </ul>
-                  </nav>
+                  <ActionSidebar resource={resource} />
                 </div>
               </div>
             </div>

--- a/app/pages/ServiceListingPage.jsx
+++ b/app/pages/ServiceListingPage.jsx
@@ -109,6 +109,7 @@ class ServicePage extends React.Component {
                     </span>
                   </p>
                 </header>
+
                 <MobileActionBar resource={resource} />
 
                 <section className="listing--main--left--about">

--- a/app/pages/ServiceListingPage.jsx
+++ b/app/pages/ServiceListingPage.jsx
@@ -19,63 +19,6 @@ import Helmet from 'react-helmet';
 import 'react-tippy/dist/tippy.css';
 import { isSFServiceGuideSite } from '../utils/whitelabel';
 
-const getResourceActions = resource => ({
-  // TODO Edit should add service ID header
-  edit: {
-    name: 'Edit',
-    icon: 'edit',
-    to: `/resource/edit?resourceid=${resource.id}`,
-  }, // TODO Update with path to /resource/:id
-  print: {
-    name: 'Print',
-    icon: 'print',
-    handler: () => {
-      window.print();
-    },
-  },
-  directions: {
-    name: 'Directions',
-    icon: 'directions',
-    link: `http://google.com/maps/dir/?api=1&destination=${
-      resource.address.latitude
-    },${resource.address.longitude}`,
-  },
-  phone: {
-    name: 'Call',
-    icon: 'call',
-    link: `tel:${resource.phones[0].number}`,
-  },
-  // TODO Integrate with mobile share, how to handle shares
-  // { name: 'Share', icon: 'share' },
-  // { name: 'Save', icon: 'save' }, TODO We have no save mechanism yet
-});
-
-const getSidebarActions = resource => {
-  const resourceActions = getResourceActions(resource);
-  const sidebarActions = [
-    resourceActions.edit,
-    resourceActions.print,
-  ];
-  if (resource.address) {
-    sidebarActions.push(resourceActions.directions);
-  }
-  return sidebarActions;
-};
-
-const getMobileActions = resource => {
-  const resourceActions = getResourceActions(resource);
-  const mobileActions = [
-    { ...resourceActions.edit, icon: 'edit-blue' },
-  ];
-  if (resource.address) {
-    mobileActions.unshift({ ...resourceActions.directions, icon: 'directions-blue' });
-  }
-  if (resource.phones && resource.phones.length > 0) {
-    mobileActions.unshift({ ...resourceActions.phone, icon: 'phone-blue' });
-  }
-  return mobileActions;
-};
-
 // TODO This should be serviceAtLocation
 const getServiceLocations = (service, resource, schedule) => (resource.address
   ? [resource.address].map(address => ({
@@ -128,8 +71,6 @@ class ServicePage extends React.Component {
 
     const { resource, program, schedule } = service;
     const details = this.generateDetailsRows();
-    const sidebarActions = getSidebarActions(resource);
-    const mobileActions = getMobileActions(resource);
     const locations = getServiceLocations(service, resource, schedule);
 
     return (
@@ -168,7 +109,7 @@ class ServicePage extends React.Component {
                     </span>
                   </p>
                 </header>
-                <MobileActionBar actions={mobileActions} />
+                <MobileActionBar resource={resource} />
 
                 <section className="listing--main--left--about">
                   <h2>About This Service</h2>
@@ -230,7 +171,7 @@ class ServicePage extends React.Component {
                 </section> */}
               </div>
               <div className="listing--aside">
-                <ActionSidebar actions={sidebarActions} />
+                <ActionSidebar resource={resource} />
                 {service.categories.map(cat => (
                   <CategoryTag key={cat.id} category={cat} />
                 ))}

--- a/app/styles/components/_admin.scss
+++ b/app/styles/components/_admin.scss
@@ -55,7 +55,7 @@
         background: #FFF;
         padding: $padding-default;
         // margin: 0 0 $padding-default;
-        
+
         a {
           float: right;
          }

--- a/app/styles/components/_listing-page.scss
+++ b/app/styles/components/_listing-page.scss
@@ -262,101 +262,16 @@
 .relativeTime {
 	padding: $padding-default;
 	font-weight: bold;
-	// &.warning {
-	// 	color: $color-orange;
-	// }
-
-	// &.success {
-	// 	color: $color-green;
-	// }
-
-	// &.danger {
-	// 	color: $color-red;
-	// }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////
-// ORG MOBILE ACTIONS MENU
-.listing-menu {
-  display: none;
-  @include r_max($break-tablet-s) {
-    display: flex;
-    justify-content: space-between;
-    padding: calc-em(16px) calc-em(4px);
-    border-top: 1px solid #dddddd;
-    border-bottom: 1px solid #dddddd;
-  }
-  &--button {
-    &-content {
-      display: flex;
-      justify-content: center;
-    }
-    &-icon {
-      margin-right: calc-em(8px);
-    }
-  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // ORG ASIDE
 
 .listing--aside {
-	max-height: 100vh;
-	padding: 0 0 0 calc-em(30px);
-	width: 100%;
-	max-width: calc-em(240px);
-	&--content {
-		width: 100%;
-		max-width: calc-em(240px);
-		&--button {
-			color: #FFFFFF;
-			font-size: 17px;
-			font-weight: bold;
-			padding: calc-em(9px) calc-em(25px);
-			background: #1C72E6;
-			border-radius: 8px;
-			margin-top: calc-em(10px);
-			display: block;
-			text-align: center;
-			width: 100%;
-			height: auto; // Unset global height for button tag name selector
-			&-first-of-type {
-				margin-top: 0;
-			}
-		}
-		&--nav {
-			margin: calc-em(30px) 0;
-			ul {
-				list-style-type: none;
-				li {
-					width: 100%;
-					white-space: nowrap;
-				  overflow: hidden;
-				  text-overflow: ellipsis;
-				  margin-bottom: calc-em(10px);
-				  &:last-of-type {
-				  	margin-bottom: 0;
-				  }
-
-				  a {
-				  	color: #333333;
-				  	&:hover {
-				  		color: #1C72E6;
-				  	}
-				  }
-				}
-				&.service--nav--list {
-					list-style: disc;
-					margin-left: 1em;
-					list-style-position: inside;
-
-					li {
-						line-height: 1em;
-					}
-				}
-			}
-		}
-	}
+  max-height: 100vh;
+  padding: 0 0 0 1.875rem;
+  width: 100%;
+  max-width: 15rem;
   @include r_max($break-tablet-s) {
     display: none;
   }

--- a/app/styles/components/_org-page.scss
+++ b/app/styles/components/_org-page.scss
@@ -62,6 +62,13 @@
 		align-items: stretch;
 		align-content: stretch;
 	}
+  @include r_max($break-tablet-s) {
+    margin-top: 0;
+      &--left {
+        border-right: none;
+        width: 100%;
+      }
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -107,6 +114,9 @@
 			padding-right: 6px;
 			margin-top: calc-em(10px);
 		}
+    @include r_max($break-tablet-s) {
+      padding-bottom: calc-em(20px);
+    }
 	}
 	.badges {
 		display: flex;
@@ -247,56 +257,7 @@
 	padding: 0 0 0 calc-em(30px);
 	width: 100%;
 	max-width: calc-em(240px);
-	&--content {
-		width: 100%;
-		max-width: calc-em(240px);
-		&--button {
-			color: #FFFFFF;
-			font-size: 17px;
-			font-weight: bold;
-			padding: calc-em(9px) calc-em(25px);
-			background: #1C72E6;
-			border-radius: 8px;
-			margin-top: calc-em(10px);
-			display: block;
-			text-align: center;
-			width: 100%;
-			height: auto; // Unset global height for button tag name selector
-			&-first-of-type {
-				margin-top: 0;
-			}
-		}
-		&--nav {
-			margin: calc-em(30px) 0;
-			ul {
-				list-style-type: none;
-				li {
-					width: 100%;
-					white-space: nowrap;
-				  overflow: hidden;
-				  text-overflow: ellipsis;
-				  margin-bottom: calc-em(10px);
-				  &:last-of-type {
-				  	margin-bottom: 0;
-				  }
-
-				  a {
-				  	color: #333333;
-				  	&:hover {
-				  		color: #1C72E6;
-				  	}
-				  }
-				}
-				&.service--nav--list {
-					list-style: disc;
-					margin-left: 1em;
-					list-style-position: inside;
-
-					li {
-						line-height: 1em;
-					}
-				}
-			}
-		}
-	}
+  @include r_max($break-tablet-s) {
+    display: none;
+  }
 }

--- a/app/styles/st-base/_layout.scss
+++ b/app/styles/st-base/_layout.scss
@@ -64,37 +64,6 @@ pre {
   }
 }
 
-// Listing page action buttons
-ul.actions {
-  margin: $padding-xlarge 0;
-
-  li {
-    text-align: center;
-    border: 1px solid $color-grey2;
-    width: 128px;
-    height: 128px;
-
-    a {
-      color: $color-textfade;
-      padding: $padding-xlarge;
-      display: block;
-      width: 128px;
-      height: 128px;
-
-      .material-icons {
-        display: block;
-        margin: $padding-default $padding-default $padding-large;
-        font-size: $padding-xxlarge;
-      }
-    }
-
-    &:hover {
-      background: $color-grey2;
-      color: $color-title;
-    }
-  }
-}
-
 .tippy-tooltip {
   padding: 0;
 

--- a/app/utils/ResourceActions.js
+++ b/app/utils/ResourceActions.js
@@ -1,0 +1,30 @@
+export const getResourceActions = resource => ({
+  // TODO Edit should add service ID header
+  edit: {
+    name: 'Edit',
+    icon: 'edit',
+    to: `/resource/edit?resourceid=${resource.id}`,
+  }, // TODO Update with path to /resource/:id
+  print: {
+    name: 'Print',
+    icon: 'print',
+    handler: () => {
+      window.print();
+    },
+  },
+  directions: {
+    name: 'Directions',
+    icon: 'directions',
+    link: `http://google.com/maps/dir/?api=1&destination=${
+      resource.address.latitude
+    },${resource.address.longitude}`,
+  },
+  phone: {
+    name: 'Call',
+    icon: 'call',
+    link: `tel:${resource.phones[0].number}`,
+  },
+  // TODO Integrate with mobile share, how to handle shares
+  // { name: 'Share', icon: 'share' },
+  // { name: 'Save', icon: 'save' }, TODO We have no save mechanism yet
+});

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -16,7 +16,7 @@ export default class ResourcePage {
     this.phones = baseSelector.find('.org--main--header--phone .phone p');
     this.website = baseSelector.findReact('Website');
     this.email = baseSelector.findReact('Email');
-    this.editButton = baseSelector.find('.edit-button');
+    this.editButton = baseSelector.find('.action-sidebar--edit');
     this.services = baseSelector.find('#services.service--section .service');
   }
 

--- a/testcafe/pages/ServicePage.js
+++ b/testcafe/pages/ServicePage.js
@@ -8,9 +8,9 @@ export default class ResourcePage {
     this.serviceName = baseSelector.find('header h1');
     this.description = baseSelector.find('.listing--main--left--about');
     this.details = baseSelector.find('.listing--main--left--details');
-    this.editButton = baseSelector.find('.listing--aside--edit');
-    this.printButton = baseSelector.find('.listing--aside--print');
-    this.directionsButton = baseSelector.find('.listing--aside--directions');
+    this.editButton = baseSelector.find('.action-sidebar--edit');
+    this.printButton = baseSelector.find('.action-sidebar--print');
+    this.directionsButton = baseSelector.find('.action-sidebar--directions');
     this.schedule = baseSelector.findReact('TableOfOpeningTimes tbody tr');
     this.url = serviceId => `${config.baseUrl}/services/${serviceId}`;
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,8 @@ module.exports = {
         exclude: [
           path.resolve(__dirname, 'app/components/ui/HamburgerMenu'),
           path.resolve(__dirname, 'app/components/ui/Navigation'),
+          path.resolve(__dirname, 'app/components/listing/MobileActionBar'),
+          path.resolve(__dirname, 'app/components/listing/ActionSidebar'),
         ],
         test: /\.s?css$/,
         use: [
@@ -96,6 +98,8 @@ module.exports = {
         include: [
           path.resolve(__dirname, 'app/components/ui/HamburgerMenu'),
           path.resolve(__dirname, 'app/components/ui/Navigation'),
+          path.resolve(__dirname, 'app/components/listing/MobileActionBar'),
+          path.resolve(__dirname, 'app/components/listing/ActionSidebar'),
         ],
         test: /\.s?css$/,
         use: [


### PR DESCRIPTION
The new designs for the Organization Listing Page and the Service Listing Page are very similar. So, in implementing the Organization Listing Page redesign, I'm attempting to pull out as many shared components as possible. I started with the actions bars (we have one that we display on desktop, and another that we display on mobile).

Designs can be found on figma, here: https://www.figma.com/file/H0kD6ZZPhPR2RMyNJHWWeTtI/Web-Client?node-id=1456%3A1223

These components were partially implemented in the Service Listing Page, already. In this PR I further componentized them by moving more logic into the components and cleaning up the css. Once they were more self-contained, I was able to replace the actions bar on the Organization Listing Page with these components.

### Service
<img width="1461" alt="Screen Shot 2019-04-22 at 9 35 26 PM" src="https://user-images.githubusercontent.com/7386336/56554510-d1979880-6546-11e9-8b37-cb9c9500305e.png">
### Org
<img width="1461" alt="Screen Shot 2019-04-22 at 9 35 09 PM" src="https://user-images.githubusercontent.com/7386336/56554509-d1979880-6546-11e9-818d-a7650393fd6e.png">

### Service
<img width="1460" alt="Screen Shot 2019-04-22 at 10 37 58 PM" src="https://user-images.githubusercontent.com/7386336/56557668-cea1a580-6550-11e9-97b5-c65e7e357af7.png">
### Org
<img width="1460" alt="Screen Shot 2019-04-22 at 10 38 07 PM" src="https://user-images.githubusercontent.com/7386336/56557667-cea1a580-6550-11e9-9af2-84326df5c5c9.png">



