### PR TITLE
Fix Directions link on Search Results (#341)

### DIFF
--- a/app/components/search/ResourceEntry.jsx
+++ b/app/components/search/ResourceEntry.jsx
@@ -15,7 +15,6 @@ class ResourceEntry extends Component {
     const hitNumber = page * hitsPerPage + index + 1;
     // const schedule = hit.schedule ? { schedule_days: hit.schedule } : null;
     // let timeInfo = null;
-
     return (
       <li className="results-table-entry resource-entry">
         <header>
@@ -51,15 +50,17 @@ class ResourceEntry extends Component {
         <div className="entry-action-buttons">
           <ul className="action-buttons">
             <li className="action-button"><Link to={{ pathname: '/resource', query: { id: hit.resource_id } }}>Details</Link></li>
-            <li className="action-button">
-              <a
-                href={`https://maps.google.com?saddr=Current+Location&daddr=${hit._geoloc ? hit._geoloc.lat : 0},${hit._geoloc ? hit._geoloc.lng : 0}&dirflg=w`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Directions
-              </a>
-            </li>
+            {hit._geoloc && (
+              <li className="action-button">
+                <a
+                  href={`http://google.com/maps/dir/?api=1&destination=${hit._geoloc.lat},${hit._geoloc.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Directions
+                </a>
+              </li>
+            )}
           </ul>
         </div>
 

--- a/app/components/search/ServiceEntry.jsx
+++ b/app/components/search/ServiceEntry.jsx
@@ -50,19 +50,20 @@ class ServiceEntry extends Component {
           description={description}
           schedule={hit.schedule}
         />
-
         <div className="entry-action-buttons">
           <ul className="action-buttons">
             <li className="action-button"><Link to={{ pathname: `/services/${hit.service_id}` }}>Details</Link></li>
-            <li className="action-button">
-              <a
-                href={`https://maps.google.com?saddr=Current+Location&daddr=${hit._geoloc ? hit._geoloc.lat : 0},${hit._geoloc ? hit._geoloc.lng : 0}&dirflg=w`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Directions
-              </a>
-            </li>
+            {hit._geoloc && (
+              <li className="action-button">
+                <a
+                  href={`http://google.com/maps/dir/?api=1&destination=${hit._geoloc.lat},${hit._geoloc.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Directions
+                </a>
+              </li>
+            )}
           </ul>
         </div>
 


### PR DESCRIPTION
Uses the same Google Maps URL that is generated on the Actions side bar,
which only requires the destination lat-lng pair.