### PR TITLE
Added a null/undefined check for schedules with nil intervals.

### DIFF
--- a/app/components/listing/RelativeOpeningTime.jsx
+++ b/app/components/listing/RelativeOpeningTime.jsx
@@ -29,30 +29,31 @@ const getRelativeOpeningTime = (recurringSchedule, currentDate) => {
   });
 
   const nearestInterval = recurringSchedule.findNearestInterval(currentRecurringTime);
-
-  if (nearestInterval.overlapsTime(currentRecurringTime)) {
-    if (nearestInterval.is24Hours()) {
-      return { text: 'Open 24h today', classes: STATUS_OPEN };
+  if (nearestInterval) {
+    if (nearestInterval.overlapsTime(currentRecurringTime)) {
+      if (nearestInterval.is24Hours()) {
+        return { text: 'Open 24h today', classes: STATUS_OPEN };
+      }
+      const closesIn = nearestInterval.closesAt.difference(currentRecurringTime);
+      if (closesIn <= Duration.fromMinutes(30)) {
+        return { text: `Closes in ${closesIn.asMinutes()} mins`, classes: STATUS_CAUTION };
+      }
+      return { text: 'Open Now', classes: STATUS_OPEN };
     }
-    const closesIn = nearestInterval.closesAt.difference(currentRecurringTime);
-    if (closesIn <= Duration.fromMinutes(30)) {
-      return { text: `Closes in ${closesIn.asMinutes()} mins`, classes: STATUS_CAUTION };
+
+    const opensIn = nearestInterval.opensAt.difference(currentRecurringTime);
+    if (opensIn < Duration.fromMinutes(30)) {
+      return { text: `Opens in ${opensIn.asMinutes()} mins`, classes: STATUS_CAUTION };
     }
-    return { text: 'Open Now', classes: STATUS_OPEN };
-  }
 
-  const opensIn = nearestInterval.opensAt.difference(currentRecurringTime);
-  if (opensIn < Duration.fromMinutes(30)) {
-    return { text: `Opens in ${opensIn.asMinutes()} mins`, classes: STATUS_CAUTION };
-  }
+    if (nearestInterval.opensAt.day === currentDate.day()) {
+      return { text: 'Closed Now', classes: STATUS_CLOSED };
+    }
 
-  if (nearestInterval.opensAt.day === currentDate.day()) {
-    return { text: 'Closed Now', classes: STATUS_CLOSED };
-  }
-
-  const tomorrow = (currentDate.day() + 1) % 7;
-  if (nearestInterval.opensAt.day === tomorrow) {
-    return { text: 'Closed Until Tomorrow', classes: STATUS_CLOSED };
+    const tomorrow = (currentDate.day() + 1) % 7;
+    if (nearestInterval.opensAt.day === tomorrow) {
+      return { text: 'Closed Until Tomorrow', classes: STATUS_CLOSED };
+    }
   }
 
   return { text: 'Closed Today', classes: STATUS_CLOSED };


### PR DESCRIPTION
This should fix some issues with bad listing data on the search page - although for these resources / services, they will show as "Closed Today."