### PR TITLE
[442] Fixed the listing page incorrectly displaying hours when hours are unknown

### DIFF
--- a/app/components/listing/DetailedHours.jsx
+++ b/app/components/listing/DetailedHours.jsx
@@ -5,19 +5,21 @@ import { RecurringSchedule } from '../../utils/RecurringSchedule';
 const DetailedHours = ({ recurringSchedule }) => (
   <span className="weekly-hours-list">
     {
-      (recurringSchedule.hoursKnown
-        && recurringSchedule.intervals.map(interval => (
-          <div key={interval.key()} className="weekly-hours-list--item">
-            <span className="weekly-hours-list--item--day">{interval.opensAt.dayString()}</span>
-            <span className="weekly-hours-list--item--hours">
-              { interval.is24Hours()
-                ? '24 Hours'
-                : `${interval.opensAt.timeString()} - ${interval.closesAt.timeString()}`
-              }
-            </span>
-          </div>
-        )))
-      || (<div className="weekly-hours-list--item">Call for Hours</div>)
+      (
+        recurringSchedule.hoursKnown
+          ? (recurringSchedule.intervals.map(interval => (
+            <div key={interval.key()} className="weekly-hours-list--item">
+              <span className="weekly-hours-list--item--day">{interval.opensAt.dayString()}</span>
+              <span className="weekly-hours-list--item--hours">
+                { interval.is24Hours()
+                  ? '24 Hours'
+                  : `${interval.opensAt.timeString()} - ${interval.closesAt.timeString()}`
+                }
+              </span>
+            </div>
+          )))
+          : (<div className="weekly-hours-list--item">Call for Hours</div>)
+      )
     }
   </span>
 );

--- a/app/components/listing/DetailedHours.jsx
+++ b/app/components/listing/DetailedHours.jsx
@@ -4,17 +4,21 @@ import { RecurringSchedule } from '../../utils/RecurringSchedule';
 
 const DetailedHours = ({ recurringSchedule }) => (
   <span className="weekly-hours-list">
-    {recurringSchedule.intervals.map(interval => (
-      <div key={interval.key()} className="weekly-hours-list--item">
-        <span className="weekly-hours-list--item--day">{interval.opensAt.dayString()}</span>
-        <span className="weekly-hours-list--item--hours">
-          { interval.is24Hours()
-            ? '24 Hours'
-            : `${interval.opensAt.timeString()} - ${interval.closesAt.timeString()}`
-          }
-        </span>
-      </div>
-    ))}
+    {
+      (recurringSchedule.hoursKnown
+        && recurringSchedule.intervals.map(interval => (
+          <div key={interval.key()} className="weekly-hours-list--item">
+            <span className="weekly-hours-list--item--day">{interval.opensAt.dayString()}</span>
+            <span className="weekly-hours-list--item--hours">
+              { interval.is24Hours()
+                ? '24 Hours'
+                : `${interval.opensAt.timeString()} - ${interval.closesAt.timeString()}`
+              }
+            </span>
+          </div>
+        )))
+      || (<div className="weekly-hours-list--item">Call for Hours</div>)
+    }
   </span>
 );
 

--- a/app/components/listing/RelativeOpeningTime.jsx
+++ b/app/components/listing/RelativeOpeningTime.jsx
@@ -16,7 +16,9 @@ const STATUS_CAUTION = 'status-amber';
  */
 const getRelativeOpeningTime = (recurringSchedule, currentDate) => {
   if (!recurringSchedule) return { text: '', classes: '' };
-
+  if (!recurringSchedule.hoursKnown) {
+    return { text: 'Call for Hours', classes: STATUS_CAUTION };
+  }
   if (recurringSchedule.isOpen24_7()) {
     return { text: 'Open 24/7', classes: STATUS_OPEN };
   }


### PR DESCRIPTION
The org resource pages were showing things like "Open Now" when they had schedules marked with unknown hours.

<img width="500" alt="Screen Shot 2019-08-27 at 10 36 51 PM" src="https://user-images.githubusercontent.com/834403/63828882-b5ed3600-c91c-11e9-9df5-9eafe650f5d3.png">

This resolves this and the services inside the resource page still listing their schedules (even if they had "hours unknown" schedules.)

<img width="500" alt="Screen Shot 2019-08-27 at 10 42 41 PM" src="https://user-images.githubusercontent.com/834403/63828884-b7b6f980-c91c-11e9-80d7-f3a8f2b8ba41.png">
