### PR TITLE
TestCafe: Fix Add Service Schedule Day test.

### DIFF
--- a/testcafe/pages/ServicePage.js
+++ b/testcafe/pages/ServicePage.js
@@ -20,4 +20,17 @@ export default class ServicePage {
     this.schedule = baseSelector.findReact('TableOfOpeningTimes tbody tr');
     this.url = serviceId => `${config.baseUrl}/services/${serviceId}`;
   }
+
+  /**
+   * Wait until the page is fully loaded.
+   *
+   * Some TestCafe actions may attempt to run before a page is fully loaded, so
+   * this method can be called to force us to wait until the page is loaded
+   * first.
+   *
+   * @param t - A TestCafe test Promise.
+   */
+  async waitUntilPageLoaded(t) {
+    await t.hover(this.name);
+  }
 }

--- a/testcafe/service.js
+++ b/testcafe/service.js
@@ -57,9 +57,8 @@ test('Confirm Page Loads with Information', async t => {
     .ok();
 });
 
-test.skip('Confirm Service Schedule Day Can Be Added', async t => {
-  // Wait for page to load before counting services by using hover action.
-  await t.hover(servicePage.schedule);
+test('Confirm Service Schedule Day Can Be Added', async t => {
+  await servicePage.waitUntilPageLoaded(t);
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
@@ -68,29 +67,30 @@ test.skip('Confirm Service Schedule Day Can Be Added', async t => {
 
   await modifySheduleTime(t, 'add');
 
+  await t.navigateTo(servicePage.url(serviceId));
+  await servicePage.waitUntilPageLoaded(t);
   await t
-    .navigateTo(editResourcePage.url(1))
     .expect(servicePage.schedule.count)
     .eql(originalScheduleDayCount + 1);
 });
 
 // TODO: Uncomment with the completion of ISSUE #594
 test.skip('Confirm Service Schedule Day Can Be Deleted', async t => {
-  // Wait for page to load before counting services by using hover action.
-  await t.hover(servicePage.schedule);
+  await servicePage.waitUntilPageLoaded(t);
 
   // Count the number of schedule days
   const originalScheduleDayCount = await servicePage.schedule.with({ boundTestRun: t }).count;
 
   await modifySheduleTime(t);
 
-  await t
-    .navigateTo(servicePage.url(serviceId));
+  await t.navigateTo(servicePage.url(serviceId));
+  await servicePage.waitUntilPageLoaded(t);
 
   await modifySheduleTime(t, 'remove');
 
+  await t.navigateTo(servicePage.url(serviceId));
+  await servicePage.waitUntilPageLoaded(t);
   await t
-    .navigateTo(editResourcePage.url(1))
     .expect(servicePage.schedule.count)
     .eql(originalScheduleDayCount - 1);
 });


### PR DESCRIPTION
See https://github.com/ShelterTechSF/askdarcel-web/pull/895/files#r347166009, but it looks like the reason that the TestCafe test was failing for us is because we accidentally navigated to the wrong page.

I also added in some changes to refactor the `t.hover()` into a method with a name that more obviously describes what it is doing, which is to wait for the page to load.