### PR TITLE
Service Listing page not updating service website

### DIFF
--- a/app/components/listing/TableOfContactInfo.jsx
+++ b/app/components/listing/TableOfContactInfo.jsx
@@ -5,7 +5,7 @@ class ContactInfoTable extends React.Component {
   render() {
     const { item } = this.props;
     // TODO May break for non services, need a better check for inheritance
-    const website = item.website || item.resource.website;
+    const website = item.url || item.resource.website;
     const email = item.email || item.resource.email;
     const phones = item.phones || item.resource.phones;
 


### PR DESCRIPTION
The problem here is that: The service listing page did not update the service website when the service had a website inputted. It always kept the resource's website.
The Service page (within resource listing), however, did update the service website.

The error was found in service listing. Within ServiceListingPage.jsx, we have the "Table of Contacts info" which contains the service website. TableofContactInfo.jsx is a component, and there error is that:

The class ContactInfoTable has the constant website. This variable has the logic "service.website OR resource.website". I switched item.website to item.url, because service website is called url insteal of website in the API.