### PR TITLE
Have Navigation logo go to root URL when not on SF Families whitelabel.

### DIFF
--- a/app/components/ui/Navigation/Navigation.jsx
+++ b/app/components/ui/Navigation/Navigation.jsx
@@ -4,7 +4,7 @@ import { Link, withRouter } from 'react-router-dom';
 import qs from 'qs';
 import { images } from 'assets';
 import styles from './Navigation.module.scss';
-import { getSiteUrl, isSFFamiliesSite } from '../../../utils/whitelabel';
+import { getSiteTitle, getSiteUrl, isSFFamiliesSite } from '../../../utils/whitelabel';
 
 class Navigation extends React.Component {
   constructor() {
@@ -40,16 +40,32 @@ class Navigation extends React.Component {
   render() {
     const { showSearch, toggleHamburgerMenu } = this.props;
     const { showSecondarySearch, query } = this.state;
+
+    // On the SF Families whitelabel site, we want to link to an external site
+    // (the SF Families website), so it must be an external link. For other
+    // sites, we want to just use an internal react-router Link to the root URL,
+    // since 1) this allows us to use react-router routing and 2) this avoids
+    // having staging and development environments link to the production site.
+    let logoLink;
+    if (isSFFamiliesSite()) {
+      logoLink = (
+        <a className={styles.navLogoSFFamilies} href={getSiteUrl()}>
+          <img src={images.logoSmall} alt={getSiteTitle()} />
+        </a>
+      );
+    } else {
+      logoLink = (
+        <Link className={styles.navLogo} to="/">
+          <img src={images.logoSmall} alt={getSiteTitle()} />
+        </Link>
+      );
+    }
+
     return (
       <nav className={isSFFamiliesSite() ? styles.siteNavSFFamilies : styles.siteNav}>
         <div className={styles.primaryRow}>
           <div className={styles.navLeft}>
-            <a
-              className={isSFFamiliesSite() ? styles.navLogoSFFamilies : styles.navLogo}
-              href={getSiteUrl()}
-            >
-              <img src={images.logoSmall} alt="Ask Darcel" />
-            </a>
+            {logoLink}
             {showSearch
               && (
                 <form


### PR DESCRIPTION
## Background
I was poking around on the staging site, and then at some point I realized that I was on the production site for some reason. I figured out it was because I had clicked on the SF Service Guide logo in the nav bar, which always links to the production site even when you're on staging.

This is confusing, and it's possibly the reason why @fredciaramaglia noticed that there was some dummy data that a ShelterTech user had entered into the production site, since it's not obvious at all that you've switched sites from clicking on the logo in the nav bar.

This link was intentionally changed recently in https://github.com/ShelterTechSF/askdarcel-web/pull/1015 to do this, but we really only want this behavior on the SF Families whitelabel site. For all other environments so far, it's safer to just have a link to the `/` URL, since it preserves the domain and won't take you to a separate site.

## Changes
This PR changes the logic for that logo link element to do different things based on whether it's the SF Families whitelabel site or whether it's any other site. It also adds a fat comment so that future readers of the code understand the subtleties behind the logic, which is not obvious from reading the code.

This isn't the cleanest solution, but I think it'll do for now. If we do more whitelabel projects in the future, we probably need to model this in an actual JSON-like data structure that's defined for each site, since the nav is already getting a bit crazy with the conditional logic that checks which site you're on.

## How this was tested
I tested this locally on both the normal AskDarcel site and the SF Families whitelabel by temporarily forcing my local environment to think that it was on the SF Families site.