### PR TITLE
Fix sidebar links

### DIFF
--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { get as _get } from 'lodash';
 import { connectStateResults } from 'react-instantsearch/connectors';
 import { parseAlgoliaSchedule } from 'utils/transformSchedule';
 import styles from './SearchResults.scss';
@@ -46,7 +47,11 @@ const SearchResult = ({ hit, index }) => {
     }
     return <span>No address found</span>;
   };
-  const phoneNumber = hit.phones.length > 0 && hit.phones[0].number;
+
+  const phoneNumber = _get(hit, 'phones[0].number');
+  const latitude = _get(hit, 'addresses[0].latitude');
+  const longitude = _get(hit, 'addresses[0].longitude');
+
   return (
     <div className={styles.searchResult}>
       <div className={styles.searchText}>
@@ -65,10 +70,10 @@ const SearchResult = ({ hit, index }) => {
           )
         }
         {
-          (hit._geoloc && hit.addresses[0].address_1)
+          (latitude && longitude)
           && (
             <div className={styles.sideLinkText}>
-              <a href={`http://google.com/maps/dir/?api=1&destination=${hit._geoloc}`}>Get directions</a>
+              <a href={`http://google.com/maps/dir/?api=1&destination=${latitude},${longitude}`}>Get directions</a>
             </div>
           )
         }

--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
@@ -60,7 +60,7 @@ const SearchResult = ({ hit, index }) => {
           phoneNumber
           && (
             <div className={styles.sideLinkText}>
-              <a href={`tel${phoneNumber}`}>{`Call ${phoneNumber}`}</a>
+              <a href={`tel:${phoneNumber}`}>{`Call ${phoneNumber}`}</a>
             </div>
           )
         }
@@ -81,11 +81,6 @@ const SearchResult = ({ hit, index }) => {
             </div>
           )
         }
-        {
-          (phoneNumber || hit._geoloc || hit.url)
-          && <div className={styles.divider} />
-        }
-        <a href="http://localhost:8081/" className={styles.sideLinkText}>Report Error</a>
       </div>
     </div>
   );


### PR DESCRIPTION
This fixes a few issues with actions you can take on a search result

1. [We weren't showing `Get directions` for services](https://app.clubhouse.io/sheltertech/story/1528/add-get-directions-button-to-service-results-page)
2. [Clicking `Get Directions` was broken](https://app.clubhouse.io/sheltertech/story/1546/get-directions-links-all-lead-to-object-advjective)
3. [Clicking on `Call: ####` was broken](https://app.clubhouse.io/sheltertech/story/1549/remove-hyperlink-from-all-phone-numbers-on-search-results-page)
4. [We want to remove the `Report Error` link](https://app.clubhouse.io/sheltertech/story/1551/remove-report-error-link-from-search-results-page)