### PR TITLE
Add "Name" field to addresses (#305)

### DIFF
--- a/app/components/edit/EditAddress.jsx
+++ b/app/components/edit/EditAddress.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
 
 const hasNoLocation = address => {
-  const someFieldExistsOrNewAddress = typeof address === 'undefined' || address.address_1 !== ''
-    || address.address_2 !== '' || address.address_1 !== '' || address.address_3 !== ''
+  const someFieldExistsOrNewAddress = typeof address === 'undefined'
+    || address.name !== '' || address.address_1 !== ''
+    || address.address_2 !== '' || address.address_3 !== ''
     || address.address_4 !== '' || address.city !== '' || address.postal_code !== ''
     || address.state_province !== '' || address.country !== '';
   if (someFieldExistsOrNewAddress) {
@@ -39,6 +40,7 @@ class EditAddress extends Component {
         newAddr = address;
       } else {
         newAddr = {
+          name: '',
           address_1: '',
           address_2: '',
           address_3: '',
@@ -87,6 +89,14 @@ const AddressForm = ({
     {!noLocation
         && (
           <div>
+            <input
+              type="text"
+              className="input"
+              placeholder="Name"
+              data-field="name"
+              defaultValue={address.name}
+              onChange={handleAddressChange}
+            />
             <input
               type="text"
               className="input"

--- a/app/components/listing/ResourceInfos.jsx
+++ b/app/components/listing/ResourceInfos.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import config from '../../config';
@@ -30,39 +30,48 @@ ResourceCategories.propTypes = {
 };
 
 
+// Given an address object, returns a React DOM element that displays the
+// address on up to three lines:
+//
+//   <name>
+//   <address_1>, <address_2>
+//   <city>, <state_province>, <postal_code>
+//
+// Example 1:
+//
+//   123 Fourth Street
+//   San Francisco, CA, 94115
+//
+// Example 2:
+//
+//   SF Headquarters
+//   567 Eighth Street, Suite 201
+//   San Francisco, CA, 94115
+//
 function buildLocation(address) {
-  let line1 = '';
-  let line2 = '';
+  if (!address) return;
 
-  if (address) {
-    if (address.address_1) {
-      line1 += address.address_1;
+  const fieldsOnEachLine = [
+    ['name'],
+    ['address_1', 'address_2'],
+    ['city', 'state_province', 'postal_code'],
+  ];
+
+  return fieldsOnEachLine.map(fields => {
+    const line = fields.map(field => address[field])
+                   .filter(Boolean)
+                   .join(', ');
+    if (line.length > 0) {
+      const key = fields.join('-');
+
+      return (
+        <Fragment key={key}>
+          <span>{line}</span>
+          <br />
+        </Fragment>
+      );
     }
-
-    if (address.address_2) {
-      line1 += `, ${address.address_2}`;
-    }
-
-    if (address.city) {
-      line2 += address.city;
-    }
-
-    if (address.state_province) {
-      line2 += `, ${address.state_province}`;
-    }
-
-    if (address.postal_code) {
-      line2 += `, ${address.postal_code}`;
-    }
-  }
-
-  return (
-    <span>
-      {line1}
-      <br />
-      {line2}
-    </span>
-  );
+  });
 }
 
 function AddressInfo(props) {

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -24,6 +24,7 @@ test('Edit resource name', async t => {
 
 test('Edit resource address', async t => {
   const newProps = {
+    name: 'Main HQ',
     address1: '123 Fake St.',
     address2: 'Suite 456',
     address3: 'Room 789',

--- a/testcafe/pages/EditPage.js
+++ b/testcafe/pages/EditPage.js
@@ -3,6 +3,7 @@ import { ReactSelector } from 'testcafe-react-selectors';
 class EditAddress {
   constructor() {
     const baseSelector = ReactSelector('EditAddress');
+    this.name = baseSelector.find('input').withAttribute('data-field', 'name');
     this.address1 = baseSelector.find('input').withAttribute('data-field', 'address_1');
     this.address2 = baseSelector.find('input').withAttribute('data-field', 'address_2');
     this.address3 = baseSelector.find('input').withAttribute('data-field', 'address_3');


### PR DESCRIPTION
Allow users to include a "Name" field when editing an address. This is
useful for resources/services with multiple locations.

See also: https://github.com/ShelterTechSF/askdarcel-api/pull/421