### PR TITLE
Fix creation of schedules for new services.

### DIFF
--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -193,12 +193,17 @@ function postNotes(notesObj, promises, uriObj) {
   }
 }
 
+// THis is only called for schedules for new services, not for resources nor for
+// existing services.
 function createFullSchedule(scheduleObj) {
   if (scheduleObj) {
     const newSchedule = [];
     let tempDay = {};
     Object.keys(scheduleObj).forEach(day => {
       scheduleObj[day].forEach(curr => {
+        if (curr.opens_at === null || curr.closes_at === null) {
+          return;
+        }
         tempDay = {};
         tempDay.day = day;
         tempDay.opens_at = curr.opens_at;


### PR DESCRIPTION
I think the bug with creating schedules for new services was introduced by my hoisting of state up the component hierarchy. Now new services may have `null`s in some of their schedule days, and if they aren't touched in the new service form, it ends up sending invalid data to the backend. This adds a quick guard to filter out any ScheduleDays that have null `opens_at` or `closes_at` attributes.