### PR TITLE
Re-enable no-plusplus ESLint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'jsx-a11y/label-has-for': ['error', { required: { some: ['nesting', 'id'] } }],
     'no-console': 'warn',
-    'no-plusplus': 'off',
     'no-underscore-dangle': 'off',
     'react/forbid-prop-types': 'off',
     'react/prefer-stateless-function': 'off',

--- a/app/components/edit/EditCollection.jsx
+++ b/app/components/edit/EditCollection.jsx
@@ -55,29 +55,25 @@ export default function editCollectionHOC(ResourceObjectItem,
 
     createItemComponents() {
       const { collection } = this.state;
-      const items = [];
-      for (let i = 0; i < collection.length; i++) {
-        if (!collection[i].isRemoved) {
-          items.push(
-            <div key={i} className="edit--section--list--item--collection-container">
-              <ResourceObjectItem
-                index={i}
-                item={collection[i]}
-                handleChange={this.handleChange}
-              />
-              <button
-                type="button"
-                className="trash-button icon-button"
-                onClick={() => this.removeItem(i, collection[i])}
-              >
-                <i className="material-icons">&#xE872;</i>
-              </button>
-            </div>,
-          );
-        }
-      }
-
-      return items;
+      return collection
+        .map((item, index) => [item, index])
+        .filter(([item]) => !item.isRemoved)
+        .map(([item, index]) => (
+          <div key={index} className="edit--section--list--item--collection-container">
+            <ResourceObjectItem
+              index={index}
+              item={item}
+              handleChange={this.handleChange}
+            />
+            <button
+              type="button"
+              className="trash-button icon-button"
+              onClick={() => this.removeItem(index, item)}
+            >
+              <i className="material-icons">&#xE872;</i>
+            </button>
+          </div>
+        ));
     }
 
     render() {

--- a/app/components/edit/EditNotes.jsx
+++ b/app/components/edit/EditNotes.jsx
@@ -64,22 +64,15 @@ class EditNotes extends Component {
 
   renderNotes() {
     const { existingNotes } = this.state;
-    const notesArray = [];
-
-    for (let i = 0; i < existingNotes.length; i++) {
-      const note = existingNotes[i];
-      notesArray.push(
-        <EditNote
-          key={note.key}
-          index={i}
-          note={note}
-          handleChange={this.handleNoteChange}
-          removeNote={this.removeNote}
-        />,
-      );
-    }
-
-    return notesArray;
+    return existingNotes.map((note, i) => (
+      <EditNote
+        key={note.key}
+        index={i}
+        note={note}
+        handleChange={this.handleNoteChange}
+        removeNote={this.removeNote}
+      />
+    ));
   }
 
   render() {

--- a/tools/cli/approveChangeRequests.js
+++ b/tools/cli/approveChangeRequests.js
@@ -49,12 +49,12 @@ function approveChangeRequests() {
       return data.change_requests.reduce((action, changeRequest) => action
         .catch(err => {
           console.log(err);
-          stats.errors++;
+          stats.errors += 1;
         })
         .then(() => {
           // If this changeRequest was not marked duplicate
           if (!duplicates[changeRequest.id]) {
-            stats.approved++;
+            stats.approved += 1;
             const body = {};
             changeRequest.field_changes.forEach(fieldChange => {
               const { field_name, field_value } = fieldChange;
@@ -68,7 +68,7 @@ function approveChangeRequests() {
             }).then(() => console.log('approved', changeRequest.id));
           }
           console.log('not applying duplicate', changeRequest.id);
-          stats.duplicates++;
+          stats.duplicates += 1;
           return Promise.resolve();
         }), Promise.resolve('first'));
     })


### PR DESCRIPTION
The [`no-plusplus`](https://eslint.org/docs/rules/no-plusplus) rule disallows the use of the `i++` unary operator, and it is enabled by default in the Airbnb style guide. This PR deletes the line in our `.eslintrc.js` so that it is enforced again.

I'm of the opinion that we should 1) stick as closely as possible to common style guides and 2) that most usages of `i++` are in loops where we should prefer `.map()`, `.flatMap()`, or `.reduce()` anyway, so I'd prefer to re-enable the rule.

It's also simple enough to type in the allowed `i += 1`, which is not vulnerable to the potentially awkward semicolon insertion issue that the rule was designed for.