### PR TITLE
Refactor EditAddress state

### DIFF
--- a/app/components/edit/EditAddress.jsx
+++ b/app/components/edit/EditAddress.jsx
@@ -1,92 +1,45 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
-const hasNoLocation = address => {
-  const someFieldExistsOrNewAddress = typeof address === 'undefined'
-    || address.name !== '' || address.address_1 !== ''
-    || address.address_2 !== '' || address.address_3 !== ''
-    || address.address_4 !== '' || address.city !== '' || address.postal_code !== ''
-    || address.state_province !== '' || address.country !== '';
-  if (someFieldExistsOrNewAddress) {
-    return false;
-  }
-  return true;
+const EditAddress = ({ address, setAddress, setHasLocation }) => (
+  <AddressForm
+    setAddress={setAddress}
+    setHasLocation={setHasLocation}
+    address={address}
+  />
+);
+
+EditAddress.propTypes = {
+  address: PropTypes.object,
+  setAddress: PropTypes.func.isRequired,
+  setHasLocation: PropTypes.func.isRequired,
 };
 
-class EditAddress extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { address: {}, noLocation: hasNoLocation(props.address) };
-    this.handleAddressChange = this.handleAddressChange.bind(this);
-    this.handleNoLocationChange = this.handleNoLocationChange.bind(this);
-  }
-
-  handleAddressChange(e) {
-    const { field } = e.target.dataset;
-    const { value } = e.target;
-    const { address } = this.state;
-    const { updateAddress } = this.props;
-    address[field] = value;
-    this.setState(address, () => {
-      updateAddress(address);
-    });
-  }
-
-  handleNoLocationChange() {
-    const { updateAddress } = this.props;
-    this.setState(state => {
-      const { address } = this.props;
-      let newAddr;
-      if (state.noLocation) {
-        newAddr = address;
-      } else {
-        newAddr = {
-          name: '',
-          address_1: '',
-          address_2: '',
-          address_3: '',
-          address_4: '',
-          city: '',
-          country: '',
-          postal_code: '',
-          state_province: '',
-        };
-      }
-      return { noLocation: !state.noLocation, address: newAddr };
-    }, () => {
-      const { address } = this.state;
-      updateAddress(address);
-    });
-  }
-
-  render() {
-    const { address = {} } = this.props;
-    const { noLocation } = this.state;
-    return (
-      <AddressForm
-        handleAddressChange={this.handleAddressChange}
-        handleNoLocationChange={this.handleNoLocationChange}
-        noLocation={noLocation}
-        address={address}
-      />
-    );
-  }
-}
+EditAddress.defaultProps = {
+  address: null,
+};
 
 const AddressForm = ({
-  noLocation, handleNoLocationChange, handleAddressChange, address,
-}) => (
-  <li key="address" className="edit--section--list--item">
-    <label htmlFor="address">Address</label>
-    <label className="inline-checkbox">
-      <input
-        type="checkbox"
-        className="input-checkbox"
-        checked={noLocation}
-        onChange={handleNoLocationChange}
-      />
+  setHasLocation, setAddress, address,
+}) => {
+  const handleFieldChange = event => {
+    const { target } = event;
+    const { value, dataset: { field } } = target;
+    setAddress({ ...address, [field]: value });
+  };
+  return (
+    <li key="address" className="edit--section--list--item">
+      <label htmlFor="address">Address</label>
+      <label className="inline-checkbox">
+        <input
+          type="checkbox"
+          className="input-checkbox"
+          checked={!address}
+          onChange={e => setHasLocation(!e.target.checked)}
+        />
         No Physical Location
-    </label>
-    {!noLocation
+      </label>
+      {address
         && (
           <div>
             <input
@@ -94,77 +47,78 @@ const AddressForm = ({
               className="input"
               placeholder="Name"
               data-field="name"
-              defaultValue={address.name}
-              onChange={handleAddressChange}
+              value={address.name}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="Address 1"
               data-field="address_1"
-              defaultValue={address.address_1}
-              onChange={handleAddressChange}
+              value={address.address_1}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="Address 2"
               data-field="address_2"
-              defaultValue={address.address_2}
-              onChange={handleAddressChange}
+              value={address.address_2}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="Address 3"
               data-field="address_3"
-              defaultValue={address.address_3}
-              onChange={handleAddressChange}
+              value={address.address_3}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="Address 4"
               data-field="address_4"
-              defaultValue={address.address_4}
-              onChange={handleAddressChange}
+              value={address.address_4}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="City"
               data-field="city"
-              defaultValue={address.city}
-              onChange={handleAddressChange}
+              value={address.city}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="State/Province"
               data-field="state_province"
-              defaultValue={address.state_province}
-              onChange={handleAddressChange}
+              value={address.state_province}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="Country"
               data-field="country"
-              defaultValue={address.country}
-              onChange={handleAddressChange}
+              value={address.country}
+              onChange={handleFieldChange}
             />
             <input
               type="text"
               className="input"
               placeholder="Postal/Zip Code"
               data-field="postal_code"
-              defaultValue={address.postal_code}
-              onChange={handleAddressChange}
+              value={address.postal_code}
+              onChange={handleFieldChange}
             />
           </div>
         )
     }
-  </li>
-);
+    </li>
+  );
+};
 
 export default EditAddress;

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -241,12 +241,41 @@ const prepSchedule = scheduleObj => {
 
 const deepClone = obj => JSON.parse(JSON.stringify(obj));
 
+const addressIsBlank = address => {
+  if (_.isEmpty(address)) {
+    return true;
+  }
+  const someFieldExists = address.name !== ''
+    || address.address_1 !== ''
+    || address.address_2 !== ''
+    || address.address_3 !== ''
+    || address.address_4 !== ''
+    || address.city !== ''
+    || address.postal_code !== ''
+    || address.state_province !== ''
+    || address.country !== '';
+  return !someFieldExists;
+};
+
+const blankAddress = Object.freeze({
+  name: '',
+  address_1: '',
+  address_2: '',
+  address_3: '',
+  address_4: '',
+  city: '',
+  country: '',
+  postal_code: '',
+  state_province: '',
+});
+
 class OrganizationEditPage extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
       scheduleObj: {},
+      hasLocation: false,
       address: {},
       services: {},
       deactivatedServiceIds: new Set(),
@@ -263,7 +292,6 @@ class OrganizationEditPage extends React.Component {
     this.handleResourceFieldChange = this.handleResourceFieldChange.bind(this);
     this.handleScheduleChange = this.handleScheduleChange.bind(this);
     this.handlePhoneChange = this.handlePhoneChange.bind(this);
-    this.handleAddressChange = this.handleAddressChange.bind(this);
     this.handleNotesChange = this.handleNotesChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleDeactivation = this.handleDeactivation.bind(this);
@@ -277,7 +305,10 @@ class OrganizationEditPage extends React.Component {
     window.addEventListener('beforeunload', this.keepOnPage);
     if (splitPath[splitPath.length - 1] === 'new') {
       this.setState({
-        newResource: true, resource: { schedule: {} }, scheduleObj: buildScheduleDays(undefined),
+        hasLocation: true,
+        newResource: true,
+        resource: { schedule: {} },
+        scheduleObj: buildScheduleDays(undefined),
       });
     }
     const resourceID = params.id;
@@ -306,9 +337,11 @@ class OrganizationEditPage extends React.Component {
       }),
       {},
     );
+
     this.setState({
       resource,
       services,
+      hasLocation: !addressIsBlank(resource.addresses[0]),
       scheduleObj: buildScheduleDays(resource.schedule),
     });
   }
@@ -390,6 +423,39 @@ class OrganizationEditPage extends React.Component {
     });
   }
 
