### PR TITLE
Change /resource?id= URL to /organizations/:id

### DIFF
--- a/app/components/layout/ListingTitleLink.jsx
+++ b/app/components/layout/ListingTitleLink.jsx
@@ -19,7 +19,7 @@ class ListingTitleLink extends React.Component {
   getListingLink() {
     const { type, listing } = this.props;
     switch (type) {
-      case 'org': return `/resource?id=${listing.id}`;
+      case 'org': return `/organizations/${listing.id}`;
       case 'service': return `/services/${listing.id}`;
       default: throw new Error('unknown listing type');
     }

--- a/app/components/layout/OrganizationCard.jsx
+++ b/app/components/layout/OrganizationCard.jsx
@@ -17,7 +17,7 @@ class OrganizationCard extends React.Component {
     const maxHeight = '106px';
 
     return (
-      <Link to={{ pathname: '/resource', query: { id } }} className="card" style={{ maxHeight }}>
+      <Link to={`/organizations/${id}`} className="card" style={{ maxHeight }}>
         <StreetViewImage address={address} size={maxHeight} />
         <header className="content">
           <h3>{ name }</h3>

--- a/app/components/search/ResourceEntry.jsx
+++ b/app/components/search/ResourceEntry.jsx
@@ -16,7 +16,7 @@ class ResourceEntry extends Component {
     const hitNumber = page * hitsPerPage + index + 1;
     const { recurringSchedule } = hit;
     return (
-      <Link to={{ pathname: '/resource', query: { id: hit.resource_id } }}>
+      <Link to={`/organizations/${hit.resource_id}`}>
         <li className="results-table-entry resource-entry">
           <div className="entry-details">
             <h4 className="entry-headline">{`${hitNumber}. ${hit.name}`}</h4>

--- a/app/components/search/ServiceEntry.jsx
+++ b/app/components/search/ServiceEntry.jsx
@@ -21,7 +21,7 @@ class ServiceEntry extends Component {
           <div className="entry-details">
             <h4 className="entry-headline">{`${hitNumber}. ${hit.name}`}</h4>
             <p className="entry-meta">
-              <Link to={{ pathname: '/resource', query: { id: hit.resource_id } }}>{hit.service_of}</Link>
+              <Link to={`/organizations/${hit.resource_id}`}>{hit.service_of}</Link>
             </p>
             <p className="entry-meta">
               <span>{hit.addresses && hit.addresses.address_1 ? hit.addresses.address_1 : 'No address found'}</span>

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -511,7 +511,7 @@ class OrganizationEditPage extends React.Component {
       .then(response => {
         if (response.ok) {
           alert('Resource successfuly created. Thanks!');
-          response.json().then(res => browserHistory.push(`/resource?id=${res.resources[0].resource.id}`));
+          response.json().then(res => browserHistory.push(`/organizations/${res.resources[0].resource.id}`));
         } else {
           Promise.reject(response);
         }
@@ -604,7 +604,7 @@ class OrganizationEditPage extends React.Component {
 
     const that = this;
     Promise.all(promises).then(() => {
-      that.props.router.push({ pathname: '/resource', query: { id: that.state.resource.id } });
+      that.props.router.push(`/organizations/${that.state.resource.id}`);
       showPopUpMessage({
         type: 'success',
         message: 'Successfully saved your changes.',

--- a/app/pages/OrganizationListingPage.jsx
+++ b/app/pages/OrganizationListingPage.jsx
@@ -50,13 +50,7 @@ class BaseOrganizationListingPage extends React.Component {
   }
 
   loadResourceFromServer() {
-    const {
-      location: {
-        query: {
-          id,
-        },
-      },
-    } = this.props;
+    const { params: { id } } = this.props;
     dataService.getResource(id).then(resource => {
       this.setState({ resource });
     });

--- a/app/pages/admin/ChangeRequests.jsx
+++ b/app/pages/admin/ChangeRequests.jsx
@@ -213,7 +213,7 @@ export class ChangeRequestsPage extends React.Component {
     return (
       <div className="titlebox">
         <h2>
-          <Link to={{ pathname: '/resource', query: { id: resource.id } }} target="_blank">
+          <Link to={`/organizations/${resource.id}`} target="_blank">
             <i className="material-icons">link</i>
           </Link>
           {resource.name}

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -24,6 +24,11 @@ function redirectToRoot(nextState, replace) {
   });
 }
 
+const redirectToOrganizations = (nextState, replace) => {
+  const { location: { query: { id } } } = nextState;
+  replace(`/organizations/${id}`);
+};
+
 // Adapted from
 // https://github.com/ReactTraining/react-router/issues/2019#issuecomment-256591800
 // Note: When we upgrade to react-router 4.x, we should use
@@ -39,15 +44,19 @@ export default (
     <IndexRoute component={HomePage} />
     <Route name="admin" path="/admin" component={AdminPage} />
     <Route name="changeRequests" path="/admin/changes" component={ChangeRequestsPage} />
+    <Route path="/organizations/:id" component={OrganizationListingPage} />
     <Route name="editResource" path="/resource/edit" component={OrganizationEditPage} />
     <Route name="newResource" path="/resource/new" component={OrganizationEditPage} />
     <Route name="privacyPolicy" path="/privacy-policy" component={PrivacyPolicyPage} />
-    <Route name="resource" path="/resource" component={OrganizationListingPage} />
     <Route name="search" path="/search" component={SearchResultsPage} />
     <Route name="ServicePage" path="/services/:service" component={ServiceListingPage} />
     <Route name="termsOfService" path="/terms-of-service" component={TermsOfServicePage} />
     <Route name="AboutPage" path="/about" component={AboutPage} />
     <Route name="listingDemo" path="/demo/listing" component={ListingDebugPage} />
+
+    {/* Legacy redirects */}
+    <Route path="/resource" onEnter={redirectToOrganizations} />
+
     <Route path="*" onEnter={redirectToRoot} />
   </Route>
 );

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -35,6 +35,6 @@ export default class ResourcePage {
   }
 
   static url(resourceId) {
-    return `${config.baseUrl}/resource?id=${resourceId}`;
+    return `${config.baseUrl}/organizations/${resourceId}`;
   }
 }


### PR DESCRIPTION
I've been working on trying to upgrade from React Router 3 to React Route 4, and one of the more annoying things to do is dealing with the query param on the Resource (Organization) listing page, since they dropped the built-in query parameter parser, and you have to parse the query string yourself.

I figured we should try to make our routes consistent anyway, so in this PR I changed the `/resource?id=` URL to `/organizations/:id`. This makes it match the services routes, which already look like `/services/:id`. I also took this as an opportunity to rename the route from `resource` to `organization`, since I believe that's the direction we want to move towards, and it's probably best to get that URL renamed before the big launch.

Lastly, I did add a redirect in place so that if you try visiting the old URL it redirects to the new one.