### PR TITLE
Replace Open Now button with custom Algolia RefinementList

### DIFF
--- a/app/components/search/Filtering.jsx
+++ b/app/components/search/Filtering.jsx
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { browserHistory } from 'react-router';
-import { getCurrentDayTime } from '../../utils/index';
 import FacetRefinementList from './FacetRefinementList';
+import OpenNowRefinementList from './OpenNowRefinementList';
 import { eligibilitiesMapping, categoriesMapping } from '../../utils/refinementMappings';
 import filters_icon from '../../assets/img/filters-icon.png';
 import './Filtering.scss';
@@ -11,44 +10,13 @@ class Filtering extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      openNow: false,
       filtersActive: false,
-      oldPathname: '',
-      oldSearch: '',
     };
-  }
-
-  toggleOpenNow = () => {
-    const currentDayTime = getCurrentDayTime();
-    const currentLocation = browserHistory.getCurrentLocation();
-    const { pathname } = currentLocation;
-    const { search } = currentLocation;
-    const { oldPathname, oldSearch, openNow: currentValue } = this.state;
-
-
-    if (currentValue === true) {
-      browserHistory.push({
-        pathname: oldPathname,
-        search: oldSearch,
-      });
-    } else {
-      // save the current URL in this components state so we can use it when
-      // 'Open now' is toggled off
-      this.setState({ oldPathname: pathname, oldSearch: search });
-      // refinementList[open_times][0]=F-11:30
-      browserHistory.push({
-        pathname,
-        search: `${search}&refinementList[open_times][0]=${currentDayTime}`,
-      });
-    }
-    // refinementList[open_times][0]=F-11:30
-    this.setState({ openNow: !currentValue });
   }
 
   setFiltersActive = filtersActive => this.setState({ filtersActive })
 
   render() {
-    const { openNow } = this.state;
     const { filtersActive } = this.state;
     return (
       <div>
@@ -66,13 +34,7 @@ class Filtering extends Component {
             >
                 Filters
             </button>
-            <button
-              className={`filter-chip ${openNow ? 'active' : ''}`}
-              onClick={this.toggleOpenNow}
-              type="button"
-            >
-              Open now
-            </button>
+            <OpenNowRefinementList attribute="open_times" />
             <div className={`custom-refinement ${filtersActive ? 'active' : ''}`}>
               {/* FacetRefinementList is a generalized refinement list for filtering
                   limit={100} indicates the limit of facet values Algolia returns. default is 10

--- a/app/components/search/OpenNowRefinementList.jsx
+++ b/app/components/search/OpenNowRefinementList.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connectRefinementList } from 'react-instantsearch/connectors';
+import { getCurrentDayTime } from '../../utils/index';
+
+
+/**
+ * A custom Algolia InstantSearch RefinementList widget representing the Open
+ * Now button.
+ *
+ * We implement this as a custom widget because we want to show users a
+ * different representation of the search parameter than is actually stored
+ * internally. Internally the open_times attribute is represented as an array of
+ * times in 30-minute chunks, where the presence of a chunk indicates that the
+ * organization or service is open during that chunk. Externally, we only want
+ * to present a binary Open Now filter where activating the filter means
+ * filtering for schedules where an open_times chunk exists for the user's
+ * current local time.
+ *
+ * For example, if it is Sunday 10:00 AM locally, then enabling the Open Now
+ * filter should filter for organizations or services which have 'Su-10:00' in
+ * the open_times array.
+ */
+const OpenNowRefinementList = ({ currentRefinement, refine }) => {
+  const isActive = currentRefinement.length !== 0;
+  const toggleRefinement = () => {
+    if (isActive) {
+      refine([]);
+    } else {
+      refine([getCurrentDayTime()]);
+    }
+  };
+  return (
+    <button
+      className={`filter-chip ${isActive ? 'active' : ''}`}
+      onClick={toggleRefinement}
+      type="button"
+    >
+      Open now
+    </button>
+  );
+};
+
+OpenNowRefinementList.propTypes = {
+  currentRefinement: PropTypes.arrayOf(PropTypes.string).isRequired,
+  refine: PropTypes.func.isRequired,
+};
+
+export default connectRefinementList(OpenNowRefinementList);

--- a/app/components/search/SearchMap.scss
+++ b/app/components/search/SearchMap.scss
@@ -33,7 +33,3 @@
     width: 60vw;
   }
 }
-
-.refinement-list {
-  display: none;
-}

--- a/app/pages/SearchPage.jsx
+++ b/app/pages/SearchPage.jsx
@@ -4,7 +4,6 @@ import {
   InstantSearch,
   Configure,
   SearchBox,
-  RefinementList,
 } from 'react-instantsearch/dom';
 import { isEqual } from 'lodash';
 import qs from 'qs';
@@ -72,11 +71,6 @@ class SearchPage extends Component {
           {configuration}
           <div className="search-box">
             <SearchBox />
-          </div>
-          <div className="refinement-list">
-            <RefinementList attribute="categories" />
-            <RefinementList attribute="open_times" />
-            <RefinementList attribute="eligibilities" />
           </div>
           <SearchResultsContainer />
         </InstantSearch>

--- a/app/pages/SearchPage.jsx
+++ b/app/pages/SearchPage.jsx
@@ -50,11 +50,6 @@ class SearchPage extends Component {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  createURL(state) {
-    return `search?${qs.stringify(state)}`;
-  }
-
   render() {
     const { userLocation } = this.props;
     const { aroundLatLng, searchState } = this.state;
@@ -63,7 +58,6 @@ class SearchPage extends Component {
     ) : (
       <Configure aroundLatLngViaIP aroundRadius="all" />
     );
-    /* eslint-disable no-undef */
     return (
       <div className="search-page-container">
 
@@ -73,7 +67,7 @@ class SearchPage extends Component {
           indexName={`${config.ALGOLIA_INDEX_PREFIX}_services_search`}
           searchState={searchState}
           onSearchStateChange={this.onSearchStateChange}
-          createURL={this.createURL}
+          createURL={state => `search?${qs.stringify(state)}`}
         >
           {configuration}
           <div className="search-box">
@@ -89,7 +83,6 @@ class SearchPage extends Component {
       </div>
     );
   }
-  /* eslint-enable no-undef */
 }
 
 function mapStateToProps(state) {


### PR DESCRIPTION
I'm trying to untangle a bit of the logic and state on the Search results page to make it easier to upgrade to the latest react-router.

One improvement is to replace our custom logic for the Open Now button with a Algolia React InstantSearch custom RefinementList. We previously had some custom logic that had to keep track of browser history and URL and conditionally insert or remove the query parameter for "open now".

By replacing this with a custom RefinementList, we don't need to keep track of the URL state ourselves, and instead we can delegate that to the Algolia React library. This allows us to sever the dependency on `react-router` in the `Filtering` component.

In addition, it means we don't need to instantiate the `<RefinementList>` objects within the `<SearchPage>` component that we were unconditionally hiding with CSS. It looks like instantiating `<RefinementList>`s registers the attributes we can filter by with the `<InstantSearch>` component. We previously had to instantiate an invisible `<RefinementList attribute="open_times">` in order to tell the `<InstantSearch>` component that we want to be able to filter by `open_times`. With this PR, because we have a custom `RefinementList` component corresponding to the `open_times` attribute, the actual rendered widget now registers itself with the `<InstantSearch>` component, and we no longer need the invisible `<RefinementList>`s.