### PR TITLE
#700 - Make map markers interactive

### DIFF
--- a/app/components/search/SearchMap.jsx
+++ b/app/components/search/SearchMap.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import GoogleMap from 'google-map-react';
+import { Tooltip } from 'react-tippy';
+import ServiceEntry from './ServiceEntry';
+import ResourceEntry from './ResourceEntry';
 import config from '../../config';
 import './SearchMap.scss';
 
@@ -25,37 +28,79 @@ function UserLocationMarker() {
   );
 }
 
-function CustomMarker({ index }) {
-  /*  eslint-disable max-len */
-  return (
-    <svg width="30" height="50" viewBox="0 0 102 60" className="marker">
-      <g fill="none" fillRule="evenodd">
-        <g
-          transform="translate(-60, 0)"
-          stroke="#8962B2"
-          id="pin"
-          viewBox="0 0 100 100"
-        >
-          <path
-            d="M157.39 34.315c0 18.546-33.825 83.958-33.825 83.958S89.74 52.86 89.74 34.315C89.74 15.768 104.885.73 123.565.73c18.68 0 33.825 15.038 33.825 33.585z"
-            strokeWidth="5.53"
-            fill="#E6D2FC"
+function CustomMarker({
+  hit, index, page, hitsPerPage,
+}) {
+  const hitNumber = page * hitsPerPage + index + 1;
+
+  const getPopoverHtml = () => {
+    switch (hit.type) {
+      case 'service':
+        return (
+          <ServiceEntry
+            page={page}
+            hitsPerPage={hitsPerPage}
+            hit={hit}
+            index={index}
           />
+        );
+      case 'resource':
+        return (
+          <ResourceEntry
+            page={page}
+            hitsPerPage={hitsPerPage}
+            hit={hit}
+            index={index}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Tooltip
+      arrow
+      useContext
+      interactive
+      html={getPopoverHtml()}
+      theme="light"
+      trigger="click"
+      position="bottom"
+    >
+      <svg width="30" height="50" viewBox="0 0 102 60" className="marker">
+        <g fill="none" fillRule="evenodd">
+          <g
+            transform="translate(-60, 0)"
+            stroke="#8962B2"
+            id="pin"
+            viewBox="0 0 100 100"
+          >
+            <path
+              d="M157.39 34.315c0 18.546-33.825 83.958-33.825 83.958S89.74 52.86 89.74 34.315C89.74 15.768 104.885.73 123.565.73c18.68 0 33.825 15.038 33.825 33.585z"
+              strokeWidth="5.53"
+              fill="#E6D2FC"
+            />
+          </g>
+          <text fontSize="45px" x="65" y="55" fill="#276ce5" fontWeight="bold" textAnchor="middle">{hitNumber}</text>
         </g>
-        <text fontSize="45px" x="65" y="55" fill="#276ce5" fontWeight="bold" textAnchor="middle">{index + 1}</text>
-      </g>
-    </svg>
+      </svg>
+    </Tooltip>
   );
-  /*  eslint-enable max-len */
 }
 
-const SearchMap = ({ hits, userLocation }) => {
+const SearchMap = ({
+  hits, userLocation, page, hitsPerPage,
+}) => {
   if (!hits || !hits.length) {
     return null;
   }
 
   const markers = hits.map((hit, index) => (
     <CustomMarker
+      hit={hit}
+      page={page}
+      hitsPerPage={hitsPerPage}
       lat={hit._geoloc ? hit._geoloc.lat : 0}
       lng={hit._geoloc ? hit._geoloc.lng : 0}
       key={hit.objectID}

--- a/app/components/search/SearchMap.scss
+++ b/app/components/search/SearchMap.scss
@@ -23,6 +23,16 @@
   width: 30px;
   top: -27px;
   left: -15px;
+  cursor: pointer;
+}
+
+.tippy-tooltip-content {
+  .entry-details {
+    text-align: start;
+  }
+  .entry-headline {
+    max-width: 100%;
+  }
 }
 
 .map-wrapper {

--- a/app/components/search/SearchResultsContainer.jsx
+++ b/app/components/search/SearchResultsContainer.jsx
@@ -73,7 +73,11 @@ No results have been found for
             </Link>
           </div>
         </div>
-        <SearchMap hits={hits} />
+        <SearchMap
+          hits={hits}
+          page={searchResults.page}
+          hitsPerPage={searchResults.hitsPerPage}
+        />
       </div>
     );
   }


### PR DESCRIPTION
When users perform a search, they are shown a list of results along with a map with markers for each of the results. Users can drag and zoom the entire map, but individual markers are not interactive. This PR displays a popover with information about the resource when a marker is clicked. Clicking through the popover takes the user to the resource detail page.

### Map with markers
<img width="1398" alt="Screen Shot 2019-10-06 at 4 42 51 PM" src="https://user-images.githubusercontent.com/7386336/66277943-8a356800-e859-11e9-824e-c55d2f9e4c2f.png">

### Clicking on a marker gives some cursory information in a popover
<img width="1398" alt="Screen Shot 2019-10-06 at 4 42 56 PM" src="https://user-images.githubusercontent.com/7386336/66277944-8acdfe80-e859-11e9-9ffe-02fd2bf2949a.png">

### Clicking on popover takes user to resource details page
<img width="1398" alt="Screen Shot 2019-10-06 at 4 43 01 PM" src="https://user-images.githubusercontent.com/7386336/66277945-8acdfe80-e859-11e9-805a-268d8d424237.png">


While I was in there, I also fixed a bug where the numbers on the markers do not match the numbers in the results list when the user is not on the first page of results.

### before notice that list shows results 21-40 while markers are labeled 1-20
<img width="1398" alt="Screen Shot 2019-10-06 at 4 53 21 PM" src="https://user-images.githubusercontent.com/7386336/66277991-fdd77500-e859-11e9-8373-93f08bb6dab5.png">

### after notice that markers match up with list items
<img width="1398" alt="Screen Shot 2019-10-06 at 4 53 09 PM" src="https://user-images.githubusercontent.com/7386336/66277989-fadc8480-e859-11e9-9200-5d3cb5bd2a32.png">


