### PR TITLE
Only do Travis CI branch builds on master and release tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,15 @@ addons:
     - g++-4.8
 env:
   - ALGOLIA_INDEX_PREFIX=travisci
+
+branches:
+  only:
+    - master
+    # Build any branch or tag whose name matches the format consisting of any
+    # number of digits separated by periods, since that matches our release tag
+    # format.
+    - /^(\d+)(\.\d+)*$/
+
 before_install:
 - cp config.example.yml config.yml
 - export CHROME_BIN=chromium-browser


### PR DESCRIPTION
Ever wonder why we get two Travis CI build statuses for each PR? It's because Travis CI has [two types of builds](https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests), branch builds and PR builds. The main difference is that the PR build will merge in the target branch before running the build, which can catch cases where conflicting changes have been merged into the target branch.

This PR will change the Travis CI settings so that we don't do branch builds on PRs, and so that branch builds only happen on `master` and any branch or tag matching the format consisting of numeric digits separated by periods. The latter is important, since it affects our deploy process, so if I screwed this up or if we change our tagging format, we'll need to update the Travis CI settings so that we build the release tags.