### PR TITLE
Skip questionnaire and go directly to results page for internet resources.

### DIFF
--- a/app/pages/ServiceDiscoveryForm/constants.js
+++ b/app/pages/ServiceDiscoveryForm/constants.js
@@ -38,7 +38,7 @@ export const CATEGORIES = [
     id: '1000007',
     name: 'Internet Access',
     slug: 'internet-access-resources',
-    steps: [STEPS.ELIGIBILITIES, STEPS.RESULTS],
+    steps: [STEPS.RESULTS],
   },
   {
     algoliaCategoryName: 'Covid-finance',


### PR DESCRIPTION
It's actually kind of neat how easy this change was to make. By removing any other STEP from the list, it'll just automatically redirect you to the search results page.