### PR TITLE
Refactor RefinementListFilter to reuse existing Algolia functionality.

### DIFF
--- a/app/pages/ServiceDiscoveryResults/RefinementListFilter.jsx
+++ b/app/pages/ServiceDiscoveryResults/RefinementListFilter.jsx
@@ -1,86 +1,36 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connectRefinementList } from 'react-instantsearch/connectors';
 import styles from './ServiceDiscoveryResults.scss';
 
-class RefinementListFilter extends Component {
-  static propTypes = {
-    refine: PropTypes.func.isRequired,
-    currentRefinement: PropTypes.array.isRequired,
-  };
+const RefinementListFilter = ({ items, refine }) => (
+  <div className="refinement-wrapper">
+    <ul className="refinement-ul">
+      {items.map(item => (
+        <label key={item.label} className={styles.checkBox}>
+          {item.label}
+          <input
+            type="checkbox"
+            checked={item.isRefined}
+            onChange={e => {
+              e.preventDefault();
+              refine(item.value);
+            }}
+          />
+        </label>
+      ))}
+    </ul>
+  </div>
+);
 
-  constructor(props) {
-    super(props);
-
-    const checks = {};
-    props.availableOptions
-      .forEach(opt => { checks[opt.name] = props.selectedOptions[opt.id]; });
-
-    this.state = {
-      isChecked: checks,
-    };
-
-    this.changeRefinement = this.changeRefinement.bind(this);
-    this.setChecks = this.setChecks.bind(this);
-  }
-
-  componentDidUpdate(prevProps) {
-    const { currentRefinement } = this.props;
-    if (currentRefinement.sort().join(',') !== prevProps.currentRefinement.sort().join(',')) {
-      const checks = this.setChecks();
-      // setState is done in a condition so it won't create loop
-      this.setState({ isChecked: checks }); // eslint-disable-line react/no-did-update-set-state
-    }
-  }
-
-  setChecks() {
-    const { availableOptions, currentRefinement } = this.props;
-    const checks = {};
-    availableOptions.forEach(opt => {
-      checks[opt.name] = currentRefinement.includes(opt.name);
-    });
-    return checks;
-  }
-
-  changeRefinement(option, event) { // eslint-disable-line no-unused-vars
-    const { refine } = this.props;
-    const { currentRefinement } = this.props;
-    const { isChecked } = this.state;
-    let newRefinement;
-    if (isChecked[option]) {
-      // If option currently checked, remove from refinement
-      newRefinement = currentRefinement.filter(value => option !== value);
-    } else {
-      // If key currently unchecked, add to refinement
-      newRefinement = currentRefinement.concat(option);
-    }
-    refine(newRefinement);
-  }
-
-  render() {
-    const { isChecked } = this.state;
-    const { availableOptions } = this.props;
-
-    return (
-      <div className="refinement-wrapper">
-        <ul className="refinement-ul">
-          {availableOptions.map(option => (
-            <label key={option.id} className={styles.checkBox}>
-              {option.name}
-              <input
-                type="checkbox"
-                name={option.name}
-                id={option.id}
-                value={isChecked[option.name]}
-                checked={isChecked[option.name]}
-                onChange={this.changeRefinement.bind(this, option.name)}
-              />
-            </label>
-          ))}
-        </ul>
-      </div>
-    );
-  }
-}
+RefinementListFilter.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.arrayOf(PropTypes.string).isRequired,
+    count: PropTypes.number.isRequired,
+    isRefined: PropTypes.bool.isRequired,
+  })).isRequired,
+  refine: PropTypes.func.isRequired,
+};
 
 export default connectRefinementList(RefinementListFilter);

--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { InstantSearch, Configure } from 'react-instantsearch/dom';
+import _ from 'lodash';
 import config from '../../config';
 import OpenNowFilter from './OpenNowFilter';
 import RefinementListFilter from './RefinementListFilter';
@@ -41,9 +42,7 @@ export default class ServiceDiscoveryResults extends Component {
   render() {
     const {
       eligibilities,
-      selectedEligibilities,
       subcategories,
-      selectedSubcategories,
       categoryName,
       algoliaCategoryName,
     } = this.props;
@@ -53,6 +52,8 @@ export default class ServiceDiscoveryResults extends Component {
       initialSubcategoriesRefinement,
       searchState,
     } = this.state;
+
+    const subcategoryNames = subcategories.map(c => c.name);
 
     return (
       <div className={styles.container}>
@@ -81,9 +82,8 @@ export default class ServiceDiscoveryResults extends Component {
                 <div className={styles.filterTitle}>Eligibilities</div>
                 <RefinementListFilter
                   attribute="eligibilities"
-                  availableOptions={eligibilities}
-                  selectedOptions={selectedEligibilities}
                   defaultRefinement={initialEligibilityRefinement}
+                  transformItems={items => _.sortBy(items, ['label'])}
                 />
               </div>
               )}
@@ -93,9 +93,19 @@ export default class ServiceDiscoveryResults extends Component {
                 <div className={styles.filterTitle}>Categories</div>
                 <RefinementListFilter
                   attribute="categories"
-                  availableOptions={subcategories}
-                  selectedOptions={selectedSubcategories}
                   defaultRefinement={initialSubcategoriesRefinement}
+                  transformItems={items => {
+                    // Note that in Algolia, the categories attribute is for all
+                    // categories, but for this page, we only want to display
+                    // the specific subcategories of the target category, not
+                    // all categories that the services are tagged with.
+                    // We filter down the categories list from Algolia to just
+                    // the subcategories.
+                    const subcategoryItems = items.filter(
+                      item => subcategoryNames.include(item.label),
+                    );
+                    return _.sortBy(subcategoryItems, ['label']);
+                  }}
                 />
               </div>
               )}


### PR DESCRIPTION
I was trying to debug some of the issues that we were seeing in prod when I noticed that there was a lot of stuff that we were doing in RefinementListFilter that's unnecessary, since the Algolia helpers already do a lot of that work. I redid the component to look more like [the example in the Algolia docs](https://www.algolia.com/doc/api-reference/widgets/refinement-list/react/#create-and-instantiate-your-connected-widget), where we don't define any custom props, since Algolia already has them.

I think this simplifies the component because there's no longer any state, as all the state is derived from the Algolia higher-order component helper that ties it to the context created by the containing `<InstantSearch>` component.

One of the more notable difference is that now the `<RefinementListFilter>` is a pretty dumb component, and the act of filtering down the selectable subcategories is in the instantiation of the `<RefinementListFilter>` in ServiceDiscoveryResults.jsx, via the [`transformItems`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/react/#connector-param-exposed-transformitems) prop, which is the official API for filtering, sorting, or otherwise altering the filter options.

I'm not sure if this actually fixes things in prod, but I can confirm that at least locally, the Food pathway works for me.