### PR TITLE
Clarify the ALGOLIA_INDEX_PREFIX instructions in config.example.yml.

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -9,6 +9,8 @@
 # AskDarcel project
 GOOGLE_API_KEY: 'AIzaSyAz2oiKYp048xbbjXH54PrNDdQO38I6-pc'
 
+# Please replace the entire value of the ALGOLIA_INDEX_PREFIX setting with your
+# GitHub username, including the < and > symbols.
 ALGOLIA_INDEX_PREFIX: '<ENTER_YOUR_GITHUB_USERNAME_HERE>'
 ALGOLIA_APPLICATION_ID: 'J8TVT53HPZ'
 ALGOLIA_READ_ONLY_API_KEY: 'fdf77b152ff7ce0ea4e4221ff3d17d85'


### PR DESCRIPTION
A number of people have accidentally thought that you need to leave in the `<` and `>` symbols in the ALGOLIA_INDEX_PREFIX in `config.yml`. I added a comment just above it that hopefully makes it very clear that you should replace the `<` and `>` symbols as well.