### PR TITLE
Hardcode sfserviceguide.org for absolute URL to og:image.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= htmlWebpackPlugin.options.title %></title>
-  <meta property="og:image" content="<%= require('assets/img/sfsg-preview.png') %>" />
+  <meta property="og:image" content="https://sfserviceguide.org<%= require('assets/img/sfsg-preview.png') %>" />
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
Apparently links to images in the `og:image` tag need to be absolute, not relative. (https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url).

This is not great, but the best we can do is hardcode `https://sfserviceguide.org` as a prefix to the URL. The challenge for us is that we deploy the same Docker image in both staging and production environments, and the URL is not known at image building time since it changes depending on where we deploy to. To add to the challenge, we even have the same deployment used for both the SF Service Guide and the Ask Darcel sites, which can only tell the difference based on which URL was used to make the request.

This really will not be possible to do "correctly" without an actual "backend" to the frontend application.