### PR TITLE
Fix styling of MOHCD Funded badge on map tooltips

### DIFF
--- a/app/components/search/ResourceEntry.jsx
+++ b/app/components/search/ResourceEntry.jsx
@@ -19,7 +19,18 @@ class ResourceEntry extends Component {
       <Link to={`/organizations/${hit.resource_id}`}>
         <li className="results-table-entry resource-entry">
           <div className="entry-details">
-            <h4 className="entry-headline">{`${hitNumber}. ${hit.name}`}</h4>
+            <div className="entry-header">
+              <h4 className="entry-headline">{`${hitNumber}. ${hit.name}`}</h4>
+              {hit.is_mohcd_funded
+                ? (
+                  <div className="mohcd-funded">
+                    <img src={images.mohcdSeal} alt="MOHCD seal" />
+                    <p>Funded by MOHCD</p>
+                  </div>
+                )
+                : null
+              }
+            </div>
             <p className="entry-meta">
               <span>{hit.address && hit.address.address_1 ? hit.address.address_1 : 'No address found'}</span>
               {recurringSchedule
@@ -30,20 +41,6 @@ class ResourceEntry extends Component {
                   )
               }
             </p>
-            {hit.is_mohcd_funded
-              ? (
-                <div className="mohcd-funded">
-                  <img src={images.mohcdSeal} alt="MOHCD seal" />
-                  <p>Funded by MOHCD</p>
-                </div>
-              )
-              : (
-                <div className="mohcd-funded">
-                  <img src={images.mohcdSeal} alt="MOHCD seal" />
-                  <p>Funded by MOHCD</p>
-                </div>
-              )
-            }
             <div className="entry-body">
               <ReactMarkdown className="rendered-markdown" source={description} />
             </div>

--- a/app/components/search/SearchEntry.scss
+++ b/app/components/search/SearchEntry.scss
@@ -27,6 +27,12 @@
   }
 }
 
+.entry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
 .entry-headline {
   color: rgba(0,0,0,0.87);
   font-size: 18px;
@@ -79,9 +85,6 @@
 }
 
 .mohcd-funded {
-  position: absolute;
-  right: 30px;
-  top: 20px;
   display: flex;
   align-items: center;
   & > img {
@@ -91,6 +94,7 @@
   & > p {
     font-size: 12px;
     color: #666;
+    min-width: 110px;
   }
   @media screen and (max-width: 1024px) {
     display: none;

--- a/app/components/search/SearchMap.scss
+++ b/app/components/search/SearchMap.scss
@@ -29,9 +29,7 @@
 .tippy-tooltip-content {
   .entry-details {
     text-align: start;
-  }
-  .entry-headline {
-    max-width: 100%;
+    padding: 20px;
   }
 }
 

--- a/app/components/search/ServiceEntry.jsx
+++ b/app/components/search/ServiceEntry.jsx
@@ -19,7 +19,18 @@ class ServiceEntry extends Component {
       <Link to={{ pathname: `/services/${hit.service_id}` }}>
         <li className="results-table-entry service-entry">
           <div className="entry-details">
-            <h4 className="entry-headline">{`${hitNumber}. ${hit.name}`}</h4>
+            <div className="entry-header">
+              <h4 className="entry-headline">{`${hitNumber}. ${hit.name}`}</h4>
+              {hit.is_mohcd_funded
+                ? (
+                  <div className="mohcd-funded">
+                    <img src={images.mohcdSeal} alt="MOHCD seal" />
+                    <p>Funded by MOHCD</p>
+                  </div>
+                )
+                : null
+              }
+            </div>
             <p className="entry-meta">
               <Link to={`/organizations/${hit.resource_id}`}>{hit.service_of}</Link>
             </p>
@@ -33,16 +44,6 @@ class ServiceEntry extends Component {
                   )
               }
             </p>
-
-            {hit.is_mohcd_funded
-              ? (
-                <div className="mohcd-funded">
-                  <img src={images.mohcdSeal} alt="MOHCD seal" />
-                  <p>Funded by MOHCD</p>
-                </div>
-              )
-              : null
-            }
             <div className="entry-body">
               <ReactMarkdown className="rendered-markdown service-entry-body" source={description} />
             </div>


### PR DESCRIPTION
This is a bit of a continuation of https://github.com/ShelterTechSF/askdarcel-web/pull/875, where I added tooltips with some details when you click on a map marker. I just noticed that these tooltips needed a little styling love for when they are displaying the `MOHCD Funded` badge.

Notice that with the current styling, the header overlaps with the MOHCD badge.
<img width="1545" alt="Screen Shot 2019-10-20 at 1 23 57 PM" src="https://user-images.githubusercontent.com/7386336/67166251-8407b700-f342-11e9-9d1d-516db03a0348.png">

Moved the header & badge into the same flexbox so they play a little nicer with each other.
<img width="1545" alt="Screen Shot 2019-10-20 at 1 59 15 PM" src="https://user-images.githubusercontent.com/7386336/67166261-98e44a80-f342-11e9-8586-cdbe59308e50.png">

Also noticed that for some reason we were showing the badge regardless of whether or not a resource actually had the `is_mohcd_funded` property as true on the backend. Fixed that while I was in there.

