### PR TITLE
Simplify z-index handling.

### DIFF
--- a/app/components/edit/EditSidebar.module.scss
+++ b/app/components/edit/EditSidebar.module.scss
@@ -15,7 +15,7 @@
   @media screen and (max-width: 900px ) {
     width: 100%;
     height: 80px;
-    z-index: 1000;
+    z-index: 1;
   }
 
   @media screen and (max-width: 767px ) {
@@ -106,7 +106,6 @@
   padding: 15px 25px;
   width: 250px;
   background: $color-grey1;
-  z-index: 2;
 
   @media screen and (max-width: 900px ) {
     flex-direction: row;

--- a/app/components/search/SearchEntry.scss
+++ b/app/components/search/SearchEntry.scss
@@ -6,7 +6,6 @@
   transition: all 200ms ease;
   background: #fff;
   &:active, &:hover, &:focus {
-    z-index: 1;
     box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.2);
   }
   @media screen and (max-width: 767px) {

--- a/app/components/search/SearchMap.scss
+++ b/app/components/search/SearchMap.scss
@@ -1,7 +1,6 @@
 .results-map {
   flex: 1 1 auto;
   position: relative;
-  z-index: 1;
   width: 45vw;
   @media screen and ( min-width: 1440px ){
     width: 55vw;

--- a/app/components/search/SearchResultsContainer.scss
+++ b/app/components/search/SearchResultsContainer.scss
@@ -35,8 +35,6 @@
   align-items: stretch;
   width: 55vw;
   box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, 0.4);
-  position: relative;
-  z-index: 2;
   background: #F3F5F7;
   height: 100%;
   @media screen and ( min-width: 1440px ){

--- a/app/components/ui/Navigation/Navigation.module.scss
+++ b/app/components/ui/Navigation/Navigation.module.scss
@@ -5,9 +5,8 @@
 
 @mixin siteNavShared {
   position: sticky;
-  position: -webkit-sticky;
   top: 0;
-  z-index: 1000;
+  z-index: 1;
 }
 
 .siteNav {

--- a/app/components/ui/PopUpMessage.scss
+++ b/app/components/ui/PopUpMessage.scss
@@ -28,7 +28,7 @@
   }
 
   &.hidden {
-    z-index: -1;
     opacity: 0;
+    pointer-events: none;
   }
 }

--- a/app/pages/OrganizationEditPage.scss
+++ b/app/pages/OrganizationEditPage.scss
@@ -30,7 +30,6 @@
   background: #fff;
   margin: calc-em(35px) calc-em(30px) calc-em(40px) 0;
   width: 100%;
-  z-index: 999;
   text-align: center;
   &--title {
     color: #333333;

--- a/app/styles/utils/_layoututils.scss
+++ b/app/styles/utils/_layoututils.scss
@@ -70,7 +70,11 @@ body {
 }
 
 .search-page-container {
-  overflow: hidden;
+  // Create a stacking context so that any descendent elements that increase
+  // their z-index cannot stack above elements in the stacking context of
+  // .search-page-container, which includes the nav bar.
+  position: relative;
+  z-index: 0;
 }
 
 .disabled-feature {


### PR DESCRIPTION
In order to prevent an arms race of larger z-indexes, this change
removed z-indexes from elements that do not need them and reduces
the z-index values of elements that do need them. It also adds some
z-index: 0 values (with comments!) in order to explicitly construct a
stacking context to prevent descendant elements from hovering over
higher level sibling elements.

The remaining z-indexes are between 0 and 3.

I manually tested this on the search results page and the edit page, which were the two main pages that had z-indexes set on their elements. I also made sure to test the site in a mobile view, since some of the z-indexes are specifically for the mobile layouts.