+  // Combine several sources of data to provide a view of an address appropriate
+  // both for the UI and for sending API requests.
+  //
+  // this.state.resource.address always contains the original, unmodified
+  // address that came from the initial API load. (Note, it might be the case
+  // that this field is being modified without going through this.setState().
+  // Whoops!)
+  //
+  // this.state.address only contains modifications to the address
+  //
+  // this.state.hasLocation = false will always force the flattened address to
+  // be "null/empty". This reason this exists as a separate flag instead of
+  // actually just nullifying this.state.address is so that when toggling back
+  // and forth between having and not having a location, the previous values are
+  // restored.
+  getFlattenedAddress = () => {
+    const { resource, address, hasLocation } = this.state;
+    if (!hasLocation) {
+      return null;
+    }
+    // TODO: Update this to handle multiple addresses
+    const { addresses: resourceAddresses = [] } = resource;
+    return { ...blankAddress, ...resourceAddresses[0], ...address };
+  }
+
+  setAddress = address => {
+    this.setState({ address, inputsDirty: true });
+  }
+
+  setHasLocation = hasLocation => {
+    this.setState({ hasLocation, inputsDirty: true });
+  }
+
   keepOnPage(e) {
     const { inputsDirty } = this.state;
     if (inputsDirty) {
@@ -450,6 +516,7 @@ class OrganizationEditPage extends React.Component {
       address,
       alternate_name,
       email,
+      hasLocation,
       legal_status,
       long_description,
       name,
@@ -510,12 +577,100 @@ class OrganizationEditPage extends React.Component {
     postSchedule(scheduleObj, promises);
 
     // address
-    if (!_.isEmpty(address) && resource.addresses) {
-      // TODO: Allow for change of multiple addresses
-      // Temporary solution until the full implementaion for editing multiple addresses goes in
-      // All organizations only have one address right now anyways
-      promises.push(dataService.post(`/api/addresses/${resource.addresses[0].id}/change_requests`, {
-        change_request: address,
+    //
+    // There are many possible scenarios here, some of which we just cannot
+    // support right now and we should just fail loudly if they happen.
+    //
+    // In terms of starting states, we have the following:
+    //
+    //   No addresses associated with the resource:
+    //     We can't really handle this case today so just abort.
+    //
+    //   Multiple addresses asociated with the resource:
+    //     We can't really handle this case today so just abort.
+    //
+    //   Exactly one address associated with the resource:
+    //     Two cases:
+    //     1. Every single field on the address is the blank string. This is
+    //        equivalent to "No Physical Location", since previously (and
+    //        currently) we had no way of deleting an address.
+    //     2. The address is not blank.
+    //
+    //  If we ignore the 0 and > 1 address cases, then we only have to handle
+    //  stating states 1) and 2).
+    //
+    //  Drilling down deeper into each of these starting states, we list out the
+    //  possible user actions:
+    //    1. Started with "No Physical Location"/blank address.
+    //      a) User does not touch anything related to the address field.
+    //         => Don't submit anything related to the address.
+    //      b) User unchecks the "No Physical Location" box.
+    //         => Submit all of the field changes as a change request. Note that
+    //            because the id field is _not_ blank, we still have an ID that
+    //            we can target.
+    //
+    //    2. Started with a non-blank address.
+    //      a) User does not touch anything related to the address field.
+    //         => Don't submit anything related to the address.
+    //      b) User modifies a field on the address.
+    //         => Submit all of the field changes as a change request.
+    //      c) User checks the "No Physical Location" box.
+    //         => Blank out all of the fields and then submit a change request
+    //         with the fields blanked out.
+    //
+    // Just to reiterate the actual representation of these states within the
+    // React this.state property:
+    //
+    //   this.state.resource.addresses[0]
+    //     Represents the original, unmodified address from the API load.
+    //
+    //   this.state.address
+    //     Represents any diffs to the address field, and should generally be
+    //     combined with this.state.resource.addresses[0] to get the full
+    //     representation of the resource.
+    //
+    //   this.state.hasLocation
+    //     Represents whether the user has (un)checked the "No Physical
+    //     Location") checkbox, and should be consulted before directly reading
+    //     from this.state.address. For UI purposes, we don't want to
+    //     immediately blank out this.state.address in case if the user unchecks
+    //     the "No Physical Location" checkbox, since we would want to restore
+    //     the previous values.
+
+    // Abort on the unhandled cases
+    if (_.isEmpty(resource.addresses) || resource.addresses.length !== 1) {
+      alert('Issue saving changes.');
+      throw new Error(`Cannot handle resource with 0 or more than 1 address. Resource id: ${resource.id}.`);
+    }
+
+    const originalAddress = resource.addresses[0];
+
+    // Scenario 1)
+    if (addressIsBlank(originalAddress)) {
+      if (!hasLocation) {
+        // 1a)
+        // Do nothing
+      } else {
+        // 1b)
+        promises.push(dataService.post(`/api/addresses/${originalAddress.id}/change_requests`, {
+          change_request: address,
+        }));
+      }
+    // Scenario 2)
+    } else if (hasLocation) {
+      if (_.isEmpty(address)) {
+        // 2a)
+        // Do nothing
+      } else {
+        // 2b)
+        promises.push(dataService.post(`/api/addresses/${originalAddress.id}/change_requests`, {
+          change_request: address,
+        }));
+      }
+    } else {
+      // 2c)
+      promises.push(dataService.post(`/api/addresses/${originalAddress.id}/change_requests`, {
+        change_request: blankAddress,
       }));
     }
 
@@ -596,10 +751,6 @@ class OrganizationEditPage extends React.Component {
     this.setState({ scheduleObj, inputsDirty: true });
   }
 
-  handleAddressChange(addressObj) {
-    this.setState({ address: addressObj, inputsDirty: true });
-  }
-
   handleNotesChange(notesObj) {
     this.setState({ notes: notesObj, inputsDirty: true });
   }
@@ -630,12 +781,6 @@ class OrganizationEditPage extends React.Component {
 
   renderSectionFields() {
     const { resource, scheduleObj } = this.state;
-
-    // TODO: Do not just show the first address
-    // Temporary solution until the full implementaion for editing multiple addresses goes in
-    // All organizations only have one address right now anyways
-    const { addresses = [] } = resource;
-    const address = addresses[0];
     return (
       <section id="info" className="edit--section">
         <ul className="edit--section--list">
@@ -667,8 +812,9 @@ class OrganizationEditPage extends React.Component {
           </li>
 
           <EditAddress
-            address={address}
-            updateAddress={this.handleAddressChange}
+            address={this.getFlattenedAddress()}
+            setAddress={this.setAddress}
+            setHasLocation={this.setHasLocation}
           />
 
           <EditPhones


### PR DESCRIPTION
As mentioned in https://github.com/ShelterTechSF/askdarcel-web/pull/889#issuecomment-570960935, this is my attempt at refactoring the state management on the Edit page with respect to addresses to simplify the supporting of multiple addresses.

This is branched from https://github.com/ShelterTechSF/askdarcel-web/pull/894, so the diff will be messy and include the stuff from that PR until that PR merges in to master. In the meantime, you can look at the following diff view to see what was added in this PR: https://github.com/ShelterTechSF/askdarcel-web/compare/akalkanis_885_resource_page_multiple_addresses...refactor-edit-address-state

Basically what I tried to do was remove all React state from the `<EditAddress>` component, and hoist whatever necessary state into the OrganizationEditPage itself. Previously there were four (!) different places that held state related to the address, and updates to them were very difficult to keep track of, not to mention one of them violated the React rule of not directly mutating the state object:

1. `OrganizationEditPage.state.resource.addresses[0]`: This was the state of the address as it came from the initial API request. However, due to this line, we were previously directly mutating it: https://github.com/ShelterTechSF/askdarcel-web/blob/5a85d49fd50ae2e731cc26f9fea34de5717a5733/app/components/edit/EditAddress.jsx#L28

    This is [not allowed by React](https://reactjs.org/docs/react-component.html#state), and it could lead to undefined behavior, since React does not know that we are modifying its value that we. We were unfortunately relying on this undefined behavior.

2. `OrganizationEditPage.state.address`: This usually represented any modifications to the address, since most of the time we didn't directly modify `this.state.resource.addresses[0]`.

3. `EditAddress.state.address`: This was the original EditAddress component's state of the address, and it wasn't always clear how it related to both of the other two states above. In addition, `<EditAddress>` also contained an extra `hasNoLocation` boolean state variable that was not present in `OrganizationEditPage` at all.

4. The actual `<input>` elements in `EditAddress`, since they are [uncontrolled components](https://reactjs.org/docs/uncontrolled-components.html). This mean that they kept track of their own state independent of the components that contain them.

I think I managed to collapse these all into really two places:
1. `OrganizationEditPage.state.resource.addresses[0]`, which really should be immutable now, and
2. `OrganizationEditPage.state.address`/`OrganizationEditPage.state.hasLocation`, which is expected to mutate as a user modifies fields.

There are a bunch of tricky edge cases to keep in mind, and I have a very long comment in the `handleSubmit()` method that describes 7 scenarios, 2 of which I am just throwing an exception for until we actually handle multiple addresses and 0 addresses.

Just note that this does not actually do anything to support multiple addresses, but I think by getting rid of the redundant state, it'll make it easier to actually implement that feature because we won't have to carefully keep four different representations of the same state in sync.