### PR TITLE
Fix lint for SearchTabView component.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,7 +13,6 @@ app/components/search/ResourcesRow.jsx
 app/components/search/ResourcesTable.jsx
 app/components/search/SearchMap.jsx
 app/components/search/SearchTabHelper.jsx
-app/components/search/SearchTabView.jsx
 app/components/search/SearchTable.jsx
 app/components/ui/Accordion/Accordion.jsx
 app/components/ui/Accordion/AccordionItem.jsx

--- a/app/components/search/SearchTabView.jsx
+++ b/app/components/search/SearchTabView.jsx
@@ -1,62 +1,37 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import SearchTabHelper from './SearchTabHelper';
-import TableOfOpeningTimes from '../listing/TableOfOpeningTimes';
-import { timeToString } from '../../utils/index';
 
 class SearchTabView extends React.Component {
   constructor(props) {
     super(props);
     this.state = { active: 'Description' };
-    // this.getSchedule = this.getSchedule.bind(this);
-  }
-
-  // @Deprecated for now
-  getSchedule(scheduleInfo) {
-    if (!scheduleInfo) {
-      return 'No hours listed';
-    }
-    return (
-      <table className="compact">
-        <tbody>
-          { scheduleInfo.map(sched => (
-            <tr key={sched.day}>
-              <th>{ sched.day }</th>
-              <td>
-                { timeToString(sched.opens_at) }
--
-                { timeToString(sched.closes_at) }
-              </td>
-            </tr>
-          )) }
-        </tbody>
-      </table>
-    );
   }
 
   getTabList() {
     const { applicationProcess, description } = this.props;
 
-    const tabs = [[ 'Description', description ], [ 'How To Apply', applicationProcess ]];
+    const tabs = [['Description', description], ['How To Apply', applicationProcess]];
 
     return tabs
-      .filter(([title, content]) => content)
+      .filter(([, content]) => content)
       .map(([title, content]) => ({
-        title: title,
-        content: <ReactMarkdown className="rendered-markdown" source={ content } />
+        title,
+        content: <ReactMarkdown className="rendered-markdown" source={content} />,
       }));
   }
 
   render() {
+    const { active } = this.state;
     const tabs = this.getTabList();
-    const activeTab = tabs.find(tab => tab.title === this.state.active);
+    const activeTab = tabs.find(tab => tab.title === active);
 
     return (
       <div className="service-entry-additional-info">
         <div className="service-entry-tabs">
           <SearchTabHelper
-            active={this.state.active}
-            onChange={active => this.setState({ active })}
+            active={active}
+            onChange={newActive => this.setState({ active: newActive })}
           >
             { tabs.map(tab => <div key={tab.title}>{ tab.title }</div>) }
           </SearchTabHelper>


### PR DESCRIPTION
This is a little bit of refactoring I'm doing to make it easier to unify the representation of times, since there are some unused codepaths in the `SearchTabView` that the linter will flag.