### PR TITLE
fix broken styles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,12 +94,24 @@ module.exports = {
         ],
       },
       {
+        include: [
+          path.resolve(__dirname, 'app/components/listing/MobileActionBar'),
+          path.resolve(__dirname, 'app/components/listing/ActionSidebar'),
+        ],
+        test: /\.s?css$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+          },
+          'sass-loader',
+        ],
+      },
+      {
         // New stylesheets are treated as locally-scoped CSS modules.
         include: [
           path.resolve(__dirname, 'app/components/ui/HamburgerMenu'),
           path.resolve(__dirname, 'app/components/ui/Navigation'),
-          path.resolve(__dirname, 'app/components/listing/MobileActionBar'),
-          path.resolve(__dirname, 'app/components/listing/ActionSidebar'),
         ],
         test: /\.s?css$/,
         use: [


### PR DESCRIPTION
When I put together [this PR](https://github.com/ShelterTechSF/askdarcel-web/pull/721), the styles for `ActionSidebar` and `MobileActionBar` were working as expected. However, this PR got merged and now when I start up master, the styles are not being applied properly. I understand the issue (they are being built as css modules but being used as regular stylesheets), but I don't understand why they were working locally for me before.

I don't have time to update these components to use css modules right now, but I don't want to leave master in a broken state. So, I've just updated our webpack loaders so these particular files are not built as css modules.

Before:
<img width="1200" alt="Screen Shot 2019-04-30 at 10 54 13 PM" src="https://user-images.githubusercontent.com/7386336/57007102-e3a6b600-6b9a-11e9-86bf-3f063789a12f.png">

After:
<img width="1200" alt="Screen Shot 2019-04-30 at 10 53 18 PM" src="https://user-images.githubusercontent.com/7386336/57007095-d7baf400-6b9a-11e9-971e-9151301d889b.png">


