### PR TITLE
Remove unnecessary styling for RefinementListFilter.

### DIFF
--- a/app/pages/ServiceDiscoveryResults/RefinementListFilter.jsx
+++ b/app/pages/ServiceDiscoveryResults/RefinementListFilter.jsx
@@ -4,23 +4,21 @@ import { connectRefinementList } from 'react-instantsearch/connectors';
 import styles from './ServiceDiscoveryResults.scss';
 
 const RefinementListFilter = ({ items, refine }) => (
-  <div className="refinement-wrapper">
-    <ul className="refinement-ul">
-      {items.map(item => (
-        <label key={item.label} className={styles.checkBox}>
-          {item.label}
-          <input
-            type="checkbox"
-            checked={item.isRefined}
-            onChange={e => {
-              e.preventDefault();
-              refine(item.value);
-            }}
-          />
-        </label>
-      ))}
-    </ul>
-  </div>
+  <ul>
+    {items.map(item => (
+      <label key={item.label} className={styles.checkBox}>
+        {item.label}
+        <input
+          type="checkbox"
+          checked={item.isRefined}
+          onChange={e => {
+            e.preventDefault();
+            refine(item.value);
+          }}
+        />
+      </label>
+    ))}
+  </ul>
 );
 
 RefinementListFilter.propTypes = {


### PR DESCRIPTION
This allows the element to naturally flow on the page instead of unnecessarily capping it at 200px.

The `refinement-ul` CSS style originally came from the search results page, where we have a multi-column layout, so it's not actually appropriate to reuse it on the Service Discovery results page.

Note that you should review the diff with whitespace changes ignored, since I removed an unnecessary `<div>` element as well.

### Original search results page filter menu
<img width="735" alt="Screen Shot 2020-07-12 at 3 15 18 PM" src="https://user-images.githubusercontent.com/1002748/87257764-94bd0780-c452-11ea-8b0e-f87da347bdd0.png">

### Before
<img width="599" alt="Screen Shot 2020-07-12 at 3 13 35 PM" src="https://user-images.githubusercontent.com/1002748/87257766-9ab2e880-c452-11ea-861f-55c657510a8a.png">


### After
<img width="599" alt="Screen Shot 2020-07-12 at 3 13 42 PM" src="https://user-images.githubusercontent.com/1002748/87257768-9dadd900-c452-11ea-8cea-3a809db22865.png">
