### PR TITLE
[570] Fixed references to markdown content without markdown styling

### DIFF
--- a/app/components/listing/Services.jsx
+++ b/app/components/listing/Services.jsx
@@ -142,7 +142,7 @@ Website:
 const ServiceEligibility = ({ result, subject }) => result && (
   <li className="service--details--item">
     <header>{subject}</header>
-    <div className="service--details--item--info">{result}</div>
+    <ReactMarkdown className="rendered-markdown service--details--item--info">{result}</ReactMarkdown>
   </li>
 );
 

--- a/app/components/search/SearchTabView.jsx
+++ b/app/components/search/SearchTabView.jsx
@@ -35,12 +35,16 @@ class SearchTabView extends React.Component {
   }
 
   getTabList() {
-    const { applicationProcess, description, schedule } = this.props;
-    const tabs = [];
-    tabs.push({ title: 'Description', content: <ReactMarkdown className="rendered-markdown" source={description} /> });
-    if (applicationProcess) { tabs.push({ title: 'How to Apply', content: <p>{applicationProcess}</p> }); }
-    // tabs.push({ title: 'Hours', content: this.getSchedule(schedule) });
-    return tabs;
+    const { applicationProcess, description } = this.props;
+
+    const tabs = [[ 'Description', description ], [ 'How To Apply', applicationProcess ]];
+
+    return tabs
+      .filter(([title, content]) => content)
+      .map(([title, content]) => ({
+        title: title,
+        content: <ReactMarkdown className="rendered-markdown" source={ content } />
+      }));
   }
 
   render() {

--- a/app/pages/ServiceListingPage.jsx
+++ b/app/pages/ServiceListingPage.jsx
@@ -88,7 +88,6 @@ const getServiceLocations = (service, resource, schedule) => (resource.address
   }))
   : []);
 
-
 class ServicePage extends React.Component {
   componentWillMount() {
     const {
@@ -111,14 +110,15 @@ class ServicePage extends React.Component {
       // ['Funding Sources', ] // TODO Doesn't exist
       [
         'Notes',
-        <ReactMarkdown className="rendered-markdown">
-          {service.notes.map(d => d.note).join('\n')}
-        </ReactMarkdown>,
+        service.notes.map(d => d.note).join('\n')
       ],
     ];
     return rows
       .filter(row => row[1])
-      .map(row => ({ title: row[0], value: row[1] }));
+      .map(row => ({
+        title: row[0],
+        value: <ReactMarkdown className="rendered-markdown">{ row[1] }</ReactMarkdown>
+      }));
   }
 
 
@@ -189,7 +189,7 @@ class ServicePage extends React.Component {
                           </td>
                         </tr>
                       )}
-                      rows={this.generateDetailsRows()}
+                      rows={details}
                     />
                   </section>
                 ) : null}

--- a/app/pages/ServiceListingPage.jsx
+++ b/app/pages/ServiceListingPage.jsx
@@ -110,14 +110,14 @@ class ServicePage extends React.Component {
       // ['Funding Sources', ] // TODO Doesn't exist
       [
         'Notes',
-        service.notes.map(d => d.note).join('\n')
+        service.notes.map(d => d.note).join('\n'),
       ],
     ];
     return rows
       .filter(row => row[1])
       .map(row => ({
         title: row[0],
-        value: <ReactMarkdown className="rendered-markdown">{ row[1] }</ReactMarkdown>
+        value: <ReactMarkdown className="rendered-markdown">{ row[1] }</ReactMarkdown>,
       }));
   }
 


### PR DESCRIPTION
The issue here was that there were several places where we were referring to markdown content without wrapping them in the appropriate component. Although issue 570 references issues with the organization description on the main org page, I found no issues with the markdown parser there. However, the services section of the main org page, the search page, and the services page all had the issues as described.
<img width="683" alt="image" src="https://user-images.githubusercontent.com/834403/56871834-4a7b7200-69d7-11e9-93d7-cb506f7a451a.png">
<img width="564" alt="image" src="https://user-images.githubusercontent.com/834403/56871845-4f402600-69d7-11e9-8e17-c9fff6328db1.png">

