### PR TITLE
Give service discovery forms and results their own pages.

### DIFF
--- a/app/components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal.jsx
+++ b/app/components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import qs from 'qs';
 import { STEPS } from 'components/ui/Modal/ServiceDiscoveryModal/constants';
-import ServiceDiscoveryResults from '../../../../pages/ServiceDiscoveryResults/ServiceDiscoveryResults';
 import { BaseModal } from '../Modal';
 import * as dataService from '../../../../utils/DataService';
 
@@ -67,7 +68,7 @@ class ServiceDiscoveryModal extends Component {
 
   render() {
     const {
-      closeModal, steps, categoryName, algoliaCategoryName,
+      closeModal, steps, categoryId,
     } = this.props;
     const {
       eligibilities, subcategories, selectedEligibilities, selectedSubcategories, currentStep,
@@ -119,16 +120,28 @@ class ServiceDiscoveryModal extends Component {
           );
         case STEPS.RESULTS:
         default:
+        {
+          const searchState = {
+            refinementList: {
+              eligibilities: eligibilities
+                .filter(elg => selectedEligibilities[elg.id])
+                .map(el => el.name),
+              categories: subcategories
+                .filter(c => selectedSubcategories[c.id])
+                .map(c => c.name),
+            },
+          };
+          const search = qs.stringify(searchState, { encodeValuesOnly: true });
           return (
-            <ServiceDiscoveryResults
-              categoryName={categoryName}
-              algoliaCategoryName={algoliaCategoryName}
-              eligibilities={eligibilities}
-              subcategories={subcategories}
-              selectedEligibilities={selectedEligibilities}
-              selectedSubcategories={selectedSubcategories}
+            <Redirect
+              push
+              to={{
+                pathname: `/service-discovery-results/${categoryId}`,
+                search: `?${search}`,
+              }}
             />
           );
+        }
       }
     };
 

--- a/app/components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal.jsx
+++ b/app/components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal.jsx
@@ -68,7 +68,7 @@ class ServiceDiscoveryModal extends Component {
 
   render() {
     const {
-      closeModal, steps, categoryId,
+      closeModal, steps, categorySlug,
     } = this.props;
     const {
       eligibilities, subcategories, selectedEligibilities, selectedSubcategories, currentStep,
@@ -136,7 +136,7 @@ class ServiceDiscoveryModal extends Component {
             <Redirect
               push
               to={{
-                pathname: `/service-discovery-results/${categoryId}`,
+                pathname: `/${categorySlug}/results`,
                 search: `?${search}`,
               }}
             />

--- a/app/components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal.jsx
+++ b/app/components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal.jsx
@@ -26,14 +26,14 @@ class ServiceDiscoveryModal extends Component {
   componentDidMount() {
     const { categoryId } = this.props;
 
-    dataService.get(`api/eligibilities?category_id=${categoryId}`).then(response => {
+    dataService.get(`/api/eligibilities?category_id=${categoryId}`).then(response => {
       const { eligibilities } = response;
       this.setState({
         eligibilities,
       });
     });
 
-    dataService.get(`api/categories/subcategories?id=${categoryId}`).then(response => {
+    dataService.get(`/api/categories/subcategories?id=${categoryId}`).then(response => {
       const { categories } = response;
       this.setState({
         subcategories: categories,

--- a/app/components/ui/Modal/ServiceDiscoveryModal/constants.js
+++ b/app/components/ui/Modal/ServiceDiscoveryModal/constants.js
@@ -3,3 +3,62 @@ export const STEPS = {
   SUBCATEGORIES: 'subcategories',
   RESULTS: 'results',
 };
+
+export const CATEGORIES = [
+  {
+    algoliaCategoryName: 'Covid-food',
+    id: '1000001',
+    name: 'Food resources',
+    slug: 'food-resources',
+    steps: [STEPS.ELIGIBILITIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-hygiene',
+    id: '1000002',
+    name: 'Hygiene resources',
+    slug: 'hygiene-resources',
+    steps: [STEPS.SUBCATEGORIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-health',
+    id: '1000005',
+    name: 'Medical Services',
+    slug: 'medical-services-resources',
+    steps: [STEPS.SUBCATEGORIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-domesticviolence',
+    id: '1000006',
+    name: 'Domestic Violence',
+    slug: 'domestic-violence-resources',
+    steps: [STEPS.SUBCATEGORIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-internet',
+    id: '1000007',
+    name: 'Internet Access',
+    slug: 'internet-access-resources',
+    steps: [STEPS.ELIGIBILITIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-finance',
+    id: '1000003',
+    name: 'Financial and Job Assistance',
+    slug: 'financial-and-job-assistance-resources',
+    steps: [STEPS.SUBCATEGORIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-housing',
+    id: '1000004',
+    name: 'Rental Assistance',
+    slug: 'rental-assistance-resources',
+    steps: [STEPS.SUBCATEGORIES, STEPS.RESULTS],
+  },
+  {
+    algoliaCategoryName: 'Covid-lgbtqa',
+    id: '1000008',
+    name: 'LGBTQ Resources',
+    slug: 'lgbtq-resources',
+    steps: [STEPS.SUBCATEGORIES, STEPS.RESULTS],
+  },
+];

--- a/app/pages/HomePage/components/GuideList/GuideList.jsx
+++ b/app/pages/HomePage/components/GuideList/GuideList.jsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 import * as typeformEmbed from '@typeform/embed';
 
-import ServiceDiscoveryModal from 'components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal';
-import { STEPS } from 'components/ui/Modal/ServiceDiscoveryModal/constants';
 import styles from './GuideList.scss';
 
 import ImgFamilyHomelessness from './assets/FamilyHomelessness.jpg';
@@ -31,9 +30,9 @@ function typeform(event, link) {
 }
 
 const GuideCard = ({
-  img, link, name, categoryId, algoliaCategoryName, categorySlug, steps, isTypeform = false,
+  img, link, name, categorySlug, isTypeform = false,
 }) => {
-  const [modalOpen, setModalOpen] = useState(false);
+  const history = useHistory();
 
   let anchorTagProps;
 
@@ -42,10 +41,10 @@ const GuideCard = ({
       role: 'button',
       onClick: e => { typeform(e, link); },
     };
-  } else if (categoryId) {
+  } else if (categorySlug) {
     anchorTagProps = {
       role: 'button',
-      onClick: () => setModalOpen(true),
+      onClick: () => history.push(`/${categorySlug}/form`),
     };
   } else {
     anchorTagProps = {
@@ -74,17 +73,6 @@ const GuideCard = ({
           </div>
         </div>
       </div>
-      {modalOpen && (
-        <ServiceDiscoveryModal
-          categoryId={categoryId}
-          categorySlug={categorySlug}
-          algoliaCategoryName={algoliaCategoryName}
-          categoryName={name}
-          isOpen={modalOpen}
-          closeModal={() => setModalOpen(false)}
-          steps={steps}
-        />
-      )}
     </a>
   );
 };
@@ -92,17 +80,13 @@ const GuideCard = ({
 GuideCard.propTypes = {
   name: PropTypes.string.isRequired,
   link: PropTypes.string,
-  categoryId: PropTypes.string,
-  algoliaCategoryName: PropTypes.string,
-  steps: PropTypes.array,
+  categorySlug: PropTypes.string,
   isTypeform: PropTypes.bool,
 };
 
 GuideCard.defaultProps = {
   link: undefined,
-  categoryId: '',
-  algoliaCategoryName: '',
-  steps: [],
+  categorySlug: '',
   isTypeform: false,
 };
 
@@ -144,80 +128,56 @@ const GuideList = () => (
         <GuideCard
           name="Food resources"
           img={ImgFood}
-          categoryId="1000001"
-          algoliaCategoryName="Covid-food"
           categorySlug="food-resources"
-          steps={[STEPS.ELIGIBILITIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="Hygiene"
           img={Imghygiene}
-          categoryId="1000002"
-          algoliaCategoryName="Covid-hygiene"
           categorySlug="hygiene-resources"
-          steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="Medical Services"
           img={Imgmedicalservices}
-          categoryId="1000005"
-          algoliaCategoryName="Covid-health"
           categorySlug="medical-services-resources"
-          steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="Domestic Violence"
           img={Imgdomesticviolence}
-          categoryId="1000006"
-          algoliaCategoryName="Covid-domesticviolence"
           categorySlug="domestic-violence-resources"
-          steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="Internet Access"
           img={Imginternet}
-          categoryId="1000007"
-          algoliaCategoryName="Covid-internet"
           categorySlug="internet-access-resources"
-          steps={[STEPS.ELIGIBILITIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="Financial and Job Assistance"
           img={Imgfinancialassistance}
-          categoryId="1000003"
-          algoliaCategoryName="Covid-finance"
           categorySlug="financial-and-job-assistance-resources"
-          steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="Rental Assistance"
           img={Imgrentalassistance}
-          categoryId="1000004"
-          algoliaCategoryName="Covid-housing"
           categorySlug="rental-assistance-resources"
-          steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
       <li className={styles.item}>
         <GuideCard
           name="LGBTQ Resources"
           img={Imglgbtq}
-          categoryId="1000008"
-          algoliaCategoryName="Covid-lgbtqa"
           categorySlug="lgbtq-resources"
-          steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
       {/* Note: these resource guides have temporarily been disabled due to covid.

--- a/app/pages/HomePage/components/GuideList/GuideList.jsx
+++ b/app/pages/HomePage/components/GuideList/GuideList.jsx
@@ -31,7 +31,7 @@ function typeform(event, link) {
 }
 
 const GuideCard = ({
-  img, link, name, categoryId, algoliaCategoryName, steps, isTypeform = false,
+  img, link, name, categoryId, algoliaCategoryName, categorySlug, steps, isTypeform = false,
 }) => {
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -77,6 +77,7 @@ const GuideCard = ({
       {modalOpen && (
         <ServiceDiscoveryModal
           categoryId={categoryId}
+          categorySlug={categorySlug}
           algoliaCategoryName={algoliaCategoryName}
           categoryName={name}
           isOpen={modalOpen}
@@ -145,6 +146,7 @@ const GuideList = () => (
           img={ImgFood}
           categoryId="1000001"
           algoliaCategoryName="Covid-food"
+          categorySlug="food-resources"
           steps={[STEPS.ELIGIBILITIES, STEPS.RESULTS]}
         />
       </li>
@@ -154,6 +156,7 @@ const GuideList = () => (
           img={Imghygiene}
           categoryId="1000002"
           algoliaCategoryName="Covid-hygiene"
+          categorySlug="hygiene-resources"
           steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
@@ -163,6 +166,7 @@ const GuideList = () => (
           img={Imgmedicalservices}
           categoryId="1000005"
           algoliaCategoryName="Covid-health"
+          categorySlug="medical-services-resources"
           steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
@@ -172,6 +176,7 @@ const GuideList = () => (
           img={Imgdomesticviolence}
           categoryId="1000006"
           algoliaCategoryName="Covid-domesticviolence"
+          categorySlug="domestic-violence-resources"
           steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
@@ -181,6 +186,7 @@ const GuideList = () => (
           img={Imginternet}
           categoryId="1000007"
           algoliaCategoryName="Covid-internet"
+          categorySlug="internet-access-resources"
           steps={[STEPS.ELIGIBILITIES, STEPS.RESULTS]}
         />
       </li>
@@ -190,6 +196,7 @@ const GuideList = () => (
           img={Imgfinancialassistance}
           categoryId="1000003"
           algoliaCategoryName="Covid-finance"
+          categorySlug="financial-and-job-assistance-resources"
           steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
@@ -199,6 +206,7 @@ const GuideList = () => (
           img={Imgrentalassistance}
           categoryId="1000004"
           algoliaCategoryName="Covid-housing"
+          categorySlug="rental-assistance-resources"
           steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>
@@ -208,6 +216,7 @@ const GuideList = () => (
           img={Imglgbtq}
           categoryId="1000008"
           algoliaCategoryName="Covid-lgbtqa"
+          categorySlug="lgbtq-resources"
           steps={[STEPS.SUBCATEGORIES, STEPS.RESULTS]}
         />
       </li>

--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ServiceDiscoveryModal from 'components/ui/Modal/ServiceDiscoveryModal/ServiceDiscoveryModal';
+
+import { CATEGORIES } from 'components/ui/Modal/ServiceDiscoveryModal/constants';
+
+const ServiceDiscoveryForm = ({ history, match }) => {
+  const { categorySlug } = match.params;
+  const category = CATEGORIES.find(c => c.slug === categorySlug);
+  return (
+    <ServiceDiscoveryModal
+      categoryId={category.id}
+      categorySlug={category.slug}
+      algoliaCategoryName={category.algoliaCategoryName}
+      categoryName={category.name}
+      isOpen
+      closeModal={() => history.goBack()}
+      steps={category.steps}
+    />
+  );
+};
+ServiceDiscoveryForm.propTypes = {
+  history: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      categorySlug: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default ServiceDiscoveryForm;

--- a/app/pages/ServiceDiscoveryForm/index.js
+++ b/app/pages/ServiceDiscoveryForm/index.js
@@ -1,0 +1,1 @@
+export { default } from './ServiceDiscoveryForm';

--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
@@ -1,99 +1,148 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { InstantSearch, Configure } from 'react-instantsearch/dom';
 import _ from 'lodash';
+import qs from 'qs';
+
 import config from '../../config';
+import Loader from '../../components/ui/Loader';
+import * as dataService from '../../utils/DataService';
+
+import ClearAllFilters from './ClearAllFilters';
 import OpenNowFilter from './OpenNowFilter';
 import RefinementListFilter from './RefinementListFilter';
-import ClearAllFilters from './ClearAllFilters';
-
 import SearchResults from './SearchResults/SearchResults';
 import styles from './ServiceDiscoveryResults.scss';
 
 
-export default class ServiceDiscoveryResults extends Component {
-  constructor(props) {
-    super(props);
+const createURL = state => `?${qs.stringify(state, { encodeValuesOnly: true })}`;
 
-    const {
-      eligibilities,
-      selectedEligibilities,
-      subcategories,
-      selectedSubcategories,
-    } = props;
+const searchStateToURL = (location, searchState) => (searchState ? `${location.pathname}${createURL(searchState)}` : '');
 
-    const initialEligibilityRefinement = eligibilities
-      .filter(elg => selectedEligibilities[elg.id]).map(e => e.name);
-    const initialSubcategoriesRefinement = subcategories
-      .filter(elg => selectedSubcategories[elg.id]).map(e => e.name);
+const urlToSearchState = location => qs.parse(location.search.slice(1));
 
-    this.state = {
-      initialEligibilityRefinement,
-      initialSubcategoriesRefinement,
-      searchState: { query: '' },
-    };
 
-    this.onSearchStateChange = this.onSearchStateChange.bind(this);
+const categoryIDToName = new Map([
+  ['1000001', 'Food resources'],
+  ['1000002', 'Hygiene'],
+]);
+
+
+/** Wrapper component that handles state management, URL parsing, and external API requests. */
+const ServiceDiscoveryResults = ({ history, location, match }) => {
+  const categoryID = match.params.category_id;
+  const [parentCategory, setParentCategory] = useState(null);
+  const [eligibilities, setEligibilities] = useState(null);
+  const [subcategories, setSubcategories] = useState(null);
+  const [searchState, setSearchState] = useState(urlToSearchState(location));
+
+  const onSearchStateChange = nextSearchState => {
+    setSearchState(nextSearchState);
+    history.push(searchStateToURL(location, nextSearchState), nextSearchState);
+  };
+
+  // TODO: Handle failure?
+  useEffect(() => {
+    dataService.get(`/api/categories/${categoryID}`).then(response => {
+      setParentCategory(response.category);
+    });
+  }, [categoryID]);
+
+  useEffect(() => {
+    dataService.get(`/api/eligibilities?category_id=${categoryID}`).then(response => {
+      setEligibilities(response.eligibilities);
+    });
+  }, [categoryID]);
+
+  useEffect(() => {
+    dataService.get(`/api/categories/subcategories?id=${categoryID}`).then(response => {
+      setSubcategories(response.categories);
+    });
+  }, [categoryID]);
+
+  const isLoading = (parentCategory === null)
+    || (eligibilities === null)
+    || (subcategories === null);
+
+  if (isLoading) {
+    return <Loader />;
   }
 
-  onSearchStateChange(nextSearchState) {
-    this.setState({ searchState: nextSearchState });
-  }
+  const categoryName = categoryIDToName.get(categoryID);
+  return (
+    <InnerServiceDiscoveryResults
+      eligibilities={eligibilities}
+      subcategories={subcategories}
+      categoryName={categoryName}
+      algoliaCategoryName={parentCategory.name}
+      searchState={searchState}
+      onSearchStateChange={onSearchStateChange}
+    />
+  );
+};
+ServiceDiscoveryResults.propTypes = {
+  history: PropTypes.object.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      category_id: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
 
-  render() {
-    const {
-      eligibilities,
-      subcategories,
-      categoryName,
-      algoliaCategoryName,
-    } = this.props;
+export default ServiceDiscoveryResults;
 
-    const {
-      initialEligibilityRefinement,
-      initialSubcategoriesRefinement,
-      searchState,
-    } = this.state;
 
-    const subcategoryNames = subcategories.map(c => c.name);
+/** Stateless inner component that just handles presentation. */
+const InnerServiceDiscoveryResults = ({
+  eligibilities,
+  subcategories,
+  categoryName,
+  algoliaCategoryName,
+  searchState,
+  onSearchStateChange,
+}) => {
+  const subcategoryNames = subcategories.map(c => c.name);
 
-    return (
-      <div className={styles.container}>
-        <div className={styles.header}>
-          <h1 className={styles.title}>{categoryName}</h1>
-        </div>
-        <InstantSearch
-          appId={config.ALGOLIA_APPLICATION_ID}
-          apiKey={config.ALGOLIA_READ_ONLY_API_KEY}
-          indexName={`${config.ALGOLIA_INDEX_PREFIX}_services_search`}
-          searchState={searchState}
-          onSearchStateChange={this.onSearchStateChange}
-        >
-          <Configure filters={`categories:'${algoliaCategoryName}'`} />
-          <div className={styles.flexContainer}>
-            <div className={styles.sidebar}>
-              <div className={styles.filterResourcesTitle}>Filter Resources</div>
-              <ClearAllFilters />
-              <div className={styles.filterGroup}>
-                <div className={styles.filterTitle}>Availability</div>
-                <OpenNowFilter attribute="open_times" />
-              </div>
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>{categoryName}</h1>
+      </div>
+      <InstantSearch
+        appId={config.ALGOLIA_APPLICATION_ID}
+        apiKey={config.ALGOLIA_READ_ONLY_API_KEY}
+        indexName={`${config.ALGOLIA_INDEX_PREFIX}_services_search`}
+        searchState={searchState}
+        onSearchStateChange={onSearchStateChange}
+      >
+        <Configure filters={`categories:'${algoliaCategoryName}'`} />
+        <div className={styles.flexContainer}>
+          <div className={styles.sidebar}>
+            <div className={styles.filterResourcesTitle}>Filter Resources</div>
+            <ClearAllFilters />
+            <div className={styles.filterGroup}>
+              <div className={styles.filterTitle}>Availability</div>
+              <OpenNowFilter attribute="open_times" />
+            </div>
 
-              {!!eligibilities.length && (
+            {!!eligibilities.length && (
               <div className={styles.filterGroup}>
                 <div className={styles.filterTitle}>Eligibilities</div>
                 <RefinementListFilter
                   attribute="eligibilities"
-                  defaultRefinement={initialEligibilityRefinement}
                   transformItems={items => _.sortBy(items, ['label'])}
                 />
               </div>
-              )}
+            )}
 
-              {!!subcategories.length && (
+            {!!subcategories.length && (
               <div className={styles.filterGroup}>
                 <div className={styles.filterTitle}>Categories</div>
                 <RefinementListFilter
                   attribute="categories"
-                  defaultRefinement={initialSubcategoriesRefinement}
                   transformItems={items => {
                     // Note that in Algolia, the categories attribute is for all
                     // categories, but for this page, we only want to display
@@ -108,15 +157,14 @@ export default class ServiceDiscoveryResults extends Component {
                   }}
                 />
               </div>
-              )}
+            )}
 
-            </div>
-            <div className={styles.results}>
-              <SearchResults />
-            </div>
           </div>
-        </InstantSearch>
-      </div>
-    );
-  }
-}
+          <div className={styles.results}>
+            <SearchResults />
+          </div>
+        </div>
+      </InstantSearch>
+    </div>
+  );
+};

--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.jsx
@@ -7,6 +7,7 @@ import qs from 'qs';
 import config from '../../config';
 import Loader from '../../components/ui/Loader';
 import * as dataService from '../../utils/DataService';
+import { CATEGORIES } from '../../components/ui/Modal/ServiceDiscoveryModal/constants';
 
 import ClearAllFilters from './ClearAllFilters';
 import OpenNowFilter from './OpenNowFilter';
@@ -20,11 +21,6 @@ const createURL = state => `?${qs.stringify(state, { encodeValuesOnly: true })}`
 const searchStateToURL = (location, searchState) => (searchState ? `${location.pathname}${createURL(searchState)}` : '');
 
 const urlToSearchState = location => qs.parse(location.search.slice(1));
-
-const CATEGORIES = [
-  { id: '1000001', slug: 'food-resources', name: 'Food resources' },
-  { id: '1000002', slug: 'hygiene-resources', name: 'Hygiene resources' },
-];
 
 
 /** Wrapper component that handles state management, URL parsing, and external API requests. */

--- a/app/pages/ServiceDiscoveryResults/index.js
+++ b/app/pages/ServiceDiscoveryResults/index.js
@@ -1,0 +1,1 @@
+export { default } from './ServiceDiscoveryResults';

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -10,6 +10,7 @@ import OrganizationEditPage from './pages/OrganizationEditPage';
 import { OrganizationListingPage } from './pages/OrganizationListingPage';
 import { SearchResultsPage } from './pages/SearchPage';
 import { ServiceListingPage } from './pages/ServiceListingPage';
+import ServiceDiscoveryResults from './pages/ServiceDiscoveryResults';
 
 import { PrivacyPolicyPage } from './pages/legal/PrivacyPolicy';
 import { TermsOfServicePage } from './pages/legal/TermsOfService';
@@ -39,6 +40,7 @@ export default () => (
     <Route path="/privacy-policy" component={PrivacyPolicyPage} />
     <Route path="/search" component={SearchResultsPage} />
     <Route path="/services/:service" component={ServiceListingPage} />
+    <Route path="/service-discovery-results/:category_id" component={ServiceDiscoveryResults} />
     <Route path="/terms-of-service" component={TermsOfServicePage} />
 
     {/* Legacy redirects */}

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -10,6 +10,7 @@ import OrganizationEditPage from './pages/OrganizationEditPage';
 import { OrganizationListingPage } from './pages/OrganizationListingPage';
 import { SearchResultsPage } from './pages/SearchPage';
 import { ServiceListingPage } from './pages/ServiceListingPage';
+import ServiceDiscoveryForm from './pages/ServiceDiscoveryForm';
 import ServiceDiscoveryResults from './pages/ServiceDiscoveryResults';
 
 import { PrivacyPolicyPage } from './pages/legal/PrivacyPolicy';
@@ -41,6 +42,7 @@ export default () => (
     <Route path="/search" component={SearchResultsPage} />
     <Route path="/services/:service" component={ServiceListingPage} />
     <Route path="/terms-of-service" component={TermsOfServicePage} />
+    <Route path="/:categorySlug/form" component={ServiceDiscoveryForm} />
     <Route path="/:categorySlug/results" component={ServiceDiscoveryResults} />
 
     {/* Legacy redirects */}

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -40,8 +40,8 @@ export default () => (
     <Route path="/privacy-policy" component={PrivacyPolicyPage} />
     <Route path="/search" component={SearchResultsPage} />
     <Route path="/services/:service" component={ServiceListingPage} />
-    <Route path="/service-discovery-results/:category_id" component={ServiceDiscoveryResults} />
     <Route path="/terms-of-service" component={TermsOfServicePage} />
+    <Route path="/:categorySlug/results" component={ServiceDiscoveryResults} />
 
     {/* Legacy redirects */}
     <Redirect path="/resource/new" to="/organizations/new" />


### PR DESCRIPTION
This included some refactoring to make the ServiceDiscoveryResults component its own standalone react-router route.

## Design
Here's what it looks like (note the address bar of my browser):

<img width="1194" alt="Screen Shot 2020-06-21 at 9 48 01 PM" src="https://user-images.githubusercontent.com/1002748/85249547-e7357600-b408-11ea-8b1a-0b3c5db6f1a2.png">

I could definitely use some more guidance on what the URLs should be (@JacobDFrank?). For now, it's just at `/service-discovery-results/:category_id`, but it causes it to have a kind of goofy URL because we started the category ID at 1,000,001.

## Technical details

I learned how to properly sync the Algolia InstantSearch state with the browser URL and react-router, which is covered in [a specific document in the Algolia docs](https://www.algolia.com/doc/guides/building-search-ui/going-further/routing-urls/react/). Their example made use of React Hooks, so I also went ahead and changed the class-based component to a function-based component with React Hooks, since it was easier to apply their example that way than to figure out how to thread both the React Router and Algolia state into the right places.

In terms of the internal structure of the `<ServiceDiscoveryResults>`, I decided to split it up into two separate components: the outer one (`<ServiceDiscoveryResults>`) is responsible for all the state, including syncing the react router state, the browser address, and the API requests to our backend service, and the inner one is a pure function component with no state.

The way that the flow works now is that the ServiceDiscoveryModal is still a modal on the home page, but instead of directly rendering the ServiceDiscoveryResults, it now serializes the important information from the form data into the URL query parameters and issues a react-router `<Redirect>` to the new `/service-discovery-results` route. The `<ServiceDiscoveryResults>` component is now responsible for deserializing that state out of the URL, as well as making some duplicated queries to the askdarcel-api service.

I had to make the redundant queries to the backend service, even though we just made them on the modal form pages, since it's on a brand new page. I don't think this is too bad, but it will now trigger a loading spinner when you first arrive at the search results page. In theory, we could probably cache the API results if we actually implemented a real "data service" that could cache results, but that's probably not an optimization that we need to make today.