### PR TITLE
Fix schedule in resource creation

### DIFF
--- a/app/components/edit/EditSchedule.jsx
+++ b/app/components/edit/EditSchedule.jsx
@@ -60,6 +60,7 @@ function buildSchedule(schedule) {
 class EditSchedule extends Component {
   constructor(props) {
     super(props);
+    const { canInheritFromParent } = props;
 
     this.state = {
       // ESLint can't detect that this field is actually beind used in the
@@ -67,9 +68,9 @@ class EditSchedule extends Component {
       // eslint-disable-next-line react/no-unused-state
       scheduleId: props.schedule ? props.schedule.id : null,
       scheduleDays: buildSchedule(props.schedule),
-      // If the service doesn't had a schedule associated with it, inherit
-      // the parent resource's schedule.
-      shouldInheritSchedule: !(_.get(props, 'schedule.schedule_days.length', false)),
+      // If the service doesn't have a schedule associated with it, and can
+      // inherit its schedule from its parent, inherit the parent resource's schedule.
+      shouldInheritSchedule: canInheritFromParent && !(_.get(props, 'schedule.schedule_days.length', false)),
     };
 
     this.handleScheduleChange = this.handleScheduleChange.bind(this);
@@ -230,6 +231,10 @@ class EditSchedule extends Component {
 
   render() {
     const { scheduleDays: schedule, shouldInheritSchedule } = this.state;
+    // This component is shared between organizations and services. Organizations
+    // are top level, and cannot inherit schedules. OTOH Services can inherit
+    // their schedule from their parent organization. This prop controls this
+    // difference in behavior.
     const { canInheritFromParent } = this.props;
     return (
       <li key="hours" className="edit--section--list--item hours">


### PR DESCRIPTION
If a service has an empty schedule, we automatically inherit its schedule from its parent. When the service schedule is being inherited from its parent, we hide the schedule block.

The bug here was that an organization had an empty schedule, which we then assumed meant it was inheriting its schedule and therefore hid the schedule block. The issue was that we did not take into account whether or not this resource was actually capable of inheriting its schedule, and whether or not we had a checkbox displayed to toggle it out of the hidden state.

We have a prop `canInheritFromParent` that determines whether or not the given resource is able to inherit its schedule (ie an Organization cannot inherit its schedule, but a service can). In this case we weren't taking this prop into account when deciding whether or not we show the schedule. We never want to hide the schedule block if the resource is not capable of inheriting its schedule.

### Service not inheriting
<img width="1460" alt="Screen Shot 2019-04-24 at 10 49 25 PM" src="https://user-images.githubusercontent.com/7386336/56712402-3be54000-66e3-11e9-9c15-356f7844eb7b.png">

### Service is inheriting
<img width="1460" alt="Screen Shot 2019-04-24 at 10 49 23 PM" src="https://user-images.githubusercontent.com/7386336/56712404-3be54000-66e3-11e9-9281-7af07c321371.png">

### Fixed resource creation
<img width="1460" alt="Screen Shot 2019-04-24 at 10 35 23 PM" src="https://user-images.githubusercontent.com/7386336/56712333-08a2b100-66e3-11e9-939d-f7f602938bd2.png">
