### PR TITLE
General styling clean up of resource page

### DIFF
--- a/app/pages/OrganizationListingPage.jsx
+++ b/app/pages/OrganizationListingPage.jsx
@@ -112,28 +112,18 @@ export class OrganizationListingPage extends React.Component {
                     {isMOHCDFunded && (<img className="mohcd-funded" src={MOHCDFunded} alt="Verified by MOHCD" />)}
                   </div>
                   <h1 className="org--main--header--title">{resource.name}</h1>
-                  <div className="org--main--header--rating disabled-feature">
-                    <p className="excellent">
-                      <i className="material-icons">sentiment_very_satisfied</i>
-                      <i className="material-icons">sentiment_very_satisfied</i>
-                      <i className="material-icons">sentiment_very_satisfied</i>
-                      <i className="material-icons">sentiment_very_satisfied</i>
-                      <i className="material-icons">sentiment_very_satisfied</i>
-                    </p>
-                  </div>
                   <div className="org--main--header--hours">
                     <RelativeOpeningTime schedule={resource.schedule} />
                   </div>
                   <div className="org--main--header--phone">
                     <PhoneNumber phones={resource.phones} />
                   </div>
-                  <div className="org--main--header--description">
-                    <header>About this resource</header>
-                    <ReactMarkdown className="rendered-markdown" source={resource.long_description || resource.short_description || 'No Description available'} />
-                  </div>
                 </header>
-
                 <MobileActionBar resource={resource} />
+                <div className="org--main--header--description">
+                  <h2>About this Organization</h2>
+                  <ReactMarkdown className="rendered-markdown" source={resource.long_description || resource.short_description || 'No Description available'} />
+                </div>
 
                 <section className="service--section" id="services">
                   <header className="service--section--header">

--- a/app/styles/components/_listing-page.scss
+++ b/app/styles/components/_listing-page.scss
@@ -149,7 +149,7 @@
 // ORG SERVICES
 
 .service--section {
-  margin-top: calc-em(50px);
+  margin-top: calc-em(20px);
   &--header {
   	border-bottom: 1px solid #DDDDDD;
   	h4 {

--- a/app/styles/components/_org-page.scss
+++ b/app/styles/components/_org-page.scss
@@ -28,11 +28,25 @@
 		align-items: stretch;
 		align-content: stretch;
 	}
+  section {
+    margin-top: calc-em(50px);
+  }
+
+  h2 {
+    font-size: 1.2em;
+    color: $color-grey7;
+  }
   @include r_max($break-tablet-s) {
     margin-top: 0;
       &--left {
         border-right: none;
         width: 100%;
+      }
+      section {
+        margin-top: calc-em(20px);
+      }
+      h2 {
+        font-size: 1em;
       }
   }
 }
@@ -81,7 +95,9 @@
 			margin-top: calc-em(10px);
 		}
     @include r_max($break-tablet-s) {
-      padding-bottom: calc-em(20px);
+      margin-top: 0;
+      padding-bottom: 0;
+      border-top: none;
     }
 	}
 	.badges {
@@ -94,13 +110,15 @@
     	margin: 10px auto;
     }
 	}
+  @include r_max($break-tablet-s) {
+    padding: 0 0 calc-em(20px) 0;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // ORG SERVICES
 
 .service--section {
-  margin-top: calc-em(50px);
   &--header {
   	border-bottom: 1px solid #DDDDDD;
   	h4 {
@@ -183,7 +201,6 @@
 // ORG INFO
 
 .info--section {
-	margin-top: calc-em(50px);
 	.info {
 		margin-top: calc-em(30px);
 		display: flex;
@@ -219,7 +236,6 @@
 // ORG Location
 
 .location--section {
-	margin-top: calc-em(50px);
   .map {
     margin-top: calc-em(30px);
   }


### PR DESCRIPTION
Moved the mobile actions bar (`Call`, `Directions`, `Edit`) up to the correct place. Cleaned up padding between sections.

BEFORE
<img width="356" alt="Screen Shot 2019-07-01 at 9 38 10 PM" src="https://user-images.githubusercontent.com/7386336/60483012-969d9980-9c48-11e9-8e7d-572a087f4b39.png">

AFTER
<img width="346" alt="Screen Shot 2019-07-01 at 10 08 43 PM" src="https://user-images.githubusercontent.com/7386336/60484043-d6ff1680-9c4c-11e9-8a79-26aa19cc70a7.png">


