### PR TITLE
add temporary covid banner

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Intercom from 'react-intercom';
 import { connect } from 'react-redux';
+import Banner from './ui/Banner/Banner';
 import Navigation from './ui/Navigation/Navigation';
 // import CategoryPage from './find/FindPage';
 // import ResourcesTable from './search/ResourcesTable';
@@ -174,6 +175,7 @@ class App extends Component {
         />
         <div id={pageWrapId}>
           <Navigation showSearch toggleHamburgerMenu={this.toggleHamburgerMenu} />
+          <Banner />
           <div className="container">
             <Routes />
           </div>

--- a/app/components/ui/Banner/Banner.jsx
+++ b/app/components/ui/Banner/Banner.jsx
@@ -10,7 +10,8 @@ export default function Banner() {
         Please find the latest information on resources available during this pandemic
         {' '}
         <a className={styles.bannerLink} href="https://docs.google.com/document/d/1R9y8KLbU-oZTJheoqobmqg6TJxkwSjTkJvm6WywHURk/edit">here</a>
-        . We are working to incorporate active services into the SF Service Guide - check back for more updates.
+        . We are working to incorporate active services into the SF Service Guide
+         - check back for more updates.
       </span>
     </div>
   );

--- a/app/components/ui/Banner/Banner.jsx
+++ b/app/components/ui/Banner/Banner.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './Banner.scss';
+
+export default function Banner() {
+  return (
+    <div className={styles.bannerContainer}>
+      <strong>CORONAVIRUS (COVID-19) UPDATE: </strong>
+      <span>
+        Many resources are operating with abnormal or reduced hours.
+        Please find the latest information on resources available during this pandemic
+        {' '}
+        <a className={styles.bannerLink} href="https://docs.google.com/document/d/1R9y8KLbU-oZTJheoqobmqg6TJxkwSjTkJvm6WywHURk/edit">here</a>
+        . We are working to incorporate active services into the SF Service Guide - check back for more updates.
+      </span>
+    </div>
+  );
+}

--- a/app/components/ui/Banner/Banner.scss
+++ b/app/components/ui/Banner/Banner.scss
@@ -1,0 +1,17 @@
+@import '../../../styles/utils/_helpers.scss';
+
+.bannerContainer {
+  width: 100%;
+  padding: calc-em(20px) calc-em(30px);
+  color: $color-white;
+  background-color: $color-red;
+  font-size: calc-em(24px);
+  strong {
+    font-weight: bold;
+  }
+}
+
+.bannerLink {
+  text-decoration: underline;
+  color: $color-white;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,7 @@ module.exports = {
         exclude: [
           path.resolve(__dirname, 'app/components/ui/HamburgerMenu'),
           path.resolve(__dirname, 'app/components/ui/Navigation'),
+          path.resolve(__dirname, 'app/components/ui/Banner'),
           path.resolve(__dirname, 'app/components/listing/MobileActionBar'),
           path.resolve(__dirname, 'app/components/listing/ActionSidebar'),
           path.resolve(__dirname, 'app/components/listing/ServiceAttribution'),
@@ -128,6 +129,7 @@ module.exports = {
         include: [
           path.resolve(__dirname, 'app/components/ui/HamburgerMenu'),
           path.resolve(__dirname, 'app/components/ui/Navigation'),
+          path.resolve(__dirname, 'app/components/ui/Banner'),
           path.resolve(__dirname, 'app/components/listing/MOHCDBadge'),
           path.resolve(__dirname, 'app/components/listing/HAPBadge'),
           path.resolve(__dirname, 'app/pages/HomePage'),


### PR DESCRIPTION
Temp banner on homepage:
<img width="1439" alt="Screen Shot 2020-03-22 at 3 43 13 PM" src="https://user-images.githubusercontent.com/7386336/77265574-49d87380-6c5a-11ea-9539-2490d1005aa4.png">

Banner will show up on all pages:
<img width="1439" alt="Screen Shot 2020-03-22 at 3 43 24 PM" src="https://user-images.githubusercontent.com/7386336/77265556-40e7a200-6c5a-11ea-90ac-f8901851d7d5.png">

