### PR TITLE
revert banner copy and push hidden pop up to bottom of stack when hidden

### DIFF
--- a/app/components/ui/Banner/Banner.jsx
+++ b/app/components/ui/Banner/Banner.jsx
@@ -5,11 +5,11 @@ export default function Banner() {
   return (
     <div className={styles.bannerContainer}>
       <strong>CORONAVIRUS COVID-19: </strong>
-      Many organizations and services have reduced hours and availability. Click
+      Many organizations and services have reduced hours and availability. See our new
       {' '}
       <a className={styles.bannerLink} href="/covid">Resource Guide</a>
       {' '}
-      for a helpful resource guide - updated daily.
+      - updated daily.
     </div>
   );
 }

--- a/app/components/ui/PopUpMessage.scss
+++ b/app/components/ui/PopUpMessage.scss
@@ -28,6 +28,7 @@
   }
 
   &.hidden {
+    z-index: -1;
     opacity: 0;
   }
 }


### PR DESCRIPTION
Just reverting the banner copy to make clear that the covid list is ours. 

<img width="1507" alt="Screen Shot 2020-04-01 at 4 54 33 PM" src="https://user-images.githubusercontent.com/7386336/78197196-80bc3f80-7439-11ea-888b-fad03a538bb7.png">

Also noticed that we have the success pop up always rendered on the screen with an opacity of 0 and it sometimes obscures things underneath it (ie the `Resource Guide` link in the banner). The opacity is nice as-is so that it has a transition, so I just dropped the z-index to a negative number when its hidden and then it gets pulled up to the front when shown.