### PR TITLE
Fix minor typo in subcategories filter.

### DIFF
--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
@@ -102,7 +102,7 @@ export default class ServiceDiscoveryResults extends Component {
                     // We filter down the categories list from Algolia to just
                     // the subcategories.
                     const subcategoryItems = items.filter(
-                      item => subcategoryNames.include(item.label),
+                      item => subcategoryNames.includes(item.label),
                     );
                     return _.sortBy(subcategoryItems, ['label']);
                   }}


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/ShelterTechSF/askdarcel-web/pull/958.

I had a minor typo, where `array.include()` should have been `array.includes()`. I hadn't tested it previously, since I wasn't able to get local data working, but I managed to fake some data in my local setup to test the categories flow.