### PR TITLE
Update COVID banner with latest vaccine information.

### DIFF
--- a/app/components/ui/Banner/Banner.jsx
+++ b/app/components/ui/Banner/Banner.jsx
@@ -5,9 +5,9 @@ import styles from './Banner.module.scss';
 export default function Banner() {
   return (
     <div className={styles.bannerContainer}>
-      <strong>CORONAVIRUS COVID-19 UPDATE: </strong>
-      Starting March 15, you will be elegible if you have certain health conditions, disabilities, or live or work in congregate settings. More&nbsp;
-      <a href="https://sf.gov/information/other-conditions-eligible-covid-19-vaccine-starting-march-15">HERE</a>
+      <strong>COVID-19 VACCINE SITES: </strong>
+      Find out where to get a vaccine if you’re eligible&nbsp;
+      <a href="https://sf.gov/vaccine-sites">HERE</a>
     </div>
   );
 }


### PR DESCRIPTION
This updates the COVID banner on our site with the latest vaccination information in San Francisco.

<img width="1028" alt="Screen Shot 2021-04-05 at 8 09 06 PM" src="https://user-images.githubusercontent.com/1002748/113653534-e6de3280-964a-11eb-84e4-c59ae74e1df4.png">
