### PR TITLE
Fix typo in datetime parsing code, affecting schedules that span midnight

### DIFF
--- a/app/utils/transformSchedule.js
+++ b/app/utils/transformSchedule.js
@@ -46,8 +46,8 @@ const parseAPIScheduleDay = apiScheduleDay => {
     return null;
   }
 
-  const opensAtMinutes = opensAtTime.hours * MINUTES_IN_HOUR + opensAtTime.minute;
-  const closesAtMinutes = closesAtTime.hours * MINUTES_IN_HOUR + closesAtTime.minute;
+  const opensAtMinutes = opensAtTime.hour * MINUTES_IN_HOUR + opensAtTime.minute;
+  const closesAtMinutes = closesAtTime.hour * MINUTES_IN_HOUR + closesAtTime.minute;
   const opensAt = new RecurringTime({
     day: DAY_TO_INT[apiScheduleDay.day],
     hour: opensAtTime.hour,


### PR DESCRIPTION
Fixes #374.

I made a typo a long time ago by typing `hours` instead of `hour`. Apparently the rest of the code would still run, since the typo only affected the part where it needed to shift the day by one if the closes_at time is before the opens_at time, which we normally use to represent time ranges that span midnight and close the next day.