### PR TITLE
Use Docker named volume for node_modules in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,37 @@ target a different instance of askdarcel-api, you can modify the `API_URL`
 environment variable in docker-compose.yml.
 
 
+#### Fully tearing down environment
+
+In case you ever need to fully tear down your local development environment,
+such as to do a fresh setup from a clean slate, you will need to run extra
+commands to remove state that is stored in Docker. Removing the git repository
+and re-cloning is _insufficient_ because some of the state is stored in Docker.
+
+In particular, for performance reasons, we save NPM modules in a `node_modules/`
+directory that is mounted from a Docker volume rather than bind mounting the
+`node_modules/` directory from the host operating system (e.g. macOS). To delete
+all the installed NPM modules, you will have to remove the Docker volume.
+
+The following command will stop all running Docker containers, delete them, and
+remove their volumes:
+
+```sh
+$ docker-compose down --remove-orphans --volumes
+```
+
+Note: When you run that command, you may get an error message about removing
+networks:
+
+```
+ERROR: error while removing network: network askdarcel id
+4c4713d7f42173843437de3b0051a9d7e7bc81eb18123993975c3cd5a9e0a38e has active
+endpoints
+```
+
+If this happens, then you need to run `docker-compose stop` in the askdarcel-api
+application first before running the `docker-compose down` command above.
+
 ## Non-Docker Development Environment
 
 ### Installing Node.js and npm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,14 @@ services:
       - '8080:8080'
     volumes:
       - .:/usr/src/app:delegated
+      # Mount a separate, named volume over node_modules/ because Docker for
+      # Mac's gRPC FUSE sync is really, really slow for the number of files in
+      # node_modules.
+      - node-modules:/usr/src/app/node_modules
     working_dir: /usr/src/app
+
+volumes:
+  node-modules:
 
 networks:
   # Used to connect to askdarcel-api in a different docker-compose instance


### PR DESCRIPTION
I'd like to propose a change to how our Docker development environment is set up in order to make it much, much faster to install NPM modules (I measured an **8x** improvement), especially from a clean slate. The downside to this proposal is that it makes the development environment more opaque, since it relies on more advanced Docker features.

## High-level changes

Instead of bind mounting the `node_modules/` directory from the host OS (e.g. macOS), we now create a [Docker (named) volume](https://docs.docker.com/storage/volumes/) to store the `node_modules/` directory. Docker volumes are persistent file system volumes that, in Docker for Mac, live entirely within the Linux virtual machine that runs Docker, and they continue to persist even when containers are stopped.

## Impact on developers, even if they don't necessarily know Docker in depth

From the perspective of a developer, the `node_modules/` directory that they see in their file system _will not_ correspond to the `node_modules/` directory that the application sees when running in a container. When running in Docker, the `node_modules/` directory from the host OS is essentially replaced with the Docker volume we created, so nothing you do to the host OS's `node_modules/` will have any effect on the Docker containers.

This _may_ affect an IDE's ability to understand which NPM modules are installed. However, since I'm not an IDE user, I'm not sure how I would be able to test this.

There's no change to the normal commands developers run, since the changes are under the docker/docker-compose hood, so the usual `docker-compose run` commands will continue to work.

If you're used to running `rm -rf node_modules/` to delete the NPM modules in order to reinstall the app from scratch, that won't work anymore, and instead you will need to delete the Docker volume. In fact, even `rm -rf askdarcel-web` and re-cloning the repo won't delete the volumes, and you'll still have to run a special command to delete the volume. I updated the README with instructions on how to do this.

## Migrating from the old setup to this new one

The only migration step for anyone who already had the application set up previously is to run `docker-compose run --rm web npm install` again. (Though you may also want to `rm -rf node_modules/` just to get rid of the old and now-unused files to avoid any confusion in the future.)

## Detailed explanation

The reason this has such a large impact on performance is because bind mounts on Docker for Mac are very slow. This has always been a problem with Docker on macOS, even from the days before the current Docker for Mac desktop app was created, and although there have been improvements over time, I suspect that the update that Docker made last year to switch to the gRPC FUSE synching strategy has caused a large performance regression for certain types of applications.

NPM and `node_modules/` are a particularly problematic case, since not only does gRPC FUSE need to copy over a huge number of bytes (it's 655 MiB for our application), but most of these bytes are split across a ton of small JavaScript source files (I count 92,571 distinct files in my `node_modules`), so we continue to pay the overhead of intercepting file system calls on the Docker side of things in order to translate them over to file system calls in macOS.

Switching to a named volume greatly improves performance in this case because it means the `node_modules/` never leave the Linux virtual machine, so there's no need to sync files or calls between macOS and Linux, and Linux can just read/write these files normally. `node_modules/` is fine to put in the named volume because none of those files is committed to git, and developers generally aren't touching the files in there.

## Measurements

In my not-very-scientific experiments on my laptop (a 15" 2016 MacBook Pro with quad core 2.7 GHz Intel Core i7's):

- Running `docker-compose run --rm web npm install` from scratch (i.e. `node_modules/` deleted) takes 12m53.931s
- Running the same command with the changes in the PR from scratch (i.e. Docker volume deleted) takes 1m37.957s, which is a 7.97x reduction.

The difference is so staggering that I don't think I need to run more controlled experiments to prove that this is a significant difference in performance.

While I didn't measure other commands, I suspect that this will generally speed up almost all other commands in the app, such as starting the development server or running the linter, though not by the same factor of improvement, since it only speeds up the reading of files in `node_modules` but not the reading of our own source files.

## Request for feedback

I'd like to get some feedback on whether we feel that this is an acceptable tradeoff to make, and I'm especially interested in hearing from people who are less familiar with Docker, since I'm too experienced with it to understand what this would look like from fresh eyes.

I'd also like to get feedback from people who run IDEs on whether the setup proposed in the PR has any negative interaction with their setup. I believe that VS Code has a way of interacting with files within a Docker container, so that's a route we could take, but I'm not familiar with how that's configured.