### PR TITLE
Update banner copy

### DIFF
--- a/app/components/ui/Banner/Banner.jsx
+++ b/app/components/ui/Banner/Banner.jsx
@@ -5,11 +5,11 @@ export default function Banner() {
   return (
     <div className={styles.bannerContainer}>
       <strong>CORONAVIRUS COVID-19: </strong>
-      Many organizations and services have reduced hours and availability. See our new
+      Many organizations and services have reduced hours and availability. Click
       {' '}
-      <a className={styles.bannerLink} href="https://docs.google.com/document/d/1R9y8KLbU-oZTJheoqobmqg6TJxkwSjTkJvm6WywHURk/edit">Resource Guide</a>
+      <a className={styles.bannerLink} href="https://docs.google.com/document/d/1R9y8KLbU-oZTJheoqobmqg6TJxkwSjTkJvm6WywHURk/edit">here</a>
       {' '}
-      - updated daily
+      for a helpful resource guide - updated daily.
     </div>
   );
 }

--- a/app/components/ui/Banner/Banner.scss
+++ b/app/components/ui/Banner/Banner.scss
@@ -6,6 +6,7 @@
   color: black;
   background-color: $color-yellow;
   font-size: calc-em(24px);
+  text-align: center;
   strong {
     font-weight: bold;
   }


### PR DESCRIPTION
See conversation here: https://sheltertech.slack.com/archives/C010E72NA0Z/p1585426146299600

Laura asked that we update the banner copy so that it does not say that this resource guide is ours.

<img width="1305" alt="Screen Shot 2020-03-28 at 7 53 27 PM" src="https://user-images.githubusercontent.com/7386336/77838982-d1782380-712d-11ea-902e-9f556631efb9.png">
