### PR TITLE
Log browser console errors experienced when running TestCafe tests.

### DIFF
--- a/testcafe/editResource.js
+++ b/testcafe/editResource.js
@@ -7,7 +7,19 @@ const editResourcePage = new EditResourcePage();
 const servicePage = new ServicePage();
 
 fixture`Edit Resource`
-  .page(ResourcePage.url(1));
+  .page(ResourcePage.url(1))
+  .afterEach(async t => {
+    const { log, warn, error } = await t.getBrowserConsoleMessages();
+
+    console.log('Captured console.log() messages:');
+    console.log(JSON.stringify(log));
+
+    console.log('Captured console.warn() messages:');
+    console.log(JSON.stringify(warn));
+
+    console.log('Captured console.error() messages:');
+    console.log(JSON.stringify(error));
+  });
 
 
 async function testEditTextProperty(t, showPageSelector, editPageSelector, newValue) {


### PR DESCRIPTION
I'm having a terrible time debugging or reproducing the [TestCafe errors](https://travis-ci.org/github/ShelterTechSF/askdarcel-web/builds/763814860) in `master`.

No matter what I do, I can't reproduce the errors locally, even when I check out the `master` branches of both repos and I reset my database. When I look at the video recording of the browser test failures in Sauce Labs, I can see that in the "Add resource phone number" always triggers a "Sorry! An error occurred." message when the test tries to hit the Save button, but I have no idea what's causing it. According to [the code](https://github.com/ShelterTechSF/askdarcel-web/blob/efc32e14f17db6b4b9e39bbe5c93684f530677e2/app/pages/OrganizationEditPage.jsx#L691), that error message appears if any of the multiple HTTP request promises fails. It looks like we do [log the promise error to the console](https://github.com/ShelterTechSF/askdarcel-web/blob/efc32e14f17db6b4b9e39bbe5c93684f530677e2/app/pages/OrganizationEditPage.jsx#L688), but that's not possible for us to view from the current Travis CI output or the TestCafe output.

This PR is an attempt at getting TestCafe to print out any console errors that it sees in the browser to the command line console (i.e. Travis CI) so that we have more useful debug information. This isn't the cleanest way of doing things, since it pollutes the console output for even tests that succeed with stuff that looks like this:

```
 Edit Resource
Captured console.log() messages:
[]
Captured console.warn() messages:
[]
Captured console.error() messages:
["React-Hot-Loader: misconfiguration detected, using production version in non-production environment.","React-Hot-Loader: Hot Module Replacement is not enabled.","InvalidValueError: setIcon: not a string; and not an instance of PinView; and no url property; and no path property","React-Hot-Loader: misconfiguration detected, using production version in non-production environment.","React-Hot-Loader: Hot Module Replacement is not enabled.","React-Hot-Loader: misconfiguration detected, using production version in non-production environment.","React-Hot-Loader: Hot Module Replacement is not enabled.","InvalidValueError: setIcon: not a string; and not an instance of PinView; and no url property; and no path property"]
 ✓ Edit resource name
```

However, I want to submit this as a PR so that I can at least see why the current "Add resource phone number" test fails and whether this gives us more useful information before I clean it up a bit more.