### PR TITLE
824 - Remove HAP badge from resource page

### DIFF
--- a/app/components/layout/OrganizationCard.jsx
+++ b/app/components/layout/OrganizationCard.jsx
@@ -26,7 +26,6 @@ class OrganizationCard extends React.Component {
             {/* TODO Walking distance */}
           </h4>
           {/* TODO Add Rating */}
-          {/* TODO HAP Certification */}
           <p>{ this.calculateShortDescription(org) }</p>
         </header>
       </Link>

--- a/app/pages/OrganizationListingPage.jsx
+++ b/app/pages/OrganizationListingPage.jsx
@@ -19,7 +19,6 @@ import { RelativeOpeningTime } from 'components/listing/RelativeOpeningTime';
 import Services from 'components/listing/Services';
 import Notes from 'components/listing/Notes';
 import MOHCDBadge from 'components/listing/MOHCDBadge';
-import HAPBadge from 'components/listing/HAPBadge';
 import Loader from 'components/ui/Loader';
 import * as dataService from '../utils/DataService';
 import { isSFServiceGuideSite } from '../utils/whitelabel';
@@ -129,7 +128,6 @@ export class OrganizationListingPage extends React.Component {
                 <div className="org--main--header--description">
                   <h2>About this Organization</h2>
                   <ReactMarkdown className="rendered-markdown" source={resource.long_description || resource.short_description || 'No Description available'} />
-                  <HAPBadge resource={resource} />
                 </div>
 
                 <section className="service--section" id="services">

--- a/app/pages/ServiceListingPage.jsx
+++ b/app/pages/ServiceListingPage.jsx
@@ -20,7 +20,6 @@ import ReactMarkdown from 'react-markdown';
 import Helmet from 'react-helmet';
 import 'react-tippy/dist/tippy.css';
 import MOHCDBadge from 'components/listing/MOHCDBadge';
-import HAPBadge from 'components/listing/HAPBadge';
 import { isSFServiceGuideSite } from '../utils/whitelabel';
 
 // TODO This should be serviceAtLocation
@@ -125,7 +124,6 @@ class ServicePage extends React.Component {
                     attribution={resource.source_attribution}
                     status={resource.status}
                   />
-                  <HAPBadge resource={service} />
                 </section>
 
                 {details.length ? (


### PR DESCRIPTION
Remove HAP verified badge.

## Before

<img width="1390" alt="Screen Shot 2019-08-11 at 3 41 51 PM" src="https://user-images.githubusercontent.com/7386336/62840396-ebbcca00-bc4e-11e9-8720-5e36b54eb168.png">

## After

<img width="1390" alt="Screen Shot 2019-08-11 at 3 41 05 PM" src="https://user-images.githubusercontent.com/7386336/62840398-ef505100-bc4e-11e9-8ef3-64ed2d250579.png">

Note that this component was also in the service listing page, but it doesn't look like it was ever actually rendering since the verification lives at the resource level. Went ahead and removed the component anyway.
