### PR TITLE
fix(search): fix issue with showing open now or closed now

### DIFF
--- a/app/components/search/SearchResultsContainer.jsx
+++ b/app/components/search/SearchResultsContainer.jsx
@@ -50,7 +50,7 @@ const SearchResultsContainer = ({ searchState, searchResults, searching }) => {
             <Filtering />
           </div>
           <SearchTable
-            hits={searchResults.hits}
+            hits={hits}
             page={searchResults.page}
             hitsPerPage={searchResults.hitsPerPage}
           />


### PR DESCRIPTION
In the current version on master, the green or red "Open Now" or "Closed Now" is missing from the search result entries.

This looks like it may have been a bug in the adjustment of this block of code, adjusting it in this way seems to make the page work correctly, but please take a look if you could, thanks.