### PR TITLE
Refactor ProvidedService

### DIFF
--- a/app/components/edit/FormTextArea.jsx
+++ b/app/components/edit/FormTextArea.jsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 const FormTextArea = ({
   label, placeholder, value, setValue,
 }) => (
-  <li className="edit--section--list--item">
+  <Fragment>
     <label htmlFor="textarea">{label}</label>
     <textarea
       placeholder={placeholder}
       value={value}
       onChange={evt => setValue(evt.target.value)}
     />
-  </li>
+  </Fragment>
 );
 
 FormTextArea.propTypes = {

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -33,6 +33,32 @@ InputField.defaultProps = {
 };
 
 
+const TEXT_AREAS = [
+  {
+    label: 'Service Description',
+    placeholder: "Describe what you'll receive from this service in a few sentences.",
+    field: 'long_description',
+  },
+  {
+    label: 'Application Process',
+    placeholder: 'How do you apply for this service?',
+    field: 'application_process',
+  },
+  {
+    label: 'Required Documents',
+    placeholder: 'What documents do you need to bring to apply?',
+    field: 'required_documents',
+  },
+  {
+    // TODO: Make this a multiselectdropdown, create a new table in the DB for languages,
+    //       and seed it with languages
+    label: 'Interpretation Services',
+    placeholder: 'What interpretation services do they offer?',
+    field: 'interpretation_services',
+  },
+];
+
+
 class ProvidedService extends Component {
   constructor(props) {
     super(props);
@@ -48,31 +74,6 @@ class ProvidedService extends Component {
     this.state = {
       service: {},
     };
-
-    this.textAreas = [
-      {
-        label: 'Service Description',
-        placeholder: "Describe what you'll receive from this service in a few sentences.",
-        field: 'long_description',
-      },
-      {
-        label: 'Application Process',
-        placeholder: 'How do you apply for this service?',
-        field: 'application_process',
-      },
-      {
-        label: 'Required Documents',
-        placeholder: 'What documents do you need to bring to apply?',
-        field: 'required_documents',
-      },
-      {
-        // TODO: Make this a multiselectdropdown, create a new table in the DB for languages,
-        //       and seed it with languages
-        label: 'Interpretation Services',
-        placeholder: 'What interpretation services do they offer?',
-        field: 'interpretation_services',
-      },
-    ];
   }
 
   handleChange = (field, value) => {
@@ -138,7 +139,7 @@ class ProvidedService extends Component {
             />
           </li>
 
-          {this.textAreas.map(textArea => (
+          {TEXT_AREAS.map(textArea => (
             <li className="edit--section--list--item" key={textArea.field}>
               <FormTextArea
                 label={textArea.label}

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -75,15 +75,10 @@ class ProvidedService extends Component {
     ];
   }
 
-  // This is meant to gradually replace handleFieldChange in a way that does not
-  // depend on the caller necessarily being a DOM event.
-  handleServiceFieldChange = (field, value) => {
+  handleChange = (field, value) => {
     const { service } = this.state;
+    // TODO: We shouldn't be mutating state, but this component currently depends on it
     service[field] = value;
-    this.handleChange(service);
-  }
-
-  handleChange(service) {
     this.setState({ service }, () => {
       const { service: { key }, handleChange } = this.props;
       handleChange(key, service);
@@ -120,7 +115,7 @@ class ProvidedService extends Component {
               label="Name of the Service"
               placeholder="What is this service called?"
               value={flattenedService.name}
-              setValue={value => this.handleServiceFieldChange('name', value)}
+              setValue={value => this.handleChange('name', value)}
             />
           </li>
 
@@ -129,7 +124,7 @@ class ProvidedService extends Component {
               label="Nickname"
               placeholder="What it's known as in the community"
               value={flattenedService.alternate_name}
-              setValue={value => this.handleServiceFieldChange('alternate_name', value)}
+              setValue={value => this.handleChange('alternate_name', value)}
             />
           </li>
 
@@ -139,7 +134,7 @@ class ProvidedService extends Component {
               label="Service E-Mail"
               placeholder="Email address for this service"
               value={flattenedService.email}
-              setValue={value => this.handleServiceFieldChange('email', value)}
+              setValue={value => this.handleChange('email', value)}
             />
           </li>
 
@@ -149,7 +144,7 @@ class ProvidedService extends Component {
                 label={textArea.label}
                 placeholder={textArea.placeholder}
                 value={flattenedService[textArea.field] || ''}
-                setValue={value => this.handleServiceFieldChange(textArea.field, value)}
+                setValue={value => this.handleChange(textArea.field, value)}
               />
             </li>
           ))}
@@ -157,7 +152,7 @@ class ProvidedService extends Component {
           <li className="edit--section--list--item">
             <MultiSelectDropdown
               selectedItems={service.eligibilities}
-              handleSelectChange={value => this.handleServiceFieldChange('eligibilities', value)}
+              handleSelectChange={value => this.handleChange('eligibilities', value)}
               label="Eligibility"
               optionsRoute="eligibilities"
             />
@@ -168,7 +163,7 @@ class ProvidedService extends Component {
               label="Cost"
               placeholder="How much does this service cost?"
               value={flattenedService.fee}
-              setValue={value => this.handleServiceFieldChange('fee', value)}
+              setValue={value => this.handleChange('fee', value)}
             />
           </li>
 
@@ -177,7 +172,7 @@ class ProvidedService extends Component {
               label="Wait Time"
               placeholder="Is there a waiting list or wait time?"
               value={flattenedService.wait_time}
-              setValue={value => this.handleServiceFieldChange('wait_time', value)}
+              setValue={value => this.handleChange('wait_time', value)}
             />
           </li>
 
@@ -186,24 +181,24 @@ class ProvidedService extends Component {
               label="Service&#39;s Website"
               placeholder="http://"
               value={flattenedService.url}
-              setValue={value => this.handleServiceFieldChange('url', value)}
+              setValue={value => this.handleChange('url', value)}
             />
           </li>
 
           <EditSchedule
             canInheritFromParent
             schedule={service.schedule}
-            handleScheduleChange={value => this.handleServiceFieldChange('scheduleObj', value)}
+            handleScheduleChange={value => this.handleChange('scheduleObj', value)}
           />
 
           <EditNotes
             notes={service.notes}
-            handleNotesChange={value => this.handleServiceFieldChange('notesObj', value)}
+            handleNotesChange={value => this.handleChange('notesObj', value)}
           />
 
           <MultiSelectDropdown
             selectedItems={service.categories}
-            handleSelectChange={value => this.handleServiceFieldChange('categories', value)}
+            handleSelectChange={value => this.handleChange('categories', value)}
             label="Categories"
             optionsRoute="categories"
           />

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -158,12 +158,14 @@ class ProvidedService extends Component {
           </li>
 
           {this.textAreas.map(textArea => (
-            <FormTextArea
-              label={textArea.label}
-              placeholder={textArea.placeholder}
-              value={stateService[textArea.field] || textArea.defaultValue || ''}
-              setValue={value => this.handleServiceFieldChange(textArea.field, value)}
-            />
+            <li className="edit--section--list--item" key={textArea.field}>
+              <FormTextArea
+                label={textArea.label}
+                placeholder={textArea.placeholder}
+                value={stateService[textArea.field] || textArea.defaultValue || ''}
+                setValue={value => this.handleServiceFieldChange(textArea.field, value)}
+              />
+            </li>
           ))}
 
           <li className="edit--section--list--item">

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -73,11 +73,6 @@ class ProvidedService extends Component {
         field: 'interpretation_services',
       },
     ];
-
-    this.handleNotesChange = this.handleNotesChange.bind(this);
-    this.handleScheduleChange = this.handleScheduleChange.bind(this);
-    this.handleCategoryChange = this.handleCategoryChange.bind(this);
-    this.handleEligibilityChange = this.handleEligibilityChange.bind(this);
   }
 
   // This is meant to gradually replace handleFieldChange in a way that does not
@@ -93,30 +88,6 @@ class ProvidedService extends Component {
       const { service: { key }, handleChange } = this.props;
       handleChange(key, service);
     });
-  }
-
-  handleNotesChange(notesObj) {
-    const { service } = this.state;
-    service.notesObj = notesObj;
-    this.handleChange(service);
-  }
-
-  handleScheduleChange(scheduleObj) {
-    const { service } = this.state;
-    service.scheduleObj = scheduleObj;
-    this.handleChange(service);
-  }
-
-  handleCategoryChange(categories) {
-    const { service } = this.state;
-    service.categories = categories;
-    this.handleChange(service);
-  }
-
-  handleEligibilityChange(eligibilities) {
-    const { service } = this.state;
-    service.eligibilities = eligibilities;
-    this.handleChange(service);
   }
 
   render() {
@@ -186,7 +157,7 @@ class ProvidedService extends Component {
           <li className="edit--section--list--item">
             <MultiSelectDropdown
               selectedItems={service.eligibilities}
-              handleSelectChange={this.handleEligibilityChange}
+              handleSelectChange={value => this.handleServiceFieldChange('eligibilities', value)}
               label="Eligibility"
               optionsRoute="eligibilities"
             />
@@ -222,14 +193,17 @@ class ProvidedService extends Component {
           <EditSchedule
             canInheritFromParent
             schedule={service.schedule}
-            handleScheduleChange={this.handleScheduleChange}
+            handleScheduleChange={value => this.handleServiceFieldChange('scheduleObj', value)}
           />
 
-          <EditNotes notes={service.notes} handleNotesChange={this.handleNotesChange} />
+          <EditNotes
+            notes={service.notes}
+            handleNotesChange={value => this.handleServiceFieldChange('notesObj', value)}
+          />
 
           <MultiSelectDropdown
             selectedItems={service.categories}
-            handleSelectChange={this.handleCategoryChange}
+            handleSelectChange={value => this.handleServiceFieldChange('categories', value)}
             label="Categories"
             optionsRoute="categories"
           />

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -1,9 +1,37 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import EditNotes from './EditNotes';
 import EditSchedule from './EditSchedule';
 import MultiSelectDropdown from './MultiSelectDropdown';
 import FormTextArea from './FormTextArea';
+
+
+const InputField = ({
+  type, label, placeholder, value, setValue,
+}) => (
+  <Fragment>
+    <label htmlFor="input">{label}</label>
+    <input
+      type={type}
+      placeholder={placeholder}
+      value={value}
+      onChange={evt => setValue(evt.target.value)}
+    />
+  </Fragment>
+);
+
+InputField.propTypes = {
+  type: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  setValue: PropTypes.func.isRequired, // A function to call when setting a new value
+};
+
+InputField.defaultProps = {
+  type: 'text',
+};
+
 
 class ProvidedService extends Component {
   constructor(props) {
@@ -21,26 +49,21 @@ class ProvidedService extends Component {
       service: {},
     };
 
-    const { service } = this.props;
-
     this.textAreas = [
       {
         label: 'Service Description',
         placeholder: "Describe what you'll receive from this service in a few sentences.",
         field: 'long_description',
-        defaultValue: service.long_description,
       },
       {
         label: 'Application Process',
         placeholder: 'How do you apply for this service?',
         field: 'application_process',
-        defaultValue: service.application_process,
       },
       {
         label: 'Required Documents',
         placeholder: 'What documents do you need to bring to apply?',
         field: 'required_documents',
-        defaultValue: service.required_documents,
       },
       {
         // TODO: Make this a multiselectdropdown, create a new table in the DB for languages,
@@ -48,11 +71,9 @@ class ProvidedService extends Component {
         label: 'Interpretation Services',
         placeholder: 'What interpretation services do they offer?',
         field: 'interpretation_services',
-        defaultValue: service.interpretation_services,
       },
     ];
 
-    this.handleFieldChange = this.handleFieldChange.bind(this);
     this.handleNotesChange = this.handleNotesChange.bind(this);
     this.handleScheduleChange = this.handleScheduleChange.bind(this);
     this.handleCategoryChange = this.handleCategoryChange.bind(this);
@@ -72,12 +93,6 @@ class ProvidedService extends Component {
       const { service: { key }, handleChange } = this.props;
       handleChange(key, service);
     });
-  }
-
-  handleFieldChange(e) {
-    const { service } = this.state;
-    service[e.target.dataset.field] = e.target.value;
-    this.handleChange(service);
   }
 
   handleNotesChange(notesObj) {
@@ -107,6 +122,10 @@ class ProvidedService extends Component {
   render() {
     const { handleDeactivation, index, service } = this.props;
     const { service: stateService, submitting } = this.state;
+    const flattenedService = {
+      ...service,
+      ...stateService,
+    };
     return (
       <li id={`${service.id}`} className="edit--service edit--section">
         <header className="edit--section--header">
@@ -126,34 +145,30 @@ class ProvidedService extends Component {
 
         <ul className="edit--section--list">
           <li className="edit--section--list--item">
-            <label htmlFor="input">Name of the Service</label>
-            <input
-              type="text"
+            <InputField
+              label="Name of the Service"
               placeholder="What is this service called?"
-              data-field="name"
-              defaultValue={service.name}
-              onChange={this.handleFieldChange}
+              value={flattenedService.name}
+              setValue={value => this.handleServiceFieldChange('name', value)}
             />
           </li>
 
           <li className="edit--section--list--item">
-            <label htmlFor="input">Nickname</label>
-            <input
-              type="text"
+            <InputField
+              label="Nickname"
               placeholder="What it's known as in the community"
-              data-field="alternate_name"
-              defaultValue={service.alternate_name}
-              onChange={this.handleFieldChange}
+              value={flattenedService.alternate_name}
+              setValue={value => this.handleServiceFieldChange('alternate_name', value)}
             />
           </li>
 
           <li key="email" className="edit--section--list--item email">
-            <label htmlFor="email">Service E-Mail</label>
-            <input
+            <InputField
               type="email"
-              defaultValue={service.email}
-              data-field="email"
-              onChange={this.handleFieldChange}
+              label="Service E-Mail"
+              placeholder="Email address for this service"
+              value={flattenedService.email}
+              setValue={value => this.handleServiceFieldChange('email', value)}
             />
           </li>
 
@@ -162,7 +177,7 @@ class ProvidedService extends Component {
               <FormTextArea
                 label={textArea.label}
                 placeholder={textArea.placeholder}
-                value={stateService[textArea.field] || textArea.defaultValue || ''}
+                value={flattenedService[textArea.field] || ''}
                 setValue={value => this.handleServiceFieldChange(textArea.field, value)}
               />
             </li>
@@ -178,32 +193,29 @@ class ProvidedService extends Component {
           </li>
 
           <li className="edit--section--list--item">
-            <label htmlFor="input">Cost</label>
-            <input
+            <InputField
+              label="Cost"
               placeholder="How much does this service cost?"
-              data-field="fee"
-              defaultValue={service.fee}
-              onChange={this.handleFieldChange}
+              value={flattenedService.fee}
+              setValue={value => this.handleServiceFieldChange('fee', value)}
             />
           </li>
 
           <li className="edit--section--list--item">
-            <label htmlFor="input">Wait Time</label>
-            <input
+            <InputField
+              label="Wait Time"
               placeholder="Is there a waiting list or wait time?"
-              data-field="wait_time"
-              defaultValue={service.wait_time}
-              onChange={this.handleFieldChange}
+              value={flattenedService.wait_time}
+              setValue={value => this.handleServiceFieldChange('wait_time', value)}
             />
           </li>
 
           <li className="edit--section--list--item">
-            <label htmlFor="input">Service&#39;s Website</label>
-            <input
+            <InputField
+              label="Service&#39;s Website"
               placeholder="http://"
-              data-field="url"
-              defaultValue={service.url}
-              onChange={this.handleFieldChange}
+              value={flattenedService.url}
+              setValue={value => this.handleServiceFieldChange('url', value)}
             />
           </li>
 


### PR DESCRIPTION
This PR does some refactoring to the `ProvidedService` component on the edit page. I think the main things I succeeded at improving are:

1. Changing various simple text input fields from stateful components to controlled form components, thereby hoisting the state into the `ProvidedService` component,
2. Collapsing the `handleFooChange()` methods into a single method, and
3. Adding a `flattenedService` variable to the `render()` method that collapses both the version of the service passed in as a prop with the version of the service which is part of the state. For some reason, much of our code only stores the changes to objects in the state, but not the whole object, so it makes it trickier to control children components when the prop and the state have separate, incomplete info. With this `flattenedService` variable, I hope to simplify the code by being able to pass in a view of the object with all changes applied to it.