### PR TITLE
780 show all eligibility items on homepage rather than scroll. Keep s…

### DIFF
--- a/app/styles/components/_landing-page-eligibility-block.scss
+++ b/app/styles/components/_landing-page-eligibility-block.scss
@@ -63,14 +63,16 @@
   align-content: flex-start;
   display: flex;
   flex-direction: column;
-  flex-flow: column wrap;
-  max-height: 200px;
+  flex-flow: wrap;
   overflow-x: auto;
   overflow-y: hidden;
   overflow: -moz-scrollbars-none;
   position: relative;
   margin: 0 -5px;  // Set negative margin to allow for box-shadow to be visible
-
+  @include r_max($break-tablet-p) {
+    flex-flow: column wrap;
+    max-height: 200px;
+  }
   &::-webkit-scrollbar {
     width: 0 !important
   }


### PR DESCRIPTION
…croll on mobile

this is a minor UI tweak, which, on the homepage, will wrap eligibilities to new rows rather than scrolling. the eligibility items on screens < 960px (our $break-tablet-p break point) will scroll as before.

### **Desktop adds extra rows (i just duped the UI els for development purposes):**
![image](https://user-images.githubusercontent.com/3012520/63821395-bcba7f80-c901-11e9-96f9-0b1ed3ceb956.png)

### **Mobile maintains scroll:** 
![image](https://user-images.githubusercontent.com/3012520/63821350-854bd300-c901-11e9-9d03-59f9adc7eb3c.png)

### **Mobile two:** 
![image](https://user-images.githubusercontent.com/3012520/63821388-aca2a000-c901-11e9-8b49-a31ffa059e49.png)


