### PR TITLE
[DONOTMERGE] Make external link prepend https if not provided

### DIFF
--- a/app/components/listing/ResourceInfos.jsx
+++ b/app/components/listing/ResourceInfos.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
@@ -109,9 +109,13 @@ PhoneNumber.propTypes = {
 };
 
 
-const ExternalLink = ({ children, to }) => (
-  <a href={to} target="_blank" rel="noopener noreferrer">{children}</a>
-);
+const ExternalLink = ({ children, to }) => {
+  const url = useMemo(() => {
+    if (!/^https+:\/\//.test(to)) { return `https://${to}`; }
+    return to;
+  }, [to]);
+  return <a href={url} target="_blank" rel="noopener noreferrer">{children}</a>;
+};
 
 ExternalLink.propTypes = {
   to: PropTypes.string.isRequired,


### PR DESCRIPTION
https://app.clubhouse.io/sheltertech/story/1933/external-website-urls-don-t-work-without-explicitly-writing-http

A solution as requested to the above. I also just fixed the underlying data on the bad organization page, which I'd argue is a more robust solution, in which case we should not merge this.