### PR TITLE
Unify source of user location state in App component

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -105,7 +105,6 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      userLocation: null,
       hamburgerMenuIsOpen: false,
     };
     this.toggleHamburgerMenu = this.toggleHamburgerMenu.bind(this);
@@ -116,13 +115,11 @@ class App extends Component {
     const { setUserLocation } = this.props;
     getLocation().then(coords => {
       setUserLocation(coords);
-      this.setState({ userLocation: coords });
     }).catch(e => {
       console.log('Could not obtain location, defaulting to San Francisco.', e);
       // HACK: Hardcode middle of San Francisco
       const userLocation = { lat: 37.7749, lng: -122.4194 };
       setUserLocation(userLocation);
-      this.setState({ userLocation });
     });
   }
 
@@ -136,11 +133,7 @@ class App extends Component {
 
   render() {
     const { children, location } = this.props;
-    const { hamburgerMenuIsOpen, userLocation } = this.state;
-    const childrenWithProps = React.Children.map(
-      children,
-      child => React.cloneElement(child, { userLocation }),
-    );
+    const { hamburgerMenuIsOpen } = this.state;
 
     const outerContainerId = 'outer-container';
     const pageWrapId = 'page-wrap';
@@ -161,7 +154,7 @@ class App extends Component {
         <div id={pageWrapId}>
           <Navigation showSearch={location.pathname !== '/'} toggleHamburgerMenu={this.toggleHamburgerMenu} />
           <div className="container">
-            {childrenWithProps}
+            {children}
           </div>
           <PopUpMessage />
         </div>

--- a/app/pages/OrganizationListingPage.jsx
+++ b/app/pages/OrganizationListingPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import Helmet from 'react-helmet';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   AddressInfo,
@@ -35,7 +36,7 @@ const getResourceLocation = resource => {
   };
 };
 
-export class OrganizationListingPage extends React.Component {
+class BaseOrganizationListingPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -186,11 +187,11 @@ export class OrganizationListingPage extends React.Component {
   }
 }
 
-OrganizationListingPage.defaultProps = {
+BaseOrganizationListingPage.defaultProps = {
   userLocation: null,
 };
 
-OrganizationListingPage.propTypes = {
+BaseOrganizationListingPage.propTypes = {
   location: PropTypes.shape({
     query: PropTypes.shape({ resourceid: PropTypes.string }).isRequired,
   }).isRequired,
@@ -200,3 +201,7 @@ OrganizationListingPage.propTypes = {
     lng: PropTypes.number.isRequired,
   }),
 };
+
+const mapStateToProps = state => ({ userLocation: state.user.location });
+
+export const OrganizationListingPage = connect(mapStateToProps)(BaseOrganizationListingPage);

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -3,7 +3,7 @@ import config from '../config';
 
 export default class ResourcePage {
   constructor() {
-    const baseSelectorName = 'OrganizationListingPage';
+    const baseSelectorName = 'BaseOrganizationListingPage';
     const baseSelector = ReactSelector(baseSelectorName);
     this.address = ReactSelector(`${baseSelectorName} AddressInfo`);
     this.description = baseSelector.find('.org--main--header--description div');


### PR DESCRIPTION
The reason I'm making this change is actually because I'm trying to upgrade a bunch of dependencies including react-router, but the `React.Children.map()` in the middle of the main `App` component is causing me some trouble, since react-router completely changed between v3 and v4 and we can't easily map over the children pages like this anymore.

What this PR does is get rid of the `React.Children.map()`, which was only being used to automatically pass the `userLocation` prop to all the children of the `App` component, which we can instead do with Redux. In fact, someone had already added the user location to the root Redux store and passed it to the SearchPage, so the only Page component I had to change to use Redux was the OrganizationListingPage.

What this also does is completely remove the user location state from the `App` component, since it was previously duplicated between Redux and the `App`'s own state. Now the user location is only stored in Redux, which should simplify things.