### PR TITLE
Fix New Org Creation

### DIFF
--- a/app/components/edit/EditAddress.jsx
+++ b/app/components/edit/EditAddress.jsx
@@ -77,7 +77,7 @@ const AddressForm = ({
 }) => (
   <li key="address" className="edit--section--list--item">
     <label htmlFor="address">Address</label>
-    <label>
+    <label className="inline-checkbox">
       <input
         type="checkbox"
         className="input-checkbox"

--- a/app/components/edit/EditSchedule.jsx
+++ b/app/components/edit/EditSchedule.jsx
@@ -31,13 +31,16 @@ class EditSchedule extends Component {
         { canInheritFromParent
           && (
             <div className="inherit-schedule">
-              <input
-                id="inherit"
-                type="checkbox"
-                checked={shouldInheritFromParent}
-                onChange={() => setShouldInheritFromParent(!shouldInheritFromParent)}
-              />
-              <label htmlFor="inherit">Inherit schedule from parent organization</label>
+              <label htmlFor="inherit" className="inline-checkbox">
+                <input
+                  id="inherit"
+                  className="input-checkbox"
+                  type="checkbox"
+                  checked={shouldInheritFromParent}
+                  onChange={() => setShouldInheritFromParent(!shouldInheritFromParent)}
+                />
+                Inherit schedule from parent organization
+              </label>
             </div>
           )
         }

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -226,6 +226,9 @@ const prepSchedule = scheduleObj => {
   let tempDay = {};
   Object.keys(scheduleObj).forEach(day => {
     scheduleObj[day].forEach(curr => {
+      if (curr.opens_at === null || curr.closes_at === null) {
+        return;
+      }
       tempDay = {};
       tempDay.day = day;
       tempDay.opens_at = curr.opens_at;
@@ -274,7 +277,7 @@ class OrganizationEditPage extends React.Component {
     window.addEventListener('beforeunload', this.keepOnPage);
     if (splitPath[splitPath.length - 1] === 'new') {
       this.setState({
-        newResource: true, resource: { schedule: {}, scheduleObj: buildScheduleDays(undefined) },
+        newResource: true, resource: { schedule: {} }, scheduleObj: buildScheduleDays(undefined),
       });
     }
     const resourceID = params.id;

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -410,7 +410,7 @@ class OrganizationEditPage extends React.Component {
     const schedule = prepSchedule(scheduleObj);
     const newResource = {
       name,
-      addresses: [address],
+      address,
       long_description,
       email,
       website,

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -413,7 +413,7 @@ class OrganizationEditPage extends React.Component {
     const schedule = prepSchedule(scheduleObj);
     const newResource = {
       name,
-      address,
+      addresses: [address],
       long_description,
       email,
       website,

--- a/app/pages/OrganizationEditPage.scss
+++ b/app/pages/OrganizationEditPage.scss
@@ -135,10 +135,13 @@
     }
 
     .input-checkbox {
-      margin-bottom: calc-em(10px);
       margin-right: calc-em(5px);
       width: auto;
-      float: left;
+    }
+
+    .inline-checkbox {
+      display: flex;
+      align-items: center;
     }
 
     input:not(last-of-type) {


### PR DESCRIPTION
See @Maxastuart 's report in channel for context: https://sheltertech.slack.com/archives/C0EGCTDCL/p1580195509055400

There were a few issues here. 
1) The first was that the API was throwing a 500 on submission because we were trying to send a resource with an `addresses` field and it only knows how to handle POSTs with an `address` field. 
2) Next, we weren't rendering an hours template for the new resource because we were generating the temporary schedule object and adding it to the component state nested in the `resource` object. It should be directly on component state.
3) Finally, the API errors if you send a schedule day with a null `opens_at` or `closes_at`. So, had to add some additional cleaning of the schedule before actually sending it up to remove any schedule days that had null times

### BEFORE
<img width="1552" alt="Screen Shot 2020-01-28 at 11 01 44 PM" src="https://user-images.githubusercontent.com/7386336/73334685-398bb580-4222-11ea-9dec-a17f8fc20ccd.png">

### AFTER
<img width="1552" alt="Screen Shot 2020-01-28 at 11 02 02 PM" src="https://user-images.githubusercontent.com/7386336/73334690-3c86a600-4222-11ea-98b8-01fa3098939d.png">

In addition to the functional changes necessary above, I also tweaked some styling on the checkboxes.

### BEFORE
<img width="435" alt="Screen Shot 2020-01-28 at 11 00 09 PM" src="https://user-images.githubusercontent.com/7386336/73334605-06492680-4222-11ea-9249-890d09c0159c.png">
<img width="282" alt="Screen Shot 2020-01-28 at 11 00 15 PM" src="https://user-images.githubusercontent.com/7386336/73334604-06492680-4222-11ea-9f83-e0f6f952bfa6.png">

### AFTER
<img width="343" alt="Screen Shot 2020-01-28 at 10 59 38 PM" src="https://user-images.githubusercontent.com/7386336/73334587-fe898200-4221-11ea-91a5-1e680f549d1e.png">
<img width="272" alt="Screen Shot 2020-01-28 at 10 59 03 PM" src="https://user-images.githubusercontent.com/7386336/73334590-ff221880-4221-11ea-8ec4-80fff3b38849.png">