### PR TITLE
Render descriptions as markdown

### DIFF
--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import { connectStateResults } from 'react-instantsearch/connectors';
 import { parseAlgoliaSchedule } from 'utils/transformSchedule';
 import styles from './SearchResults.scss';
@@ -52,7 +53,7 @@ const SearchResult = ({ hit, index }) => {
       <div className={styles.searchText}>
         <div className={styles.title}>{ `${index + 1}. ${hit.name}`}</div>
         <div className={styles.address}>{renderAddressMetadata(hit)}</div>
-        <div className={styles.description}>{hit.long_description}</div>
+        <ReactMarkdown className={`rendered-markdown ${styles.description}`} source={hit.long_description} />
         <div className={styles.serviceOf}>{hit.service_of}</div>
       </div>
       <div className={styles.sideLinks}>


### PR DESCRIPTION
Before:
<img width="1488" alt="Screen Shot 2020-07-12 at 3 43 51 PM" src="https://user-images.githubusercontent.com/7386336/87258231-c932c280-c456-11ea-8df1-c751659924db.png">

After
<img width="1488" alt="Screen Shot 2020-07-12 at 3 43 37 PM" src="https://user-images.githubusercontent.com/7386336/87258229-c46e0e80-c456-11ea-9b73-862adf4dc8f0.png">

