### PR TITLE
Added more / conditional styling for SFFamilies 

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -8,7 +8,7 @@ import Navigation from './ui/Navigation/Navigation';
 // import CategoryPage from './find/FindPage';
 // import ResourcesTable from './search/ResourcesTable';
 import { round } from '../utils/index';
-import { getSiteTitle, getSiteUrl } from '../utils/whitelabel';
+import { getSiteTitle, getSiteUrl, isSFFamiliesSite } from '../utils/whitelabel';
 import 'react-select/dist/react-select.css';
 import config from '../config';
 import HamburgerMenu from './ui/HamburgerMenu';
@@ -157,7 +157,9 @@ class App extends Component {
           <meta property="og:image:width" content="1200" />
           <meta property="og:image:height" content="630" />
         </Helmet>
-        {config.INTERCOM_APP_ID && <Intercom appID={config.INTERCOM_APP_ID} />}
+        {!isSFFamiliesSite()
+          && config.INTERCOM_APP_ID
+          && <Intercom appID={config.INTERCOM_APP_ID} />}
         <HamburgerMenu
           isOpen={hamburgerMenuIsOpen}
           outerContainerId={outerContainerId}
@@ -166,8 +168,11 @@ class App extends Component {
           toggleHamburgerMenu={this.toggleHamburgerMenu}
         />
         <div id={pageWrapId}>
-          <Navigation showSearch toggleHamburgerMenu={this.toggleHamburgerMenu} />
-          <Banner />
+          <Navigation
+            showSearch={!isSFFamiliesSite()}
+            toggleHamburgerMenu={this.toggleHamburgerMenu}
+          />
+          {!isSFFamiliesSite() && <Banner />}
           <div className="container">
             <Routes />
           </div>

--- a/app/components/listing/ActionSidebar.jsx
+++ b/app/components/listing/ActionSidebar.jsx
@@ -11,7 +11,6 @@ const getSidebarActions = (resource, service) => {
   const resourceActions = getResourceActions(resource, service);
   const sidebarActions = [
     resourceActions.print,
-    resourceActions.verify,
   ];
   if (resourceActions.directions) {
     sidebarActions.push(resourceActions.directions);

--- a/app/components/listing/MobileActionBar.jsx
+++ b/app/components/listing/MobileActionBar.jsx
@@ -17,7 +17,6 @@ const getMobileActions = (resource, service) => {
   if (resourceActions.directions) {
     mobileActions.push(resourceActions.directions);
   }
-  mobileActions.push(resourceActions.edit);
   return mobileActions;
 };
 

--- a/app/components/maps/MapOfLocations.jsx
+++ b/app/components/maps/MapOfLocations.jsx
@@ -8,7 +8,7 @@ import { Accordion, AccordionItem } from '../ui/Accordion';
 
 class MapOfLocations extends React.Component {
   componentDidMount() {
-    if (google === undefined) { return; }
+    if (typeof google === 'undefined' || google === null) { return; }
 
     const {
       Map, Marker, LatLng, SymbolPath,

--- a/app/components/ui/Navigation/Navigation.jsx
+++ b/app/components/ui/Navigation/Navigation.jsx
@@ -4,6 +4,7 @@ import { Link, withRouter } from 'react-router-dom';
 import qs from 'qs';
 import { images } from 'assets';
 import styles from './Navigation.module.scss';
+import { getSiteUrl, isSFFamiliesSite } from '../../../utils/whitelabel';
 
 class Navigation extends React.Component {
   constructor() {
@@ -40,12 +41,15 @@ class Navigation extends React.Component {
     const { showSearch, toggleHamburgerMenu } = this.props;
     const { showSecondarySearch, query } = this.state;
     return (
-      <nav className={styles.siteNav}>
+      <nav className={isSFFamiliesSite() ? styles.siteNavSFFamilies : styles.siteNav}>
         <div className={styles.primaryRow}>
           <div className={styles.navLeft}>
-            <Link className={styles.navLogo} to="/">
+            <a
+              className={isSFFamiliesSite() ? styles.navLogoSFFamilies : styles.navLogo}
+              href={getSiteUrl()}
+            >
               <img src={images.logoSmall} alt="Ask Darcel" />
-            </Link>
+            </a>
             {showSearch
               && (
                 <form
@@ -70,23 +74,27 @@ class Navigation extends React.Component {
             <button type="button" className={styles.searchButton} onClick={this.toggleSecondarySearch} />
             <button type="button" className={styles.hamburgerButton} onClick={toggleHamburgerMenu} />
           </div>
-          <ul className={styles.navRight}>
-            <li>
-              <Link to="/about">
-                About
-              </Link>
-            </li>
-            <li>
-              <a href="https://help.sfserviceguide.org" target="_blank" rel="noopener noreferrer">
-                FAQ
-              </a>
-            </li>
-            <li>
-              <a href="https://help.sfserviceguide.org/en/collections/1719243-contact-us" target="_blank" rel="noopener noreferrer">
-                Contact Us
-              </a>
-            </li>
-          </ul>
+          {!isSFFamiliesSite()
+            && (
+              <ul className={styles.navRight}>
+                <li>
+                  <Link to="/about">
+                    About
+                  </Link>
+                </li>
+                <li>
+                  <a href="https://help.sfserviceguide.org" target="_blank" rel="noopener noreferrer">
+                    FAQ
+                  </a>
+                </li>
+                <li>
+                  <a href="https://help.sfserviceguide.org/en/collections/1719243-contact-us" target="_blank" rel="noopener noreferrer">
+                    Contact Us
+                  </a>
+                </li>
+              </ul>
+            )
+          }
         </div>
         <div className={`${styles.secondaryRowWrapper} ${showSecondarySearch ? '' : styles.hide}`}>
           <div className={styles.secondaryRow}>

--- a/app/components/ui/Navigation/Navigation.module.scss
+++ b/app/components/ui/Navigation/Navigation.module.scss
@@ -3,12 +3,21 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 // NAVIGATION
 
-.siteNav {
-  background: $color-white;
+@mixin siteNavShared {
   position: sticky;
   position: -webkit-sticky;
   top: 0;
   z-index: 1000;
+}
+
+.siteNav {
+  background: $color-white;
+  @include siteNavShared;
+}
+
+.siteNavSFFamilies {
+  background: $color-sffamilies-nav;
+  @include siteNavShared;
 }
 
 @mixin navRow {
@@ -44,14 +53,27 @@
   }
 }
 
-.navLogo {
+@mixin navLogoShared {
   display: inline-block;
-  margin-right: calc-em(25px);
   vertical-align: top;
+}
+
+.navLogo {
+  margin-right: calc-em(25px);
   img {
     height: calc-em(20px);
     width: auto;
   }
+  @include navLogoShared;
+}
+
+.navLogoSFFamilies {
+  margin-right: calc-em(45px);
+  img {
+    height: calc-em(36px);
+    width: auto;
+  }
+  @include navLogoShared;
 }
 
 .navSearch {

--- a/app/styles/utils/_colors.scss
+++ b/app/styles/utils/_colors.scss
@@ -30,3 +30,7 @@ $color-grey9: #242C2E;
 $color-title: $color-grey9;
 $color-textfade: $color-grey6;
 $color-btn-primary: $color-brand;
+
+////////////////////////////////////////////////////////////////////////////////////////
+// SFFAMILIES COLORS
+$color-sffamilies-nav: #EDEDED;


### PR DESCRIPTION
Responding to whitelabel feedback from SFFamilies.
Affects SFFamilies whitelabel **only**:
- Removed COVID banner, Intercom, search bar, and rightside nav not desired by SFFamilies (only for SFFamilies whitelabel)
- Increased the size of the SFFamilies nav logo and changed the nav bar background color to match sffamilies.org more closely

Affects **both** SFSG and SFFamilies:
- Removed the unused "Mark Correct" button in the resource action sidebar
- Removed the "Edit" button from the mobile actions, as we wanted to stop exposing this action in the first place
- Fixed an issue where the service page would not load if the MapOfLocations component failed to reach google apis
<img width="915" alt="image" src="https://user-images.githubusercontent.com/834403/107133766-7ad88b80-68a0-11eb-9d6c-6749f06992d3.png">
