### PR TITLE
Remove mobile navigation buttons from SFFamilies whitelabel

### DIFF
--- a/app/components/ui/Navigation/Navigation.jsx
+++ b/app/components/ui/Navigation/Navigation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Link, withRouter } from 'react-router-dom';
 import qs from 'qs';
@@ -70,29 +70,31 @@ class Navigation extends React.Component {
               )
             }
           </div>
-          <div className={styles.mobileNavigation}>
-            <button type="button" className={styles.searchButton} onClick={this.toggleSecondarySearch} />
-            <button type="button" className={styles.hamburgerButton} onClick={toggleHamburgerMenu} />
-          </div>
           {!isSFFamiliesSite()
             && (
-              <ul className={styles.navRight}>
-                <li>
-                  <Link to="/about">
-                    About
-                  </Link>
-                </li>
-                <li>
-                  <a href="https://help.sfserviceguide.org" target="_blank" rel="noopener noreferrer">
-                    FAQ
-                  </a>
-                </li>
-                <li>
-                  <a href="https://help.sfserviceguide.org/en/collections/1719243-contact-us" target="_blank" rel="noopener noreferrer">
-                    Contact Us
-                  </a>
-                </li>
-              </ul>
+              <Fragment>
+                <div className={styles.mobileNavigation}>
+                  <button type="button" className={styles.searchButton} onClick={this.toggleSecondarySearch} />
+                  <button type="button" className={styles.hamburgerButton} onClick={toggleHamburgerMenu} />
+                </div>
+                <ul className={styles.navRight}>
+                  <li>
+                    <Link to="/about">
+                      About
+                    </Link>
+                  </li>
+                  <li>
+                    <a href="https://help.sfserviceguide.org" target="_blank" rel="noopener noreferrer">
+                      FAQ
+                    </a>
+                  </li>
+                  <li>
+                    <a href="https://help.sfserviceguide.org/en/collections/1719243-contact-us" target="_blank" rel="noopener noreferrer">
+                      Contact Us
+                    </a>
+                  </li>
+                </ul>
+              </Fragment>
             )
           }
         </div>


### PR DESCRIPTION
This removes the top level navigation buttons from SFFamilies. Free text is not yet supported, and all the hamburger menu items are SFSG related.

<img width="473" alt="image" src="https://user-images.githubusercontent.com/834403/111113144-9168a700-851e-11eb-828a-ac92d81a0822.png">

Note that the original SFSG / askdarcel sites retain their elements:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/834403/111113446-0b992b80-851f-11eb-9f76-b3fcbf45ed0c.png">

