### PR TITLE
Hook eligibility modal up to food category

### DIFF
--- a/app/components/ui/Modal/Modal.jsx
+++ b/app/components/ui/Modal/Modal.jsx
@@ -7,7 +7,7 @@ import styles from './Modal.scss';
 
 export const BaseModal = props => {
   const {
-    backButtonText, closeModal, modalContent, isFullScreen,
+    backButtonText, closeModal, modalContent, modalFooter, isFullScreen,
   } = props;
 
   const modalBody = isFullScreen ? (
@@ -18,9 +18,12 @@ export const BaseModal = props => {
           {backButtonText}
         </div>
       </div>
-      <div className={styles.fullscreenModalBody}>
+      <div className={
+        modalFooter ? styles.fullscreenModalBodyWithFooter : styles.fullscreenModalBody}
+      >
         {modalContent}
       </div>
+      {modalFooter}
     </Fragment>
   ) : null;
 

--- a/app/components/ui/Modal/Modal.scss
+++ b/app/components/ui/Modal/Modal.scss
@@ -47,9 +47,13 @@
     }
 }
 
-.fullscreenModalBody{
+.fullscreenModalBody, .fullscreenModalBodyWithFooter {
     display: flex;
     width: 100%;
     justify-content: center;
     padding: 48px;
+}
+
+.fullscreenModalBodyWithFooter {
+    padding-bottom: 80px;
 }

--- a/app/components/ui/Modal/ServiceDiscoveryModal.jsx
+++ b/app/components/ui/Modal/ServiceDiscoveryModal.jsx
@@ -40,7 +40,7 @@ class ServiceDiscoveryModal extends Component {
   }
 
   render() {
-    const { isEligibility } = this.props;
+    const { isEligibility, closeModal } = this.props;
     const { eligibilities, subcategories, checkedItems } = this.state;
 
     const options = isEligibility ? eligibilities : subcategories;
@@ -48,7 +48,7 @@ class ServiceDiscoveryModal extends Component {
     const modalContent = (
       <div className={styles.contentContainer}>
         <h1>Tell us more about you</h1>
-        <h2>{isEligibility ? 'Please select the best that apply to your situation.' : 'What are you currently looking for? Select all that apply.'}</h2>
+        <h2>{isEligibility ? 'What statement do you best identify with?' : 'What are you currently looking for? Select all that apply.'}</h2>
         <ul>
           {options.map(option => (
             <li className={styles.listOption} key={option.id}>
@@ -66,11 +66,19 @@ class ServiceDiscoveryModal extends Component {
       </div>
     );
 
+    const modalFooter = (
+      <div className={styles.footer}>
+        <button type="button" className={styles.actionBack} onClick={e => { e.stopPropagation(); closeModal(); }}>Back</button>
+        <button type="button" className={styles.actionSubmit}>Submit</button>
+      </div>
+    );
+
     return (
       <BaseModal
         isFullScreen
         backButtonText="All resource guides"
         modalContent={modalContent}
+        modalFooter={modalFooter}
         {...this.props}
       />
     );

--- a/app/components/ui/Modal/ServiceDiscoveryModal.scss
+++ b/app/components/ui/Modal/ServiceDiscoveryModal.scss
@@ -34,3 +34,27 @@
         font-weight: 600;
     }
 }
+
+
+.footer {
+    display: flex;
+    justify-content: flex-end;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-top: 1px solid $color-grey3;
+    background-color: $color-white;
+    button {
+        margin: 18px;
+        border: 1px solid $color-brand;
+    }
+    .actionBack {
+        background-color: transparent;
+        color: $color-brand;
+    }
+    .actionSubmit {
+        background-color: $color-brand;
+        margin-right: 80px;
+    }
+}

--- a/app/pages/HomePage/components/GuideList/GuideList.jsx
+++ b/app/pages/HomePage/components/GuideList/GuideList.jsx
@@ -136,6 +136,7 @@ const GuideList = () => (
           name="Food resources"
           link="/covid/foodmap"
           img={ImgFood}
+          categoryId="1000001"
         />
       </li>
       <li className={styles.item}>


### PR DESCRIPTION
This PR hooks the new service discovery flow up to the new food category (id `1000001`). In addition, I realized I never added the footer & buttons to the eligibilities view. So, this adds them. Here's what it looks like with some dummy-data:

<img width="1527" alt="Screen Shot 2020-06-08 at 2 51 40 PM" src="https://user-images.githubusercontent.com/7386336/84084051-96009d80-a997-11ea-9dea-28c4d9f207fe.png">

We probably want to think about what we want to do about the intercom thing in this view. But for now I just pushed the buttons over a little bit so they aren't obscured by it.
