### PR TITLE
1722 - remove scroll to get rid of gray box in results

### DIFF
--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.scss
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.scss
@@ -105,5 +105,6 @@
   .sideLinkText {
     padding: 0 8px;
     white-space: nowrap;
+    overflow: auto;
   }
 }

--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.scss
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.scss
@@ -105,6 +105,5 @@
   .sideLinkText {
     padding: 0 8px;
     white-space: nowrap;
-    overflow: scroll;
   }
 }


### PR DESCRIPTION
remove scroll in sideLinkText to get rid of the gray boxes
https://app.clubhouse.io/sheltertech/story/1722/on-some-environments-images-in-search-results-page-appear-with-gray-background

before:
![Screen Shot 2020-11-29 at 3 31 30 PM](https://user-images.githubusercontent.com/8869737/100556605-5042d480-3258-11eb-8e6d-449443d19b62.png)


after:
![Screen Shot 2020-11-29 at 3 31 44 PM](https://user-images.githubusercontent.com/8869737/100556598-47520300-3258-11eb-8ea8-cb1c8e6cb445.png)