### PR TITLE
Hoist edit schedule state up to the top

### DIFF
--- a/app/components/edit/EditSchedule.jsx
+++ b/app/components/edit/EditSchedule.jsx
@@ -2,60 +2,9 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 import { stringToTime } from '../../utils/index';
 import EditScheduleDay from './EditScheduleDay';
+import { buildScheduleDays } from '../../pages/OrganizationEditPage';
 
 import './EditSchedule.scss';
-
-function buildSchedule(schedule) {
-  const scheduleId = schedule ? schedule.id : null;
-  const currSchedule = {};
-  let finalSchedule = {};
-
-  const is24Hours = {
-    Monday: false,
-    Tuesday: false,
-    Wednesday: false,
-    Thursday: false,
-    Friday: false,
-    Saturday: false,
-    Sunday: false,
-  };
-
-  const tempSchedule = {
-    Monday: [{ opens_at: null, closes_at: null, scheduleId }],
-    Tuesday: [{ opens_at: null, closes_at: null, scheduleId }],
-    Wednesday: [{ opens_at: null, closes_at: null, scheduleId }],
-    Thursday: [{ opens_at: null, closes_at: null, scheduleId }],
-    Friday: [{ opens_at: null, closes_at: null, scheduleId }],
-    Saturday: [{ opens_at: null, closes_at: null, scheduleId }],
-    Sunday: [{ opens_at: null, closes_at: null, scheduleId }],
-  };
-
-  if (schedule) {
-    schedule.schedule_days.forEach(day => {
-      const currDay = day.day;
-      if (!is24Hours[currDay]) {
-        // Check to see if any of the hour pairs for the day
-        // indicate the resource/service is open 24 hours
-        // if there is a pair only have that in the day obj
-        if (day.opens_at === 0 && day.closes_at === 2359) {
-          is24Hours[currDay] = true;
-          // Since this record already exists in our DB, we only need the id
-          // scheduleID is needed when creating no data
-          currSchedule[currDay] = [{ opens_at: 0, closes_at: 2359, id: day.id }];
-        } else {
-          Object.assign(day, { openChanged: false, closeChanged: false });
-          if (currSchedule[currDay]) {
-            currSchedule[day.day].unshift(day);
-          } else {
-            currSchedule[day.day] = [day];
-          }
-        }
-      }
-    });
-  }
-  finalSchedule = Object.assign({}, tempSchedule, currSchedule);
-  return finalSchedule;
-}
 
 class EditSchedule extends Component {
   constructor(props) {
@@ -67,7 +16,7 @@ class EditSchedule extends Component {
       // callbacks.
       // eslint-disable-next-line react/no-unused-state
       scheduleId: props.schedule ? props.schedule.id : null,
-      scheduleDays: buildSchedule(props.schedule),
+      scheduleDays: buildScheduleDays(props.schedule),
       // If the service doesn't have a schedule associated with it, and can
       // inherit its schedule from its parent, inherit the parent resource's schedule.
       shouldInheritSchedule: canInheritFromParent && !(_.get(props, 'schedule.schedule_days.length', false)),
@@ -109,7 +58,7 @@ class EditSchedule extends Component {
             tempScheduleDays[day] = tempDaySchedule;
           });
         } else {
-          tempScheduleDays = buildSchedule(schedule);
+          tempScheduleDays = buildScheduleDays(schedule);
         }
 
         return { scheduleDays: tempScheduleDays, shouldInheritSchedule };

--- a/app/components/edit/EditSchedule.jsx
+++ b/app/components/edit/EditSchedule.jsx
@@ -1,190 +1,30 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
-import { stringToTime } from '../../utils/index';
+import PropTypes from 'prop-types';
 import EditScheduleDay from './EditScheduleDay';
-import { buildScheduleDays } from '../../pages/OrganizationEditPage';
 
 import './EditSchedule.scss';
 
 class EditSchedule extends Component {
-  constructor(props) {
-    super(props);
-    const { canInheritFromParent } = props;
-
-    this.state = {
-      // ESLint can't detect that this field is actually beind used in the
-      // callbacks.
-      // eslint-disable-next-line react/no-unused-state
-      scheduleId: props.schedule ? props.schedule.id : null,
-      scheduleDays: buildScheduleDays(props.schedule),
-      // If the service doesn't have a schedule associated with it, and can
-      // inherit its schedule from its parent, inherit the parent resource's schedule.
-      shouldInheritSchedule: canInheritFromParent && !(_.get(props, 'schedule.schedule_days.length', false)),
-    };
-
-    this.handleScheduleChange = this.handleScheduleChange.bind(this);
-    this.addTime = this.addTime.bind(this);
-    this.removeTime = this.removeTime.bind(this);
-    this.toggle24Hours = this.toggle24Hours.bind(this);
-    this.toggleInheritSchedule = this.toggleInheritSchedule.bind(this);
-  }
-
-  toggleInheritSchedule(e) {
-    const { handleScheduleChange, schedule } = this.props;
-    const shouldInheritSchedule = e.target.checked;
-
-    let tempScheduleDays = {};
-    this.setState(
-      ({ scheduleDays }) => {
-        tempScheduleDays = { ...scheduleDays };
-
-        // Services without explicit schedules automatically inherit their
-        // schedule from their parent resource. So, by completely wiping out
-        // the service schedule, the service will fall back to inheriting its
-        // parent's schedule.
-        //
-        // Go through each schedule day item and set the open/close times to null
-        // and the dirty state to true in order to completely wipe the schedule
-        // on save.
-        if (shouldInheritSchedule) {
-          Object.keys(scheduleDays).forEach(day => {
-            const tempDaySchedule = scheduleDays[day].map(curr => ({
-              ...curr,
-              opens_at: null,
-              closes_at: null,
-              openChanged: true,
-              closeChanged: true,
-            }));
-            tempScheduleDays[day] = tempDaySchedule;
-          });
-        } else {
-          tempScheduleDays = buildScheduleDays(schedule);
-        }
-
-        return { scheduleDays: tempScheduleDays, shouldInheritSchedule };
-      },
-      () => {
-        handleScheduleChange(tempScheduleDays);
-      },
-    );
-  }
-
-  addTime(day) {
-    const { handleScheduleChange } = this.props;
-    let tempScheduleDays;
-
-    this.setState(
-      ({ scheduleDays, scheduleId }) => {
-        const tempDaySchedule = scheduleDays[day].map(curr => Object.assign({}, curr));
-        tempDaySchedule.push({ opens_at: null, closes_at: null, scheduleId });
-        tempScheduleDays = Object.assign({}, scheduleDays, { [day]: tempDaySchedule });
-        return { scheduleDays: tempScheduleDays };
-      },
-      () => {
-        handleScheduleChange(tempScheduleDays);
-      },
-    );
-  }
-
-  removeTime(day, index) {
-    const { handleScheduleChange } = this.props;
-    let tempScheduleDays;
-
-    this.setState(
-      ({ scheduleDays }) => {
-        const tempDaySchedule = scheduleDays[day].map(curr => Object.assign({}, curr));
-        Object.assign(tempDaySchedule[index], {
-          opens_at: null,
-          closes_at: null,
-          openChanged: true,
-          closeChanged: true,
-        });
-
-        if (!tempDaySchedule[index].id && tempDaySchedule[index].id !== null) {
-          tempDaySchedule.id = null;
-        }
-
-        tempScheduleDays = Object.assign({}, scheduleDays, { [day]: tempDaySchedule });
-        return { scheduleDays: tempScheduleDays };
-      },
-      () => {
-        handleScheduleChange(tempScheduleDays);
-      },
-    );
-  }
-
-  handleScheduleChange(day, index, field, value) {
-    const { handleScheduleChange } = this.props;
-    let tempScheduleDays;
-
-    this.setState(
-      ({ scheduleDays }) => {
-        const tempDaySchedule = scheduleDays[day].map(curr => Object.assign({}, curr));
-        tempDaySchedule[index][field] = stringToTime(value);
-        const changedField = field === 'opens_at' ? 'openChanged' : 'closeChanged';
-        tempDaySchedule[index][changedField] = true;
-        if (!tempDaySchedule[index].id && tempDaySchedule[index].id !== null) {
-          tempDaySchedule.id = null;
-        }
-        tempScheduleDays = Object.assign({}, scheduleDays, { [day]: tempDaySchedule });
-        return { scheduleDays: tempScheduleDays };
-      },
-      () => {
-        handleScheduleChange(tempScheduleDays);
-      },
-    );
-  }
-
-  // is24Hours: indicates if the current day schedule is open 24 hours
-  toggle24Hours(day, is24Hours) {
-    const { handleScheduleChange } = this.props;
-    let tempScheduleDays;
-    this.setState(
-      ({ scheduleDays, scheduleId }) => {
-        const tempDaySchedule = Object.assign({}, scheduleDays[day][0]);
-
-        if (is24Hours) {
-          Object.assign(tempDaySchedule, {
-            opens_at: null,
-            closes_at: null,
-          });
-        } else {
-          Object.assign(tempDaySchedule, {
-            opens_at: 0,
-            closes_at: 2359,
-          });
-        }
-
-        Object.assign(tempDaySchedule, {
-          openChanged: true,
-          closeChanged: true,
-          scheduleId,
-        });
-
-        if (!tempDaySchedule.id && tempDaySchedule.id !== null) {
-          tempDaySchedule.id = null;
-        }
-
-        tempScheduleDays = Object.assign(
-          {},
-          scheduleDays,
-          { [day]: [tempDaySchedule] },
-        );
-        return { scheduleDays: tempScheduleDays };
-      },
-      () => {
-        handleScheduleChange(tempScheduleDays);
-      },
-    );
+  setScheduleDaysForDay = (day, scheduleDays) => {
+    const { handleScheduleChange, scheduleDaysByDay } = this.props;
+    handleScheduleChange({
+      ...scheduleDaysByDay,
+      [day]: scheduleDays,
+    });
   }
 
   render() {
-    const { scheduleDays: schedule, shouldInheritSchedule } = this.state;
     // This component is shared between organizations and services. Organizations
     // are top level, and cannot inherit schedules. OTOH Services can inherit
     // their schedule from their parent organization. This prop controls this
     // difference in behavior.
-    const { canInheritFromParent } = this.props;
+    const {
+      canInheritFromParent,
+      scheduleDaysByDay,
+      scheduleId,
+      setShouldInheritFromParent,
+      shouldInheritFromParent,
+    } = this.props;
     return (
       <li key="hours" className="edit--section--list--item hours">
         <span className="label">Hours</span>
@@ -194,27 +34,27 @@ class EditSchedule extends Component {
               <input
                 id="inherit"
                 type="checkbox"
-                checked={shouldInheritSchedule}
-                onChange={this.toggleInheritSchedule}
+                checked={shouldInheritFromParent}
+                onChange={() => setShouldInheritFromParent(!shouldInheritFromParent)}
               />
               <label htmlFor="inherit">Inherit schedule from parent organization</label>
             </div>
           )
         }
-        {!shouldInheritSchedule && (
+        {!shouldInheritFromParent && (
           <div>
             <span className="label open-24-label">24 hrs?</span>
             <ul className="edit-hours-list">
               {
-                Object.keys(schedule).map(day => (
+                Object.entries(scheduleDaysByDay).map(([day, scheduleDays]) => (
                   <EditScheduleDay
                     key={day}
                     day={day}
-                    dayHours={schedule[day]}
-                    handleScheduleChange={this.handleScheduleChange}
-                    toggle24Hours={this.toggle24Hours}
-                    addTime={this.addTime}
-                    removeTime={this.removeTime}
+                    scheduleId={scheduleId}
+                    scheduleDays={scheduleDays}
+                    setScheduleDays={
+                      newScheduleDays => this.setScheduleDaysForDay(day, newScheduleDays)
+                    }
                   />
                 ))
               }
@@ -225,4 +65,18 @@ class EditSchedule extends Component {
     );
   }
 }
+
+EditSchedule.propTypes = {
+  scheduleDaysByDay: PropTypes.object.isRequired,
+  canInheritFromParent: PropTypes.bool.isRequired,
+  shouldInheritFromParent: PropTypes.bool.isRequired,
+  setShouldInheritFromParent: PropTypes.func,
+  handleScheduleChange: PropTypes.func.isRequired,
+  scheduleId: PropTypes.number.isRequired,
+};
+
+EditSchedule.defaultProps = {
+  setShouldInheritFromParent: null,
+};
+
 export default EditSchedule;

--- a/app/components/edit/EditScheduleDay.jsx
+++ b/app/components/edit/EditScheduleDay.jsx
@@ -127,10 +127,19 @@ class EditScheduleDay extends Component {
         scheduleId,
       },
     };
+    const remainingScheduleDays = is24Hours
+      ? scheduleDays.slice(1).map(sd => ({
+        ...sd,
+        opens_at: null,
+        closes_at: null,
+        openChanged: true,
+        closeChanged: true,
+      }))
+      : [];
     if (!oldScheduleDay.id && oldScheduleDay.id !== null) {
       newScheduleDay.id = null;
     }
-    setScheduleDays([newScheduleDay]);
+    setScheduleDays([newScheduleDay, ...remainingScheduleDays]);
   }
 
   render() {

--- a/app/components/edit/EditScheduleDay.jsx
+++ b/app/components/edit/EditScheduleDay.jsx
@@ -1,6 +1,82 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { timeToTimeInputValue } from '../../utils/index';
+import { stringToTime, timeToTimeInputValue } from '../../utils/index';
+
+const TimeInputRow = ({
+  dayOfWeekAbbrev, index, scheduleDay, is24Hours, setScheduleDay,
+}) => {
+  const removeTime = () => {
+    const newScheduleDay = {
+      ...scheduleDay,
+      opens_at: null,
+      closes_at: null,
+      openChanged: true,
+      closeChanged: true,
+    };
+    if (!scheduleDay.id && scheduleDay.id !== null) {
+      newScheduleDay.id = null;
+    }
+
+    setScheduleDay(newScheduleDay);
+  };
+
+  const changeOpenOrCloseTime = (field, value) => {
+    const parsedTime = stringToTime(value);
+    const changedField = field === 'opens_at' ? 'openChanged' : 'closeChanged';
+    const newScheduleDay = {
+      ...scheduleDay,
+      [field]: parsedTime,
+      [changedField]: true,
+    };
+    if (!scheduleDay.id && scheduleDay.id !== null) {
+      newScheduleDay.id = null;
+    }
+
+    setScheduleDay(newScheduleDay);
+  };
+  // This checks if a time for a day was deleted, and skips rendering if it was
+  if (index > 0 && scheduleDay.opens_at === null
+     && scheduleDay.closes_at === null
+     && scheduleDay.openChanged === true
+     && scheduleDay.closeChanged === true) {
+    return null;
+  }
+  return (
+    <li key={index}>
+      <p>{ index === 0 && dayOfWeekAbbrev }</p>
+      {is24Hours
+        ? (
+          <div>
+            <p className="open-24-hours">Open 24 hours</p>
+          </div>
+        )
+        : (
+          <div>
+            <input
+              type="time"
+              value={timeToTimeInputValue(scheduleDay.opens_at)}
+              onChange={e => changeOpenOrCloseTime('opens_at', e.target.value)}
+            />
+            <input
+              type="time"
+              value={timeToTimeInputValue(scheduleDay.closes_at)}
+              onChange={e => changeOpenOrCloseTime('closes_at', e.target.value)}
+            />
+            {index > 0 && (
+              <button
+                type="button"
+                onClick={() => removeTime()}
+                className="remove-time icon-button"
+              >
+                <i className="material-icons">delete</i>
+              </button>
+            )}
+          </div>
+        )
+      }
+    </li>
+  );
+};
 
 const DAYS_OF_WEEK = Object.freeze({
   Monday: 'M',
@@ -13,60 +89,57 @@ const DAYS_OF_WEEK = Object.freeze({
 });
 
 class EditScheduleDay extends Component {
-  buildTimeInput(day, index, curr, is24Hours) {
-    // This checks if a time for a day was deleted, and skips rendering if it was
-    if (index > 0 && curr.opens_at === null
-     && curr.closes_at === null
-     && curr.openChanged === true
-     && curr.closeChanged === true) {
-      return null;
+  setScheduleDayForIndex = (index, scheduleDay) => {
+    const { scheduleDays, setScheduleDays } = this.props;
+    const newScheduleDays = [
+      ...scheduleDays.slice(0, index),
+      scheduleDay,
+      ...scheduleDays.slice(index + 1),
+    ];
+    setScheduleDays(newScheduleDays);
+  }
+
+  addTime = () => {
+    const { scheduleDays, scheduleId, setScheduleDays } = this.props;
+    const tempDaySchedule = [
+      ...scheduleDays,
+      { opens_at: null, closes_at: null, scheduleId },
+    ];
+    setScheduleDays(tempDaySchedule);
+  }
+
+  setIs24Hours = is24Hours => {
+    const { scheduleId, scheduleDays, setScheduleDays } = this.props;
+
+    const oldScheduleDay = scheduleDays[0];
+    const newScheduleDay = {
+      ...oldScheduleDay,
+      ...(is24Hours ? {
+        opens_at: 0,
+        closes_at: 2359,
+      } : {
+        opens_at: null,
+        closes_at: null,
+      }),
+      ...{
+        openChanged: true,
+        closeChanged: true,
+        scheduleId,
+      },
+    };
+    if (!oldScheduleDay.id && oldScheduleDay.id !== null) {
+      newScheduleDay.id = null;
     }
-    const { handleScheduleChange, removeTime } = this.props;
-    const abbrev = DAYS_OF_WEEK[day];
-    return (
-      <li key={index}>
-        <p>{ index === 0 && abbrev }</p>
-        {is24Hours
-          ? (
-            <div>
-              <p className="open-24-hours">Open 24 hours</p>
-            </div>
-          )
-          : (
-            <div>
-              <input
-                type="time"
-                value={timeToTimeInputValue(curr.opens_at)}
-                onChange={e => handleScheduleChange(day, index, 'opens_at', e.target.value)}
-              />
-              <input
-                type="time"
-                value={timeToTimeInputValue(curr.closes_at)}
-                onChange={e => handleScheduleChange(day, index, 'closes_at', e.target.value)}
-              />
-              {index > 0 && (
-                <button
-                  type="button"
-                  onClick={() => removeTime(day, index)}
-                  className="remove-time icon-button"
-                >
-                  <i className="material-icons">delete</i>
-                </button>
-              )}
-            </div>
-          )
-        }
-      </li>
-    );
+    setScheduleDays([newScheduleDay]);
   }
 
   render() {
     const {
-      day, addTime, dayHours, toggle24Hours,
+      day, scheduleDays,
     } = this.props;
     let is24Hours = false;
 
-    if (dayHours[0].opens_at === 0 && dayHours[0].closes_at === 2359) {
+    if (scheduleDays[0].opens_at === 0 && scheduleDays[0].closes_at === 2359) {
       is24Hours = true;
     }
 
@@ -74,14 +147,23 @@ class EditScheduleDay extends Component {
       <div className="day-group">
         <div className="hours">
           {
-            dayHours.map((curr, i) => (
-              this.buildTimeInput(day, i, curr, is24Hours)
+            scheduleDays.map((scheduleDay, index) => (
+              <TimeInputRow
+                key={index /* eslint-disable-line react/no-array-index-key */}
+                dayOfWeekAbbrev={DAYS_OF_WEEK[day]}
+                index={index}
+                scheduleDay={scheduleDay}
+                is24Hours={is24Hours}
+                setScheduleDay={
+                  newScheduleDay => this.setScheduleDayForIndex(index, newScheduleDay)
+                }
+              />
             ))
           }
         </div>
         <div className="add-time">
           {!is24Hours && (
-            <button type="button" className="icon-button" onClick={() => addTime(day)}>
+            <button type="button" className="icon-button" onClick={this.addTime}>
               <i className="material-icons">add</i>
             </button>
           )}
@@ -90,7 +172,7 @@ class EditScheduleDay extends Component {
           <input
             type="checkbox"
             checked={is24Hours}
-            onChange={() => toggle24Hours(day, is24Hours)}
+            onChange={() => this.setIs24Hours(!is24Hours)}
           />
         </div>
       </div>
@@ -99,15 +181,12 @@ class EditScheduleDay extends Component {
 }
 
 EditScheduleDay.propTypes = {
-  dayHours: PropTypes.arrayOf(PropTypes.shape({
+  scheduleDays: PropTypes.arrayOf(PropTypes.shape({
     closes_at: PropTypes.number,
     opens_at: PropTypes.number,
   })).isRequired,
-  addTime: PropTypes.func.isRequired,
-  toggle24Hours: PropTypes.func.isRequired,
-  removeTime: PropTypes.func.isRequired,
-  handleScheduleChange: PropTypes.func.isRequired,
   day: PropTypes.string.isRequired,
+  setScheduleDays: PropTypes.func.isRequired,
 };
 
 export default EditScheduleDay;

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -4,6 +4,7 @@ import EditNotes from './EditNotes';
 import EditSchedule from './EditSchedule';
 import MultiSelectDropdown from './MultiSelectDropdown';
 import FormTextArea from './FormTextArea';
+import { buildScheduleDays } from '../../pages/OrganizationEditPage';
 
 
 const InputField = ({
@@ -66,6 +67,34 @@ const ProvidedService = ({
   const handleChange = (field, value) => {
     const { id } = service;
     editServiceById(id, { id, [field]: value });
+  };
+
+  const setShouldInheritScheduleFromParent = shouldInherit => {
+    const { scheduleObj: scheduleDaysByDay } = service;
+
+    let tempScheduleDays = {};
+
+    if (shouldInherit) {
+      tempScheduleDays = Object.entries(scheduleDaysByDay).reduce(
+        (acc, [day, scheduleDays]) => (
+          {
+            ...acc,
+            [day]: scheduleDays.map(scheduleDay => ({
+              ...scheduleDay,
+              opens_at: null,
+              closes_at: null,
+              openChanged: true,
+              closeChanged: true,
+            })),
+          }
+        ),
+        {},
+      );
+    } else {
+      tempScheduleDays = buildScheduleDays(service.schedule);
+    }
+    handleChange('shouldInheritScheduleFromParent', shouldInherit);
+    handleChange('scheduleObj', tempScheduleDays);
   };
 
   return (
@@ -162,7 +191,10 @@ const ProvidedService = ({
 
         <EditSchedule
           canInheritFromParent
-          schedule={service.schedule}
+          shouldInheritFromParent={service.shouldInheritScheduleFromParent}
+          setShouldInheritFromParent={setShouldInheritScheduleFromParent}
+          scheduleId={service.schedule.id}
+          scheduleDaysByDay={service.scheduleObj}
           handleScheduleChange={value => handleChange('scheduleObj', value)}
         />
 
@@ -198,6 +230,7 @@ ProvidedService.propTypes = {
     required_documents: PropTypes.string,
     application_process: PropTypes.string,
     long_description: PropTypes.string,
+    shouldInheritScheduleFromParent: PropTypes.bool.isRequired,
   }).isRequired,
   handleDeactivation: PropTypes.func.isRequired,
   editServiceById: PropTypes.func.isRequired,

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -12,7 +12,6 @@ import EditSchedule from '../components/edit/EditSchedule';
 import EditPhones from '../components/edit/EditPhones';
 import EditSidebar from '../components/edit/EditSidebar';
 import * as dataService from '../utils/DataService';
-import { createTemplateSchedule } from '../utils/index';
 
 import './OrganizationEditPage.scss';
 
@@ -302,6 +301,8 @@ const handleCancel = () => {
   browserHistory.goBack();
 };
 
+const deepClone = obj => JSON.parse(JSON.stringify(obj));
+
 export class OrganizationEditPage extends React.Component {
   constructor(props) {
     super(props);
@@ -388,7 +389,7 @@ export class OrganizationEditPage extends React.Component {
     const { resource } = this.state;
     const newServices = [];
     Object.entries(servicesObj).forEach(([key, value]) => {
-      const currentService = value;
+      const currentService = deepClone(value);
       if (key < 0) {
         if (currentService.notesObj) {
           const notes = Object.values(currentService.notesObj.notes);
@@ -408,6 +409,7 @@ export class OrganizationEditPage extends React.Component {
         delete currentService.notesObj;
         postSchedule(currentService.scheduleObj, promises);
         delete currentService.scheduleObj;
+        delete currentService.shouldInheritScheduleFromParent;
         if (!_.isEmpty(currentService)) {
           promises.push(dataService.post(uri, { change_request: currentService }));
         }
@@ -448,8 +450,10 @@ export class OrganizationEditPage extends React.Component {
       id: nextServiceId,
       notes: [],
       schedule: {
-        schedule_days: createTemplateSchedule(),
+        schedule_days: [],
       },
+      scheduleObj: buildScheduleDays(undefined),
+      shouldInheritScheduleFromParent: true,
     };
     this.setState({
       services: { ...services, [nextServiceId]: newService },

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -75,6 +75,70 @@ function updateCollectionObject(object, id, path, promises) {
   );
 }
 
+/** Build UI state schedule from API schedule.
+ *
+ * The difference between the schedule that comes from the API and the schedule
+ * that is saved as React UI state is that the UI state schedule's schema groups
+ * ScheduleDays by day of week. This allows us to represent blank ScheduleDays
+ * when a new, blank time is added but before an open time or a close time is
+ * set. The API schedule schema does not support having a ScheduleDay that has
+ * no open and close time but that is attached to a day of week. This feature is
+ * required for the UI because the blank time needs to appear under a day of
+ * week before an open and close time is set.
+ */
+const buildScheduleDays = schedule => {
+  const scheduleId = schedule ? schedule.id : null;
+  const currSchedule = {};
+  let finalSchedule = {};
+
+  const is24Hours = {
+    Monday: false,
+    Tuesday: false,
+    Wednesday: false,
+    Thursday: false,
+    Friday: false,
+    Saturday: false,
+    Sunday: false,
+  };
+
+  const tempSchedule = {
+    Monday: [{ opens_at: null, closes_at: null, scheduleId }],
+    Tuesday: [{ opens_at: null, closes_at: null, scheduleId }],
+    Wednesday: [{ opens_at: null, closes_at: null, scheduleId }],
+    Thursday: [{ opens_at: null, closes_at: null, scheduleId }],
+    Friday: [{ opens_at: null, closes_at: null, scheduleId }],
+    Saturday: [{ opens_at: null, closes_at: null, scheduleId }],
+    Sunday: [{ opens_at: null, closes_at: null, scheduleId }],
+  };
+
+  if (schedule) {
+    schedule.schedule_days.forEach(day => {
+      const currDay = day.day;
+      if (!is24Hours[currDay]) {
+        // Check to see if any of the hour pairs for the day
+        // indicate the resource/service is open 24 hours
+        // if there is a pair only have that in the day obj
+        if (day.opens_at === 0 && day.closes_at === 2359) {
+          is24Hours[currDay] = true;
+          // Since this record already exists in our DB, we only need the id
+          // scheduleID is needed when creating no data
+          currSchedule[currDay] = [{ opens_at: 0, closes_at: 2359, id: day.id }];
+        } else {
+          Object.assign(day, { openChanged: false, closeChanged: false });
+          if (currSchedule[currDay]) {
+            currSchedule[day.day].unshift(day);
+          } else {
+            currSchedule[day.day] = [day];
+          }
+        }
+      }
+    });
+  }
+  finalSchedule = Object.assign({}, tempSchedule, currSchedule);
+  return finalSchedule;
+}
+export { buildScheduleDays };
+
 /**
  * Create a change request for a new object.
  */

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -348,7 +348,7 @@ export class OrganizationEditPage extends React.Component {
     window.addEventListener('beforeunload', this.keepOnPage);
     if (splitPath[splitPath.length - 1] === 'new') {
       this.setState({
-        newResource: true, resource: {},
+        newResource: true, resource: { schedule: {}, scheduleObj: buildScheduleDays(undefined) },
       });
     }
     const resourceID = query.resourceid;

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -85,21 +85,6 @@ export function daysOfTheWeek() {
   ];
 }
 
-export function createTemplateSchedule() {
-  const daysTemplate = [];
-  for (let i = 0; i < daysOfTheWeek().length; i += 1) {
-    const day = daysOfTheWeek()[i];
-    daysTemplate.push({
-      day,
-      opens_at: null,
-      closes_at: null,
-      id: i + 1,
-    });
-  }
-
-  return daysTemplate;
-}
-
 export function sortScheduleDays(scheduleDays) {
   const days = daysOfTheWeek();
   return scheduleDays.sort((a, b) => (


### PR DESCRIPTION
## Overview

This is hopefully the final of all the refactoring PRs that I'm doing before I can finally work on https://github.com/ShelterTechSF/askdarcel-web/issues/647.

With this PR, all of the React state related to schedules on the Edit page will be moved up to the top level, which ensures a single canonical representation of schedule-based state on the page. This, I believe, is a vast improvement over the old version of code, where the schedule state was represented at four different levels, and they all had to be kept in sync with each other, which made changing the representation of the schedule very difficult.

## What was changed

Just to recap, here's what the Component hierarchy on the Edit page looks like:

- OrganizationEditPage
  - EditSchedule (for the resource)
  - EditServices (wraps the collection of all services)
    - ProvidedService (represents just a single service)
      - EditSchedule (for the service)

EditSchedule itself has the following hierarchy:

- EditSchedule
  - EditScheduleDay (which represents each day of the week, and can actually contain more than one "ScheduleDay", where "ScheduleDay" in this context actually means a single time range. Lots of confusion arises from reusing the same word to sometimes mean just one time range and othertimes multiple time ranges)

Previously, EditServices had the state that represents the whole schedule, and I moved it up to the top level. The original execution order was confusing because the state was also already being duplicated back to the top-level component, but only open actually making an edit to a schedule. Now the state lives _only_ at the top level and it is created at component construction time, not only when a schedule is actually edited.

There were several event handler methods that would mutate the state of EditServices, and I have split them up such that each event handler lives in the component that actually uses them, but each component has an internal helper method that gets passed in that allows them to modify a slice of the parent component's state. Let me explain with an example.

The EditSchedule component is passed in a prop that lets it set the values of the entire schedule state, which is mostly represented with a mapping from day of week to a list of ScheduleDays. The EditSchedule component passes a setter method prop to EditSchedule day which is only allowed to modify the list of ScheduleDays for a particular day of the week, without allowing it to modify any of the other days of the week. EditScheduleDay itself now has a new subcomponent named TimeInputRow, which is only responsible for a single ScheduleDay, and EditScheduleDay passes a setter prop to TimeInputRow that only allows it to modify a single ScheduleDay.

This hierarchy allows us to pass a smaller set of state editing functions to each subcomponent while also allowing for the flexibility of subcomponents to construct more specific state editing methods. With a single `setScheduleDaysForDayOfWeek()`, a subcomponent can add/remove new time ranges, edit existing time ranges, etc.

I have hopefully done all this correctly, which was at least simplified via my earlier efforts of getting rid of state in the EditServices and ProvidedService components.

### How this was tested

Here's the checklist of scenarios that I have tested:

- Edit Resource
  - [x] Add a second ScheduleDay to a day of the week
  - [x] Remove a second ScheduleDay from a day of the week
  - [x] Remove all ScheduleDays from a single day of the week
  - [x] Edit a ScheduleDay's open time
  - [x] Edit a ScheduleDay's close time
  - [x] Change a day of the week with one ScheduleDay to be 24 hours
  - [x] Change a day of the week with multiple ScheduleDays to be 24 hours (all but one ScheduleDay should be deleted)
  - [x] Change a day of the week from being 24 hours to having a set time
- Edit Service
  - [x] Add a second ScheduleDay to a day of the week
  - [x] Remove a second ScheduleDay from a day of the week
  - [x] Remove all ScheduleDays from a single day of the week
  - [x] Edit a ScheduleDay's open time
  - [x] Edit a ScheduleDay's close time
  - [x] Change a day of the week with one ScheduleDay to be 24 hours
  - [x] Change a day of the week with multiple ScheduleDays to be 24 hours (all but one ScheduleDay should be deleted)
  - [x] Change a day of the week from being 24 hours to having a set time
  - [x] Set service schedule to inherit from resource
  - [x] Set service schedule to no longer inherit from resource
  - [x] Creating a new Service should allow for the above operations to still succeed
- Create New Resource
  - [x] Only sanity checked that the page isn't broken (because it actually was and I at least fixed it enough to pass the one failing TestCafe test)