### PR TITLE
Change edit address API calls to use strings, not stringified integers

### DIFF
--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -18,11 +18,9 @@ import { withPopUpMessages } from '../actions/popUpMessageActions';
 
 import './OrganizationEditPage.scss';
 
-// These correspond to the ChangeRequest.action enum on the askdarcel-api side,
-// which are apparently strings that contain numbers, rather than numbers.
-const ACTION_INSERT = '0';
-const ACTION_EDIT = '1';
-const ACTION_REMOVE = '2';
+const ACTION_INSERT = 'insert';
+const ACTION_EDIT = 'edit';
+const ACTION_REMOVE = 'remove';
 
 /**
  * Apply a set of changes to a base array of items.


### PR DESCRIPTION
This is probably going to depend on @katerina-kossler's backend PR in https://github.com/ShelterTechSF/askdarcel-api/pull/576.

@katerina-kossler and I talked about this, and we decided that changing these to real strings and not stringified integers would be less confusing and easier to implement the code for on the backend, so this changes the frontend code to send real strings. I tested this against her current PR, which accepts either strings or integers, but we decided that we're just going to remove the handling of integers to make that code cleaner.

This was only ever being used for the recent multiple addresses feature, so none of the other models should be affected by this.