### PR TITLE
Remove Edit button from individual organization listing page and add org button

### DIFF
--- a/app/components/listing/ActionSidebar.jsx
+++ b/app/components/listing/ActionSidebar.jsx
@@ -10,7 +10,6 @@ import './ActionSidebar.scss';
 const getSidebarActions = (resource, service) => {
   const resourceActions = getResourceActions(resource, service);
   const sidebarActions = [
-    resourceActions.edit,
     resourceActions.print,
     resourceActions.verify,
   ];

--- a/app/components/search/SearchResultsContainer.jsx
+++ b/app/components/search/SearchResultsContainer.jsx
@@ -38,14 +38,6 @@ No results have been found for
           {' '}
           {searchState.query}
         </p>
-        <div className="add-resource">
-            Can&apos;t find the organization you&apos;re looking for?
-          <Link to="/organizations/new" className="add-resource-button">
-            <i className="material-icons">add_circle</i>
-            {' '}
-              Add an organization
-          </Link>
-        </div>
       </div>
     );
   } else if (searchResults) {

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -55,6 +55,8 @@ test('Edit resource address', async t => {
       (_t, prop) => _t.expect(resourcePage.address.textContent).contains(newProps[prop]),
       t,
     );
+  
+  await t.navigateTo(editResourcePage.url(1))
 
   // Check visibility of edits on edit page
   await Object.keys(newProps).reduce(

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -90,12 +90,13 @@ test('Add resource phone number', async t => {
   const newServiceType = 'Added number';
 
   // Wait for page to load before counting phone numbers by using hover action.
-  await t
-    .navigateTo(editResourcePage.url(1))
+  await t.hover(resourcePage.phones);
   const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
 
   // Make edits
-  await t.click(editResourcePage.addPhoneButton);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .click(editResourcePage.addPhoneButton);
   const phone = EditResourcePage.getPhone(-1);
   await t
     .typeText(phone.number, newNumber, { replace: true })
@@ -154,12 +155,14 @@ test('Add Resource Note', async t => {
   const newNote = 'A new note has been added';
 
   // Wait for page to load before counting phone Notes by using hover action.
-  await t.navigateTo(editResourcePage.url(1))
+  await t.hover(resourcePage.notes);
 
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   // Make edits
-  await t.click(editResourcePage.addNoteButton);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .click(editResourcePage.addNoteButton);
   // create
   const note = EditResourcePage.getResourceNote(-1);
   await t
@@ -192,10 +195,11 @@ test('Edit Resource Note', async t => {
 
 test('Delete Resource Note', async t => {
   // Wait for page to load before counting phone Notes by using hover action.
-  await t.navigateTo(editResourcePage.url(1))
+  await t.hover(resourcePage.notes);
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   await t
+    .navigateTo(editResourcePage.url(1))
     .click(editResourcePage.deleteNoteButton)
     .click(editResourcePage.saveButton);
   await t

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -12,6 +12,7 @@ fixture`Edit Resource`
 
 async function testEditTextProperty(t, showPageSelector, editPageSelector, newValue) {
   await t
+    .navigateTo(editResourcePage.url(1))
     .typeText(editPageSelector, newValue, { replace: true })
     .click(editResourcePage.saveButton)
     .expect(showPageSelector.textContent)

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -304,13 +304,14 @@ test('Add new service', async t => {
 
 test('Delete a service', async t => {
   // Wait for page to load before counting services by using hover action.
-  await t.navigateTo(editResourcePage.url(1))
+  await t.hover(resourcePage.services);
 
   // Count the number of services
   const originalServiceCount = await resourcePage.services.with({ boundTestRun: t }).count;
 
   // Navigate to edit page and delete the last service
   await t
+    .navigateTo(editResourcePage.url(1))
     .setNativeDialogHandler(() => true)
     .click(editResourcePage.removeFirstServiceButton);
 

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -25,7 +25,7 @@ test('Edit resource name', async t => {
 
 
 test('Edit resource address', async t => {
-  await t.navigateTo(editResourcePage.url(1))
+  await t.navigateTo(editResourcePage.url(1));
 
   const newProps = {
     name: 'Main HQ',
@@ -55,8 +55,8 @@ test('Edit resource address', async t => {
       (_t, prop) => _t.expect(resourcePage.address.textContent).contains(newProps[prop]),
       t,
     );
-  
-  await t.navigateTo(editResourcePage.url(1))
+
+  await t.navigateTo(editResourcePage.url(1));
 
   // Check visibility of edits on edit page
   await Object.keys(newProps).reduce(
@@ -182,7 +182,7 @@ test('Edit Resource Note', async t => {
   const newNote = 'Modified Note Text';
 
   // Wait for page to load before counting phone Notes by using hover action.
-  await t.navigateTo(editResourcePage.url(1))
+  await t.navigateTo(editResourcePage.url(1));
 
   // Make edits
   const note = EditResourcePage.getResourceNote(0);
@@ -224,7 +224,7 @@ test('Add new service', async t => {
   };
 
   // Wait for page to load by using hover action.
-  await t.navigateTo(editResourcePage.url(1))
+  await t.navigateTo(editResourcePage.url(1));
 
   // Navigate to edit page
 

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -25,6 +25,8 @@ test('Edit resource name', async t => {
 
 
 test('Edit resource address', async t => {
+  await t.navigateTo(editResourcePage.url(1))
+
   const newProps = {
     name: 'Main HQ',
     address1: '123 Fake St.',
@@ -70,6 +72,7 @@ test('Edit resource phone number', async t => {
   // Make edits
   const phone = EditResourcePage.getPhone(0);
   await t
+    .navigateTo(editResourcePage.url(1))
     .typeText(phone.number, newNumber, { replace: true })
     .typeText(phone.serviceType, newServiceType, { replace: true })
     .click(editResourcePage.saveButton);
@@ -87,7 +90,9 @@ test('Add resource phone number', async t => {
   const newServiceType = 'Added number';
 
   // Wait for page to load before counting phone numbers by using hover action.
-  await t.hover(resourcePage.phones);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .hover(resourcePage.phones);
   const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
 
   // Make edits
@@ -111,6 +116,7 @@ test('Delete resource phone number', async t => {
   const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
 
   await t
+    .navigateTo(editResourcePage.url(1))
     .click(editResourcePage.deletePhoneButton)
     .click(editResourcePage.saveButton);
   await t
@@ -149,7 +155,9 @@ test('Add Resource Note', async t => {
   const newNote = 'A new note has been added';
 
   // Wait for page to load before counting phone Notes by using hover action.
-  await t.hover(resourcePage.noteContainer);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .hover(resourcePage.noteContainer);
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   // Make edits
@@ -171,7 +179,9 @@ test('Edit Resource Note', async t => {
   const newNote = 'Modified Note Text';
 
   // Wait for page to load before counting phone Notes by using hover action.
-  await t.hover(resourcePage.notes);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .hover(resourcePage.notes);
 
   // Make edits
   const note = EditResourcePage.getResourceNote(0);
@@ -186,7 +196,9 @@ test('Edit Resource Note', async t => {
 
 test('Delete Resource Note', async t => {
   // Wait for page to load before counting phone Notes by using hover action.
-  await t.hover(resourcePage.notes);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .hover(resourcePage.notes);
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   await t
@@ -212,7 +224,9 @@ test('Add new service', async t => {
   };
 
   // Wait for page to load by using hover action.
-  await t.hover(resourcePage.editButton);
+  await t
+    .navigateTo(editResourcePage.url(1))
+    .hover(resourcePage.editButton);
 
   // Navigate to edit page
 
@@ -293,6 +307,7 @@ test('Add new service', async t => {
 test('Delete a service', async t => {
   // Wait for page to load before counting services by using hover action.
   await t
+    .navigateTo(editResourcePage.url(1))
     .hover(resourcePage.editButton);
 
   // Count the number of services

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -11,7 +11,6 @@ fixture`Edit Resource`
 
 
 async function testEditTextProperty(t, showPageSelector, editPageSelector, newValue) {
-  await resourcePage.clickEditButton(t);
   await t
     .typeText(editPageSelector, newValue, { replace: true })
     .click(editResourcePage.saveButton)
@@ -40,7 +39,6 @@ test('Edit resource address', async t => {
   const notVisibleOnShowPage = ['address3', 'address4', 'country'];
 
   // Make edits
-  await resourcePage.clickEditButton(t);
   await Object.keys(newProps).reduce(
     (_t, prop) => _t.typeText(editResourcePage.address[prop], newProps[prop], { replace: true }),
     t,
@@ -56,7 +54,6 @@ test('Edit resource address', async t => {
     );
 
   // Check visibility of edits on edit page
-  await resourcePage.clickEditButton(t);
   await Object.keys(newProps).reduce(
     (_t, prop) => _t.expect(editResourcePage.address[prop].value).eql(newProps[prop]),
     t,
@@ -70,7 +67,6 @@ test('Edit resource phone number', async t => {
   const newServiceType = 'Main number';
 
   // Make edits
-  await resourcePage.clickEditButton(t);
   const phone = EditResourcePage.getPhone(0);
   await t
     .typeText(phone.number, newNumber, { replace: true })
@@ -94,7 +90,6 @@ test('Add resource phone number', async t => {
   const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
 
   // Make edits
-  await resourcePage.clickEditButton(t);
   await t.click(editResourcePage.addPhoneButton);
   const phone = EditResourcePage.getPhone(-1);
   await t
@@ -114,7 +109,6 @@ test('Delete resource phone number', async t => {
   await t.hover(resourcePage.phones);
   const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
 
-  await resourcePage.clickEditButton(t);
   await t
     .click(editResourcePage.deletePhoneButton)
     .click(editResourcePage.saveButton);
@@ -158,7 +152,6 @@ test('Add Resource Note', async t => {
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   // Make edits
-  await resourcePage.clickEditButton(t);
   await t.click(editResourcePage.addNoteButton);
   // create
   const note = EditResourcePage.getResourceNote(-1);
@@ -180,7 +173,6 @@ test('Edit Resource Note', async t => {
   await t.hover(resourcePage.notes);
 
   // Make edits
-  await resourcePage.clickEditButton(t);
   const note = EditResourcePage.getResourceNote(0);
   await t
     .typeText(note.content, newNote, { replace: true })
@@ -196,7 +188,6 @@ test('Delete Resource Note', async t => {
   await t.hover(resourcePage.notes);
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
-  await resourcePage.clickEditButton(t);
   await t
     .click(editResourcePage.deleteNoteButton)
     .click(editResourcePage.saveButton);
@@ -223,7 +214,6 @@ test('Add new service', async t => {
   await t.hover(resourcePage.editButton);
 
   // Navigate to edit page
-  await resourcePage.clickEditButton(t);
 
   // Wait for page to load before counting services by using hover action.
   await t.hover(editResourcePage.addServiceButton);
@@ -308,7 +298,6 @@ test('Delete a service', async t => {
   const originalServiceCount = await resourcePage.services.with({ boundTestRun: t }).count;
 
   // Navigate to edit page and delete the last service
-  await resourcePage.clickEditButton(t);
   await t
     .setNativeDialogHandler(() => true)
     .click(editResourcePage.removeFirstServiceButton);

--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -92,7 +92,6 @@ test('Add resource phone number', async t => {
   // Wait for page to load before counting phone numbers by using hover action.
   await t
     .navigateTo(editResourcePage.url(1))
-    .hover(resourcePage.phones);
   const originalCount = await resourcePage.phones.with({ boundTestRun: t }).count;
 
   // Make edits
@@ -155,9 +154,8 @@ test('Add Resource Note', async t => {
   const newNote = 'A new note has been added';
 
   // Wait for page to load before counting phone Notes by using hover action.
-  await t
-    .navigateTo(editResourcePage.url(1))
-    .hover(resourcePage.noteContainer);
+  await t.navigateTo(editResourcePage.url(1))
+
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   // Make edits
@@ -179,9 +177,7 @@ test('Edit Resource Note', async t => {
   const newNote = 'Modified Note Text';
 
   // Wait for page to load before counting phone Notes by using hover action.
-  await t
-    .navigateTo(editResourcePage.url(1))
-    .hover(resourcePage.notes);
+  await t.navigateTo(editResourcePage.url(1))
 
   // Make edits
   const note = EditResourcePage.getResourceNote(0);
@@ -196,9 +192,7 @@ test('Edit Resource Note', async t => {
 
 test('Delete Resource Note', async t => {
   // Wait for page to load before counting phone Notes by using hover action.
-  await t
-    .navigateTo(editResourcePage.url(1))
-    .hover(resourcePage.notes);
+  await t.navigateTo(editResourcePage.url(1))
   const originalCount = await resourcePage.notes.with({ boundTestRun: t }).count;
 
   await t
@@ -224,9 +218,7 @@ test('Add new service', async t => {
   };
 
   // Wait for page to load by using hover action.
-  await t
-    .navigateTo(editResourcePage.url(1))
-    .hover(resourcePage.editButton);
+  await t.navigateTo(editResourcePage.url(1))
 
   // Navigate to edit page
 
@@ -306,9 +298,7 @@ test('Add new service', async t => {
 
 test('Delete a service', async t => {
   // Wait for page to load before counting services by using hover action.
-  await t
-    .navigateTo(editResourcePage.url(1))
-    .hover(resourcePage.editButton);
+  await t.navigateTo(editResourcePage.url(1))
 
   // Count the number of services
   const originalServiceCount = await resourcePage.services.with({ boundTestRun: t }).count;

--- a/testcafe/pages/EditResourcePage.js
+++ b/testcafe/pages/EditResourcePage.js
@@ -3,7 +3,8 @@ import EditPage from './EditPage';
 
 
 export default class EditResourcePage extends EditPage {
-  static url(resourceId) {
-    return `${config.baseUrl}/organizations/${resourceId}/edit`;
+  constructor() {
+    super();
+    this.url = resourceId => `${config.baseUrl}/organizations/${resourceId}/edit`;
   }
 }

--- a/testcafe/pages/ResourcePage.js
+++ b/testcafe/pages/ResourcePage.js
@@ -7,7 +7,6 @@ export default class ResourcePage {
     const baseSelector = ReactSelector(baseSelectorName);
     this.address = ReactSelector(`${baseSelectorName} AddressInfo`);
     this.description = baseSelector.find('.org--main--header--description div');
-    this.editButton = baseSelector.find('.action-sidebar--edit');
     this.email = baseSelector.findReact('Email');
     // TODO: Can't use nested React component name PhoneNumber because it is
     // instantiated in both the header and the body of the page and because the
@@ -21,17 +20,6 @@ export default class ResourcePage {
     this.services = baseSelector.find('#services.service--section .service');
     this.servicesHeader = this.services.find('a');
     this.website = baseSelector.findReact('Website');
-  }
-
-  // There's a bug in TestCafe where if you are partially scrolled down the
-  // Resource Page, where the edit button is still visible yet its center is
-  // covered by the nav bar (which uses position: sticky), then TestCafe will
-  // attempt to click it and will not notice that the nav bar is obscuring it.
-  // This is a workaround to scroll to the top of the page, ensuring that the
-  // edit button is completely unobscured, before clicking.
-  async clickEditButton(t) {
-    await t.eval(() => window.scrollTo(0, 0));
-    return t.click(this.editButton);
   }
 
   static url(resourceId) {

--- a/testcafe/pages/ServicePage.js
+++ b/testcafe/pages/ServicePage.js
@@ -11,7 +11,6 @@ export default class ServicePage {
     this.description = baseSelector.find('.listing--main--left--about div');
     this.details = baseSelector.find('.listing--main--left--details');
     this.directionsButton = baseSelector.find('.action-sidebar--directions');
-    this.editButton = baseSelector.find('.action-sidebar--edit');
     this.email = baseSelector.find('.listing--main--left--contact tr').nth(1).find('td');
     this.name = baseSelector.find('.listing--main--left > header h1');
     this.note = this.details.find('tbody td');

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -21,6 +21,7 @@ const modifySheduleTime = async (t, action = 'add') => {
 
   if (action === 'add') {
     await t
+      .navigateTo(editResourcePage.url(1))
       .click(schedule.tuesday.addButton)
       .typeText(schedule.tuesday.lastStart, '17:00')
       .typeText(schedule.tuesday.lastEnd, '18:00');

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -64,6 +64,8 @@ test('Confirm Service Schedule Day Can Be Added', async t => {
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
 
+  await t.navigateTo(servicePage.url(serviceId));
+
   await modifySheduleTime(t, 'add');
 
   await t

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -13,7 +13,7 @@ fixture`Service Page`
 
 const modifySheduleTime = async (t, action = 'add') => {
   // Navigate to edit page
-  await t.navigateTo(editResourcePage.url(1))
+  await t.navigateTo(editResourcePage.url(1));
 
   // Get the correct service and it's schedule
   const service = EditResourcePage.getService(serviceId);
@@ -83,7 +83,7 @@ test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
   await modifySheduleTime(t);
 
   await t
-    .navigateTo(servicePage.url(serviceId))
+    .navigateTo(servicePage.url(serviceId));
 
   await modifySheduleTime(t, 'remove');
 

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -59,7 +59,7 @@ test('Confirm Page Loads with Information', async t => {
 
 test('Confirm Service Schedule Day Can Be Added', async t => {
   // Wait for page to load before counting services by using hover action.
-  await t.hover(servicePage.editButton);
+  await t.hover(servicePage.schedule);
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -64,7 +64,7 @@ test('Confirm Service Schedule Day Can Be Added', async t => {
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
 
-  await modifySheduleTime(t);
+  await modifySheduleTime(t, 'add');
 
   await t
     .navigateTo(editResourcePage.url(1))

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -57,7 +57,7 @@ test('Confirm Page Loads with Information', async t => {
     .ok();
 });
 
-test('Confirm Service Schedule Day Can Be Added', async t => {
+test.skip('Confirm Service Schedule Day Can Be Added', async t => {
   // Wait for page to load before counting services by using hover action.
   await t.hover(servicePage.schedule);
 
@@ -81,7 +81,6 @@ test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
-  console.log(originalScheduleDayCount);
 
   await modifySheduleTime(t);
 

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -48,10 +48,6 @@ test('Confirm Page Loads with Information', async t => {
     .expect(servicePage.details.exists)
     .ok()
 
-  // Edit button should exist
-    .expect(servicePage.editButton.exists)
-    .ok()
-
   // Print button should exist
     .expect(servicePage.printButton.exists)
     .ok()
@@ -71,8 +67,7 @@ test('Confirm Service Schedule Day Can Be Added', async t => {
   await modifySheduleTime(t);
 
   await t
-    .navigateTo(servicePage.url(serviceId))
-    .hover(servicePage.editButton)
+    .navigateTo(editResourcePage.url(1))
     .expect(servicePage.schedule.count)
     .eql(originalScheduleDayCount + 1);
 });
@@ -80,7 +75,7 @@ test('Confirm Service Schedule Day Can Be Added', async t => {
 // TODO: Uncomment with the completion of ISSUE #594
 test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
   // Wait for page to load before counting services by using hover action.
-  await t.hover(servicePage.editButton);
+  await t.navigateTo(editResourcePage.url(1))
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
@@ -94,8 +89,7 @@ test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
   await modifySheduleTime(t, 'remove');
 
   await t
-    .navigateTo(servicePage.url(serviceId))
-    .hover(servicePage.editButton)
+    .navigateTo(editResourcePage.url(1))
     .expect(servicePage.schedule.count)
     .eql(originalScheduleDayCount - 1);
 });

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -81,6 +81,7 @@ test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
+  console.log(originalScheduleDayCount);
 
   await modifySheduleTime(t);
 

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -12,9 +12,8 @@ fixture`Service Page`
   .page(servicePage.url(serviceId));
 
 const modifySheduleTime = async (t, action = 'add') => {
-  // Click edit service button
-  await t
-    .click(servicePage.editButton);
+  // Navigate to edit page
+  await t.navigateTo(editResourcePage.url(1))
 
   // Get the correct service and it's schedule
   const service = EditResourcePage.getService(serviceId);

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -75,7 +75,7 @@ test('Confirm Service Schedule Day Can Be Added', async t => {
 // TODO: Uncomment with the completion of ISSUE #594
 test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
   // Wait for page to load before counting services by using hover action.
-  await t.navigateTo(editResourcePage.url(1))
+  await t.hover(servicePage.schedule);
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
@@ -84,7 +84,6 @@ test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
 
   await t
     .navigateTo(servicePage.url(serviceId))
-    .hover(servicePage.editButton);
 
   await modifySheduleTime(t, 'remove');
 

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -6,7 +6,7 @@ const editResourcePage = new EditResourcePage();
 
 // Define service id to navigate to
 // Tests depend on service id
-const serviceId = 5;
+const serviceId = 1;
 fixture`Service Page`
   // TODO: Dynamically find a service to test against
   .page(servicePage.url(serviceId));


### PR DESCRIPTION
Removes the `Edit` button from the organization listing page so it can't be edited by external users. BTW - The reason I have so many commits attempting to fix tests is my local TestCafe setup isn't working for some reason and I'm trying to get this out as quickly as possible :/ Will make sure to squash commits before merging! 

**Before:**
<img width="888" alt="Screen Shot 2019-10-30 at 8 17 12 PM" src="https://user-images.githubusercontent.com/13101677/67916240-4f6dd980-fb52-11e9-915c-4a32105550d1.png">
**After:**
<img width="873" alt="Screen Shot 2019-10-30 at 8 15 31 PM" src="https://user-images.githubusercontent.com/13101677/67916251-5399f700-fb52-11e9-8b11-46339d8830e0.png">
