### PR TITLE
Handle case where ServiceDiscoveryResult doesn't have phone number.

### DIFF
--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
@@ -22,66 +22,70 @@ const transformHits = hits => hits.map(hit => {
 const SearchResults = ({ searchResults }) => {
   if (!searchResults) return null;
 
-  const renderAddressMetadata = hit => {
-    if (hit.addresses.length === 0) {
-      return <span>No address found</span>;
-    }
-    if (hit.addresses.length > 1) {
-      return <span>Multiple locations</span>;
-    }
-    if (hit.addresses[0].address_1) {
-      return <span>{hit.addresses[0].address_1}</span>;
-    }
-    return <span>No address found</span>;
-  };
-
   const hits = transformHits(searchResults.hits);
 
   return (
     <div className={styles.searchResultsContainer}>
       <div>
-        { hits.map((hit, index) => (
-          <div className={styles.searchResult} key={hit.id}>
-            <div className={styles.searchText}>
-              <div className={styles.title}>{ `${index + 1}. ${hit.name}`}</div>
-              <div className={styles.address}>{renderAddressMetadata(hit)}</div>
-              <div className={styles.description}>{hit.long_description}</div>
-              <div className={styles.serviceOf}>{hit.service_of}</div>
+        { hits.map((hit, index) => <SearchResult hit={hit} index={index} key={hit.id} />) }
+      </div>
+    </div>
+  );
+};
+
+const SearchResult = ({ hit, index }) => {
+  const renderAddressMetadata = hit_ => {
+    if (hit_.addresses.length === 0) {
+      return <span>No address found</span>;
+    }
+    if (hit_.addresses.length > 1) {
+      return <span>Multiple locations</span>;
+    }
+    if (hit_.addresses[0].address_1) {
+      return <span>{hit_.addresses[0].address_1}</span>;
+    }
+    return <span>No address found</span>;
+  };
+  const phoneNumber = hit.phones.length > 0 && hit.phones[0].number;
+  return (
+    <div className={styles.searchResult}>
+      <div className={styles.searchText}>
+        <div className={styles.title}>{ `${index + 1}. ${hit.name}`}</div>
+        <div className={styles.address}>{renderAddressMetadata(hit)}</div>
+        <div className={styles.description}>{hit.long_description}</div>
+        <div className={styles.serviceOf}>{hit.service_of}</div>
+      </div>
+      <div className={styles.sideLinks}>
+        {
+          phoneNumber
+          && (
+            <div className={styles.sideLinkText}>
+              <a href={`tel${phoneNumber}`}>{`Call ${phoneNumber}`}</a>
             </div>
-            <div className={styles.sideLinks}>
-              {
-                hit.phones[0].number
-                && (
-                  <div className={styles.sideLinkText}>
-                    <a href={`tel${hit.phones[0].number}`}>{`Call ${hit.phones[0].number}`}</a>
-                  </div>
-                )
-              }
-              {
-                (hit._geoloc && hit.addresses[0].address_1)
-                && (
-                  <div className={styles.sideLinkText}>
-                    <a href={`http://google.com/maps/dir/?api=1&destination=${hit._geoloc}`}>Get directions</a>
-                  </div>
-                )
-              }
-              <div />
-              {
-                hit.url
-                && (
-                  <div className={styles.sideLinkText}>
-                    <a href={hit.url} className={styles.sideLinkText}>Go to Website</a>
-                  </div>
-                )
-              }
-              {
-                (hit.phones[0].number || hit._geoloc || hit.url)
-                && <div className={styles.divider} />
-              }
-              <a href="http://localhost:8081/" className={styles.sideLinkText}>Report Error</a>
+          )
+        }
+        {
+          (hit._geoloc && hit.addresses[0].address_1)
+          && (
+            <div className={styles.sideLinkText}>
+              <a href={`http://google.com/maps/dir/?api=1&destination=${hit._geoloc}`}>Get directions</a>
             </div>
-          </div>
-        ))}
+          )
+        }
+        <div />
+        {
+          hit.url
+          && (
+            <div className={styles.sideLinkText}>
+              <a href={hit.url} className={styles.sideLinkText}>Go to Website</a>
+            </div>
+          )
+        }
+        {
+          (phoneNumber || hit._geoloc || hit.url)
+          && <div className={styles.divider} />
+        }
+        <a href="http://localhost:8081/" className={styles.sideLinkText}>Report Error</a>
       </div>
     </div>
   );


### PR DESCRIPTION
@jjfreund noticed that the ServiceDiscoveryResult page blows up if a result doesn't have a phone number. This PR adds some logic to check if a phone number exists before trying to use it.

I also pulled the inner loop into its own component so that it'd be easier to add code to compute the conditional check. The diff is smaller if you ignore whitespace changes.