### PR TITLE
Update buttons and add progress bar.

### DIFF
--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
@@ -117,7 +117,12 @@ const InnerServiceDiscoveryForm = ({
     <Fragment>
       <Header onGoBack={goBack} />
       <Content />
-      <Footer onGoBack={goBack} onNextStep={goToNextStep} />
+      <Footer
+        onGoBack={goBack}
+        onNextStep={goToNextStep}
+        currentStep={currentStep}
+        numSteps={steps.length}
+      />
     </Fragment>
   );
 };
@@ -134,10 +139,40 @@ const Header = ({ onGoBack }) => (
   </div>
 );
 
-const Footer = ({ onGoBack, onNextStep }) => (
+const Footer = ({
+  onGoBack, onNextStep, currentStep, numSteps,
+}) => (
   <div className={styles.footer}>
-    <button type="button" className={styles.actionBack} onClick={onGoBack}>Back</button>
-    <button type="button" className={styles.actionSubmit} onClick={onNextStep}>Submit</button>
+    <div className={styles.progressBarContainer}>
+      {
+        /*
+         * Add 1 to current step because it is 0-indexed.
+         * Subtract 1 from numSteps because we shouldn't include the RESULT step.
+         */
+      }
+      <ProgressBar currentNumber={currentStep + 1} totalNumber={numSteps - 1} />
+    </div>
+    <div className={styles.actionGroup}>
+      <button type="button" className={`${styles.button} ${styles.actionBack}`} onClick={onGoBack}>
+        Back
+      </button>
+      <button type="button" className={`${styles.button} ${styles.actionSubmit}`} onClick={onNextStep}>
+        Submit
+      </button>
+    </div>
+  </div>
+);
+
+const ProgressBar = ({ currentNumber, totalNumber }) => (
+  <div className={styles.progressBar}>
+    {totalNumber > 1 && (
+      <Fragment>
+        <div className={styles.progressBarText}>
+          {`Question ${currentNumber} / ${totalNumber}`}
+        </div>
+        <progress className={styles.progressBarMeter} value={currentNumber} max={totalNumber} />
+      </Fragment>
+    )}
   </div>
 );
 

--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.scss
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.scss
@@ -62,16 +62,59 @@
 
 .footer {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-between;
     position: fixed;
     bottom: 0;
     left: 0;
     right: 0;
     border-top: 1px solid $color-grey3;
     background-color: $color-white;
-    button {
-        margin: 18px;
+    padding: 18px 35px;
+}
+
+.progressBarMeter {
+    width: 666px;
+    height: 11px;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    // overflow: hidden must be set to force both the progress bar and progress
+    // value to get clipped to have rounded corders.
+    border-radius: 100px;
+    overflow: hidden;
+
+    &::-webkit-progress-bar {
+        background-color: #e0e0e0;
+    }
+
+    &::-webkit-progress-value {
+        background-color: #0025e4;
+    }
+
+    // This is actually the progress bar value, not the whole bar, in Firefox
+    &::-moz-progress-bar {
+        background-color: #0025e4;
+    }
+}
+
+.progressBarText {
+    color: #202020;
+    font-size: 18px;
+}
+
+.actionGroup {
+    display: flex;
+    justify-content: flex-end;
+    margin-right: 5px;
+
+    .button {
+        width: 188px;
         border: 1px solid $color-brand;
+        border-radius: 3px;
+
+        &:not(:last-child) {
+            margin-right: 30px;
+        }
     }
     .actionBack {
         background-color: transparent;
@@ -79,6 +122,5 @@
     }
     .actionSubmit {
         background-color: $color-brand;
-        margin-right: 80px;
     }
 }


### PR DESCRIPTION
This updates the footer of the service discovery form to match the mockups in https://www.figma.com/file/lhmZSzRw4mbDpil3CZ7tsC/SFSG-Topic-listings---For-production?node-id=0%3A1

I updated the buttons to match the guide, and I also added a progress bar. However, I hid the progress bar when there's only one page of questions (which I think is all of them), since it's kind of silly to see a full progress bar with 1/1 pages on every page. However, I can change this if @JacobDFrank wants the progress bar to always be there.

Here's what it looks like, including with some faked out data to make the progress bar show up:

## Chrome (with progress bar)
<img width="1357" alt="Screen Shot 2020-07-12 at 4 09 24 PM" src="https://user-images.githubusercontent.com/1002748/87258851-b2db3580-c45b-11ea-8783-039a553d45a2.png">

## Firefox (with progress bar)
<img width="1345" alt="Screen Shot 2020-07-12 at 4 09 29 PM" src="https://user-images.githubusercontent.com/1002748/87258853-b4a4f900-c45b-11ea-831b-a16fba07c17c.png">

## Chrome (without progress bar) (This is the only one that we'll actually see in prod, unless you want me to change anything)
<img width="1352" alt="Screen Shot 2020-07-12 at 4 17 36 PM" src="https://user-images.githubusercontent.com/1002748/87258855-b53d8f80-c45b-11ea-9830-9e1d7cb1996a.png">

## Chrome (with progress bar, even with only 1 element)
<img width="1347" alt="Screen Shot 2020-07-12 at 4 23 58 PM" src="https://user-images.githubusercontent.com/1002748/87258913-1e250780-c45c-11ea-9c27-8d15b09ab979.png">

---

Also, this is the first time I ever learned about the HTML [`<progress>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress) element, which is kinda neat. I followed the [guide here](https://css-tricks.com/html5-progress-element/) on styling it, since you have to do different things in Chrome/Safari/webkit vs Firefox. I didn't bother with Internet Explorer because 1) it's harder for me to test that on a Mac and 2) the latest release of Edge now runs Chromium under the hood.