### PR TITLE
Fix submit button bug feedback modal

### DIFF
--- a/app/components/listing/feedback/FeedbackModal.jsx
+++ b/app/components/listing/feedback/FeedbackModal.jsx
@@ -71,11 +71,6 @@ const FeedbackModal = ({ service, resource, closeModal }) => {
       .catch(err => console.log(err));
   };
 
-  const isReviewRequired = (
-    tagOptions.some(({ tag, selected }) => tag === 'Other' && selected)
-    && vote === DOWNVOTE
-  );
-
   const STEPS = {
     tags: (
       <FeedbackTags tagOptions={tagOptions} onSelectTag={toggleSelectedTag} />
@@ -83,7 +78,6 @@ const FeedbackModal = ({ service, resource, closeModal }) => {
     review: (
       <Review
         reviewValue={review}
-        isReviewRequired={isReviewRequired}
         onReviewChange={handleReviewChange}
       />
     ),
@@ -115,7 +109,6 @@ const FeedbackModal = ({ service, resource, closeModal }) => {
             onPrevStep={handlePrevStep}
             onNextStep={handleNextStep}
             onSubmit={handleSubmit}
-            isReviewRequired={isReviewRequired}
             isSubmitted={isSubmitted}
           />
         </div>

--- a/app/components/listing/feedback/FeedbackModal.jsx
+++ b/app/components/listing/feedback/FeedbackModal.jsx
@@ -103,9 +103,6 @@ const FeedbackModal = ({ service, resource, closeModal }) => {
         <img src={images.icon('feedback-blue-header')} alt="feedback" />
         <span>Share your Feedback</span>
       </div>
-      <div className={styles.feedbackSubheader}>
-        The team usually replies within a day.
-      </div>
       {isSubmitted === 'submitted' ? (
         <SubmitMessage closeModal={closeModal} />
       ) : (

--- a/app/components/listing/feedback/FeedbackSteps.jsx
+++ b/app/components/listing/feedback/FeedbackSteps.jsx
@@ -52,7 +52,7 @@ export const FeedbackTags = ({ tagOptions, onSelectTag }) => (
   </div>
 );
 
-export const Review = ({ reviewValue, onReviewChange, isReviewRequired }) => (
+export const Review = ({ reviewValue, onReviewChange }) => (
   <div className={styles.feedbackReview}>
     <div className={styles.stepsPrompt}>
       Please provide your feedback below:
@@ -60,9 +60,7 @@ export const Review = ({ reviewValue, onReviewChange, isReviewRequired }) => (
     <textarea
       className={styles.feedbackTextarea}
       type="text"
-      placeholder={`Type your feedback here ${
-        !isReviewRequired ? '(optional)' : '(required)'
-      }`}
+      placeholder='Type your feedback here (optional)'
       value={reviewValue}
       onChange={onReviewChange}
     />
@@ -89,7 +87,6 @@ export const NavigationButtons = ({
   onPrevStep,
   onNextStep,
   onSubmit,
-  isReviewRequired,
   isSubmitted,
 }) => (
   <div className={styles.navButtonsContainer}>
@@ -102,7 +99,7 @@ export const NavigationButtons = ({
       <button
         type="button"
         className={styles.navButtons}
-        disabled={isReviewRequired || isSubmitted === 'submitting'}
+        disabled={isSubmitted === 'submitting'}
         onClick={onSubmit}
       >
         {isSubmitted === 'submitting' ? 'Submitting...' : 'Submit'}

--- a/app/components/listing/feedback/FeedbackSteps.jsx
+++ b/app/components/listing/feedback/FeedbackSteps.jsx
@@ -61,7 +61,7 @@ export const Review = ({ reviewValue, onReviewChange, isReviewRequired }) => (
       className={styles.feedbackTextarea}
       type="text"
       placeholder={`Type your feedback here ${
-        !isReviewRequired ? '(optional)' : ''
+        !isReviewRequired ? '(optional)' : '(required)'
       }`}
       value={reviewValue}
       onChange={onReviewChange}

--- a/app/components/listing/feedback/FeedbackSteps.jsx
+++ b/app/components/listing/feedback/FeedbackSteps.jsx
@@ -60,7 +60,7 @@ export const Review = ({ reviewValue, onReviewChange }) => (
     <textarea
       className={styles.feedbackTextarea}
       type="text"
-      placeholder='Type your feedback here (optional)'
+      placeholder="Type your feedback here (optional)"
       value={reviewValue}
       onChange={onReviewChange}
     />

--- a/app/components/listing/feedback/FeedbackSteps.module.scss
+++ b/app/components/listing/feedback/FeedbackSteps.module.scss
@@ -105,7 +105,6 @@
   width: 340px;
   margin-top: 30px;
   @media screen and (max-width: 767px ) {
-    position: absolute;
     bottom: 40px;
   }
 }

--- a/app/components/listing/feedback/FeedbackSteps.module.scss
+++ b/app/components/listing/feedback/FeedbackSteps.module.scss
@@ -104,9 +104,6 @@
   justify-content: space-between;
   width: 340px;
   margin-top: 30px;
-  @media screen and (max-width: 767px ) {
-    bottom: 40px;
-  }
 }
 
 .navButtons {


### PR DESCRIPTION
- Removed feedback(review) requirement if user chooses `Other` tag and make it optional, product team want it to be a lightweight feedback experience.
<img width="714" alt="Screen Shot 2021-05-07 at 8 07 23 PM" src="https://user-images.githubusercontent.com/15119566/117555158-a2f79800-b011-11eb-907b-2df86b23b238.png">
<img width="720" alt="Screen Shot 2021-05-07 at 8 07 33 PM" src="https://user-images.githubusercontent.com/15119566/117560064-532fc580-b03f-11eb-840e-82dd559fc8b8.png">

- We currently don't have a way of reaching back out so we had to remove sub-header message **"Team will usually replies within a day"**

- Removed unnecessary styling for mobile version