### PR TITLE
Add meta tags to html-webpack-plugin so that they are available statically.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= htmlWebpackPlugin.options.title %></title>
+  <meta property="og:image" content="<%= require('assets/img/sfsg-preview.png') %>" />
 </head>
 <body>
   <div id="root"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,8 +48,21 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      title: 'Ask Darcel',
+      title: 'SF Service Guide',
       template: 'app/index.html',
+      meta: {
+        'og:url': 'https://sfserviceguide.org',
+        'og:title': 'SF Service Guide',
+        'twitter:card': 'summary_large_image',
+        'twitter:site': '@sheltertechorg',
+        'og:description': 'Get guided help finding food, housing, health resources and more in San Francisco',
+        'og:type': 'website',
+        // Note: The image is specified in the HTML itself because it needs to
+        // reference an image file.
+        'og:image:type': 'image/png',
+        'og:image:width': '1200',
+        'og:image:height': '630',
+      },
       favicon: 'app/favicon.ico',
     }),
     new ExtendedDefinePlugin({


### PR DESCRIPTION
As discussed on Slack, my previous PR (#900) doesn't work for most social media sites because the meta tags created in React are only available once the React application is bootstrapped and running. We need the meta tags to be available from just loading the HTML.

Although the longer-term solution probably involves setting up server-side rendering, for now we can statically add the relevant meta tags to the base HTML template.

I checked that this works locally by downloading the HTML with `curl` without executing the React code and checking that the tags are all there. Note that you will need to run `docker-compose run --rm web npm run build` to regenerate the HTML file first if you want to test this out locally.