### PR TITLE
Remove failing Xvfb steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ cache:
   - node_modules
 services:
 - docker
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
 env:
   - ALGOLIA_INDEX_PREFIX=travisci
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ branches:
 
 before_install:
 - cp config.example.yml config.yml
-- export CHROME_BIN=chromium-browser
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 script:
 - npm run lint
 - npm run test


### PR DESCRIPTION
It looks like all of our Travis CI builds are suddenly failing with the following error:

```
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
```

[Xvfb](https://en.wikipedia.org/wiki/Xvfb) is the X virtual framebuffer, which is a way of running graphical programs on a Linux machine without rendering to an actual screen. This is a common way of running automated scripts for graphical programs on headless machines, such as Chrome on a headless Travis CI box.

I don't think we're using this anymore, since we use Sauce Labs instead for our browser testing, and therefore this stuff can be removed.

My guess for why this suddenly started failing is that Travis CI must have removed Xvfb from its default image. We could make this work by explicitly installing Xvfb, but that's not necessary here.

Will merge if this passes Travis CI.