### PR TITLE
Init admin interface

### DIFF
--- a/app/pages/Admin/Admin.jsx
+++ b/app/pages/Admin/Admin.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default class About extends React.Component {
+export default class Admin extends React.Component {
   render() {
     return <div>initialize the Admin page</div>;
   }

--- a/app/pages/Admin/Admin.jsx
+++ b/app/pages/Admin/Admin.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class About extends React.Component {
+  render() {
+    return <div>initialize the Admin page</div>;
+  }
+}

--- a/app/pages/Admin/index.js
+++ b/app/pages/Admin/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Admin";

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -1,23 +1,23 @@
-import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
-import qs from 'qs';
-import './utils/google';
+import React from "react";
+import { Redirect, Route, Switch } from "react-router-dom";
+import qs from "qs";
+import "./utils/google";
 
 // import configureStore from './store/configureStore';
 
-import HomePage from './pages/HomePage';
-import OrganizationEditPage from './pages/OrganizationEditPage';
-import { OrganizationListingPage } from './pages/OrganizationListingPage';
-import { SearchResultsPage } from './pages/SearchPage';
-import { ServiceListingPage } from './pages/ServiceListingPage';
-import ServiceDiscoveryForm from './pages/ServiceDiscoveryForm';
-import ServiceDiscoveryResults from './pages/ServiceDiscoveryResults';
-
-import { PrivacyPolicyPage } from './pages/legal/PrivacyPolicy';
-import { TermsOfServicePage } from './pages/legal/TermsOfService';
-import About from './pages/About';
-import CovidPages from './pages/Covid';
-import { ListingDebugPage } from './pages/debug/ListingDemoPage';
+import HomePage from "./pages/HomePage";
+import OrganizationEditPage from "./pages/OrganizationEditPage";
+import { OrganizationListingPage } from "./pages/OrganizationListingPage";
+import { SearchResultsPage } from "./pages/SearchPage";
+import { ServiceListingPage } from "./pages/ServiceListingPage";
+import ServiceDiscoveryForm from "./pages/ServiceDiscoveryForm";
+import ServiceDiscoveryResults from "./pages/ServiceDiscoveryResults";
+import { PrivacyPolicyPage } from "./pages/legal/PrivacyPolicy";
+import { TermsOfServicePage } from "./pages/legal/TermsOfService";
+import About from "./pages/About";
+import Admin from "./pages/Admin";
+import CovidPages from "./pages/Covid";
+import { ListingDebugPage } from "./pages/debug/ListingDemoPage";
 
 const RedirectToOrganizations = ({ location: { search } }) => {
   const { id } = qs.parse(search.slice(1));
@@ -33,6 +33,7 @@ export default () => (
   <Switch>
     <Route exact path="/" component={HomePage} />
     <Route path="/about" component={About} />
+    <Route path="/admin" component={Admin} />
     <Route path="/covid" component={CovidPages} />
     <Route path="/demo/listing" component={ListingDebugPage} />
     <Route path="/organizations/new" component={OrganizationEditPage} />


### PR DESCRIPTION
1 - Fallowing David files structure suggestion, I am initializing the admin interface files structure and named as the fallowing based on the existed pages "Covid and About" structure considering the case sensitive names

a. Create another pages folder inside app/pages/Admin
>  - Create Categories folder
>  - Create components folder (Create all components here after)
>  - Categories.jsx

b. Create index.js
c. Create Admin.jsx

2 - Link the admin page to the system by adding the /admin path to the routes.jsx

3 - create a simple Admin component in the Admin.jsx and display "initialize the Admin page" text to make sure the system in linked properly to the admin page and its up, ready to be served to the client