### PR TITLE
Remove state from EditServices

### DIFF
--- a/app/components/edit/EditServices.jsx
+++ b/app/components/edit/EditServices.jsx
@@ -1,97 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { createTemplateSchedule } from '../../utils/index';
 import ProvidedService from './ProvidedService';
 
-class EditServices extends Component {
-  constructor(props) {
-    super(props);
 
-    const { services } = props;
-    const existingServices = services || [];
-
-    this.state = {
-      services: {},
-      existingServices,
-      uuid: -1,
-    };
-
-    this.handleServiceChange = this.handleServiceChange.bind(this);
-    this.addService = this.addService.bind(this);
-  }
-
-  /* @method handleServiceChange
-   * @description Updates the service with any changes made
-   * @param {number} id a unique identifier to find a service
-   * @param {object} service the service to be updated
-   * @returns {void}
-   */
-  handleServiceChange(id, service) {
-    const { handleServiceChange } = this.props;
-    const { services } = this.state;
-    services[id] = service;
-    this.setState({
-      services,
-    }, () => {
-      handleServiceChange(this.state);
-    });
-  }
-
-  /* @method addService
-   * @description Creates a brand new service
-   */
-  addService() {
-    const { existingServices, uuid } = this.state;
-    const newUUID = uuid - 1;
-
-    existingServices.push({
-      id: newUUID,
-      notes: [],
-      schedule: {
-        schedule_days: createTemplateSchedule(),
-      },
-    });
-    this.setState({
-      existingServices,
-      uuid: newUUID,
-    });
-  }
-
-  render() {
-    const { handleDeactivation } = this.props;
-    const { existingServices } = this.state;
-    return (
-      <li className="edit--section--list--item">
-        <ul className="edit--section--list--item--sublist edit--service--list">
-          {
-            existingServices.map((service, index) => (
-              <ProvidedService
-                key={`${service.id}`}
-                index={index}
-                service={service}
-                handleChange={this.handleServiceChange}
-                handleDeactivation={handleDeactivation}
-              />
-            ))
-          }
-        </ul>
-        <button
-          type="button"
-          className="edit--section--list--item--button new-service"
-          id="new-service-button"
-          onClick={this.addService}
-        >
-          <i className="material-icons">add_box</i>
+const EditServices = ({
+  addService, editServiceById, handleDeactivation, services,
+}) => (
+  <li className="edit--section--list--item">
+    <ul className="edit--section--list--item--sublist edit--service--list">
+      {
+        services.map((service, index) => (
+          <ProvidedService
+            key={`${service.id}`}
+            index={index}
+            service={service}
+            handleChange={editServiceById}
+            handleDeactivation={handleDeactivation}
+          />
+        ))
+      }
+    </ul>
+    <button
+      type="button"
+      className="edit--section--list--item--button new-service"
+      id="new-service-button"
+      onClick={addService}
+    >
+      <i className="material-icons">add_box</i>
           Add New Service
-        </button>
-      </li>
-    );
-  }
-}
+    </button>
+  </li>
+);
 
 EditServices.propTypes = {
   handleDeactivation: PropTypes.func.isRequired,
-  handleServiceChange: PropTypes.func.isRequired,
+  editServiceById: PropTypes.func.isRequired,
+  addService: PropTypes.func.isRequired,
+  services: PropTypes.array.isRequired,
 };
 
 export default EditServices;

--- a/app/components/edit/EditServices.jsx
+++ b/app/components/edit/EditServices.jsx
@@ -8,12 +8,7 @@ class EditServices extends Component {
     super(props);
 
     const { services } = props;
-    const existingServices = services
-      ? services.map(service => {
-        /* eslint-disable no-param-reassign */
-        service.key = service.id;
-        return service;
-      }) : [];
+    const existingServices = services || [];
 
     this.state = {
       services: {},
@@ -27,14 +22,14 @@ class EditServices extends Component {
 
   /* @method handleServiceChange
    * @description Updates the service with any changes made
-   * @param {string} key a unique identifier to find a service
+   * @param {number} id a unique identifier to find a service
    * @param {object} service the service to be updated
    * @returns {void}
    */
-  handleServiceChange(key, service) {
+  handleServiceChange(id, service) {
     const { handleServiceChange } = this.props;
     const { services } = this.state;
-    services[key] = service;
+    services[id] = service;
     this.setState({
       services,
     }, () => {
@@ -51,7 +46,6 @@ class EditServices extends Component {
 
     existingServices.push({
       id: newUUID,
-      key: newUUID,
       notes: [],
       schedule: {
         schedule_days: createTemplateSchedule(),
@@ -72,7 +66,7 @@ class EditServices extends Component {
           {
             existingServices.map((service, index) => (
               <ProvidedService
-                key={service.key}
+                key={`${service.id}`}
                 index={index}
                 service={service}
                 handleChange={this.handleServiceChange}

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -81,8 +81,8 @@ class ProvidedService extends Component {
     // TODO: We shouldn't be mutating state, but this component currently depends on it
     service[field] = value;
     this.setState({ service }, () => {
-      const { service: { key }, handleChange } = this.props;
-      handleChange(key, service);
+      const { service: { id }, handleChange } = this.props;
+      handleChange(id, service);
     });
   }
 
@@ -211,7 +211,7 @@ class ProvidedService extends Component {
 
 ProvidedService.propTypes = {
   service: PropTypes.shape({
-    id: PropTypes.string,
+    id: PropTypes.number,
     fee: PropTypes.number,
     categories: PropTypes.array,
     notes: PropTypes.array,
@@ -223,7 +223,6 @@ ProvidedService.propTypes = {
     required_documents: PropTypes.string,
     application_process: PropTypes.string,
     long_description: PropTypes.string,
-    key: PropTypes.string,
   }).isRequired,
   handleDeactivation: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired,


### PR DESCRIPTION
My next step for refactoring the frontend code is moving state out of the `EditServices` component, moving some functionality up into the `OrganizationEditPage`. This was an example of us duplicating state between multiple layers of the app, causing us to have to synchronize changes with each layer of the app.

Now `EditServices` is a stateless component, and all handler methods are passed in from above. Note that some of `EditServices`' descendant components may still have state in them.

One last note is that state about services is stored in two different places in `OrganizationEditPage`. My PR didn't change any of that; this was already the case. Services state is either stored in `this.state.resource.services` or in `this.state.services`. The difference between the two is that the former is generally what the API endpoint responded back with, where the `services` are an array of objects. The latter is an object that maps between service ID to a partially-filled out object with only the fields that have changed. My PR adds a helper function named `applyChanges()` which lets you pass in both pieces of state and immutably return an array of objects with all the changes applied.