### PR TITLE
1719 - move org name under title in results

### DIFF
--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
@@ -62,11 +62,11 @@ const SearchResult = ({ hit, index }) => {
         <div className={styles.title}>
           <Link to={`/services/${serviceId}`}>{`${index + 1}. ${hit.name}`}</Link>
         </div>
-        <div className={styles.address}>{renderAddressMetadata(hit)}</div>
-        <ReactMarkdown className={`rendered-markdown ${styles.description}`} source={hit.long_description} />
         <div className={styles.serviceOf}>
           <Link to={`/organizations/${resourceId}`}>{hit.service_of}</Link>
         </div>
+        <div className={styles.address}>{renderAddressMetadata(hit)}</div>
+        <ReactMarkdown className={`rendered-markdown ${styles.description}`} source={hit.long_description} />
       </div>
       <div className={styles.sideLinks}>
         {


### PR DESCRIPTION
Move org name up to under title in service discovery search results
https://app.clubhouse.io/sheltertech/story/1719/move-organization-name-directly-under-service-name-on-new-search-results-page
![Screen Shot 2020-11-29 at 3 12 26 PM](https://user-images.githubusercontent.com/8869737/100556249-dd385e80-3255-11eb-8d98-33061a611913.png)
