### PR TITLE
Explicitly handle case where addresses is null, not undefined.

### DIFF
--- a/app/components/search/SearchEntry.jsx
+++ b/app/components/search/SearchEntry.jsx
@@ -9,7 +9,9 @@ import './SearchEntry.scss';
 class SearchEntry extends Component {
   renderAddressMetadata() {
     const { hit } = this.props;
-    const { addresses = [] } = hit;
+    const { addresses: rawAddresses } = hit;
+    const addresses = rawAddresses || [];
+
     if (addresses.length === 0) {
       return <span>No address found</span>;
     }

--- a/app/components/search/SearchMap.jsx
+++ b/app/components/search/SearchMap.jsx
@@ -85,7 +85,8 @@ const SearchMap = ({
   }
 
   const markers = hits.map((hit, index) => {
-    const { addresses = [] } = hit;
+    const { addresses: rawAddresses } = hit;
+    const addresses = rawAddresses || [];
     return addresses.map(address => (
       <CustomMarker
         hit={hit}


### PR DESCRIPTION
Today I learned that the object destructuring syntax in JavaScript treats `null`s differently than undefined keys. Basically, `const { foo = [] } = {}` will set `foo` to `[]`, but `const { foo = [] } = { foo: null }` will set `foo` to `null`.

This seems to only affect the code related to the Algolia search results, since they seem to always return `addresses: null` rather than omitting the key, which meant that us trying to set a default value of the empty array wouldn't work properly. This separates out those assignments into two separate lines to force it to handle the case where the key is explicitly present but set to `null`.

I tested this locally by configuring by local setup to point to the staging server's Algolia index, which seemed sufficient for reproducing the bug.