### PR TITLE
Revert changes to webpack.config.js from Casey youth guide pdf.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
   entry: ['whatwg-fetch', '@babel/polyfill', path.resolve(appRoot, 'init.jsx')],
   output: {
     path: buildDir,
-    publicPath: '/',
+    publicPath: '/dist/',
     filename: 'bundle.js',
   },
   resolve: {


### PR DESCRIPTION
Although this makes it such that the youth guide pdf appears at the unattractive URL `/dist/youthguide.pdf`, we suspect that this is a change that may have broken staging and should investigate alternative means of rerouting the pdf link.