### PR TITLE
Fail gracefully if opens_at or closes_at is null.

### DIFF
--- a/app/init.jsx
+++ b/app/init.jsx
@@ -14,6 +14,10 @@ require('./styles/main.scss');
 
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({ dsn: `https://${config.SENTRY_PUBLIC_KEY}@sentry.io/${config.SENTRY_PROJECT_ID}` });
+} else {
+  // If Sentry is not enabled, use console instead.
+  Sentry.captureException = e => console.error(e);
+  Sentry.captureMessage = m => console.error(m);
 }
 
 const store = configureStore();


### PR DESCRIPTION
@derekfidler pointed out that searching for the word "shelter" on prod causes the page to crash with the following error:

```
TypeError: Cannot read property 'toString' of null
    at xi (transformSchedule.js:26)
    at ki (transformSchedule.js:37)
... many more stack frames
```

It looks like this is caused by some bad schedules in prod, where the closes_at time is null. Specifically, this is bad data in Algolia, and not necessarily our DB. I think our DB doesn't even allow for null values there, so it's probably from an old sync on prod. I have the ID of a service in prod that has this issue: 299.

The fix I have here puts a try/catch around the part of the code that attempts to parse the opens_at/closes_at integer into a time object. The calling code already handles the case where it is null, so I didn't have to change anything there. This will allow the app to attempt to make use of as much valid data as possible while throwing away any invalid data.

In order to not silently hide errors from us, I added some explicit Sentry logging calls so that even if the error is not visible to the user, we should still get an alert for it.

The way I tested this was by faking out my local Algolia index to have a service with a null closes_at time, which allowed me to reproduce this.