### PR TITLE
Allow adding/removing addresses for services

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'jsx-a11y/click-events-have-key-events': 'off',
     'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
-    'jsx-a11y/label-has-for': ['error', { required: { some: ['nesting', 'id'] } }],
+    'jsx-a11y/label-has-for': ['off'], // This is deprecated in favor of jsx-a11y/label-has-associated-control
     'no-console': 'warn',
     'no-underscore-dangle': 'off',
     'react/forbid-prop-types': 'off',

--- a/app/components/edit/EditAddress.jsx
+++ b/app/components/edit/EditAddress.jsx
@@ -137,7 +137,7 @@ const compactAddressDisplay = ({
   return lines.filter(x => x).join(', ');
 };
 
-const AddressListItem = ({
+export const AddressListItem = ({
   displayIndex, address, onEdit, onRemove,
 }) => (
   <div className={s.listItemContainer}>
@@ -147,10 +147,12 @@ const AddressListItem = ({
     <div className={s.listItemName}>{address.name}</div>
     <div className={s.listItemAddress}>{compactAddressDisplay(address)}</div>
     <div className={s.listItemEdit}>
-      <button className={s.listItemButton} type="button" onClick={onEdit}>
-        <RiEditBoxLine />
-        Edit
-      </button>
+      {onEdit && (
+        <button className={s.listItemButton} type="button" onClick={onEdit}>
+          <RiEditBoxLine />
+          Edit
+        </button>
+      )}
     </div>
     <div className={s.listItemRemove}>
       <button className={s.listItemButton} type="button" onClick={onRemove}>

--- a/app/components/edit/EditServices.jsx
+++ b/app/components/edit/EditServices.jsx
@@ -4,7 +4,7 @@ import ProvidedService from './ProvidedService';
 
 
 const EditServices = ({
-  addService, editServiceById, handleDeactivation, services,
+  addService, editServiceById, handleDeactivation, services, resourceAddresses,
 }) => (
   <li className="edit--section--list--item">
     <ul className="edit--section--list--item--sublist edit--service--list">
@@ -16,6 +16,7 @@ const EditServices = ({
             service={service}
             editServiceById={editServiceById}
             handleDeactivation={handleDeactivation}
+            resourceAddresses={resourceAddresses}
           />
         ))
       }

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -112,6 +112,13 @@ const EditAddresses = ({ service, resourceAddresses, handleChange }) => {
       if (resourceAddresses[handle].isRemoved) {
         return [];
       }
+      // HACK: Filter out any addresses that were just created on the Edit page
+      // but have not been saved to the DB yet, since they do not have IDs and the
+      // current create address API does not return the ID of the address, which
+      // prevents other logic on the Edit page from functioning correctly.
+      if (!('id' in resourceAddresses[handle])) {
+        return [];
+      }
       return [{ value: handle, label: address.name || address.address_1 }];
     });
   const handleSelectChange = e => {

--- a/app/components/edit/ProvidedService.module.scss
+++ b/app/components/edit/ProvidedService.module.scss
@@ -1,0 +1,15 @@
+.addressSelect {
+  border: 1px solid #DDDDDD;
+  display: block;
+  font-size: 16px;
+  margin-top: 15px;
+  padding: 15px;
+  width: 100%;
+}
+
+.addressList {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 12px;
+  row-gap: 2px;
+}

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -386,7 +386,7 @@ const getAddresses = state => {
   // address in the first place, but in that case, using either state.addresses
   // or state.resources.addresses should both give the same result.
   if (addresses.length === 0) {
-    return state.resource.addresses;
+    return state.resource.addresses || [];
   }
   return addresses;
 };

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -835,6 +835,7 @@ class OrganizationEditPage extends React.Component {
           editServiceById={this.editServiceById}
           addService={this.addService}
           handleDeactivation={this.handleDeactivation}
+          resourceAddresses={this.getFlattenedAddresses()}
         />
       </ul>
     );

--- a/app/pages/ServiceListingPage.jsx
+++ b/app/pages/ServiceListingPage.jsx
@@ -23,7 +23,14 @@ import { getSiteTitle } from '../utils/whitelabel';
 
 // TODO This should be serviceAtLocation
 const getServiceLocations = (service, resource, recurringSchedule) => {
-  const { addresses = [] } = resource;
+  let addresses;
+  if (service.addresses && service.addresses.length > 0) {
+    ({ addresses } = service);
+  } else if (resource.addresses) {
+    ({ addresses } = resource);
+  } else {
+    addresses = [];
+  }
   return addresses.map(address => ({
     id: address.id,
     address,

--- a/app/utils/DataService.js
+++ b/app/utils/DataService.js
@@ -57,6 +57,26 @@ export function get(url, headers) {
   });
 }
 
+export function put(url, body, headers) {
+  let queryHeaders = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+  if (headers) {
+    queryHeaders = _.assignIn(queryHeaders, headers);
+  }
+  return fetch(url, {
+    method: 'PUT',
+    mode: 'cors',
+    headers: queryHeaders,
+    body: JSON.stringify(body),
+  }).then(resp => {
+    if (!resp.ok) { throw resp; }
+    setAuthHeaders(resp);
+    return resp;
+  });
+}
+
 export function APIDelete(url, headers) {
   let queryHeaders = {
     'Content-Type': 'application/json',


### PR DESCRIPTION
Implements https://app.clubhouse.io/sheltertech/story/1873/ui-ability-to-associate-remove-multiple-addresses-from-services.

https://www.figma.com/file/tBRClGsxYN9m6ZvL2STB6t/WIP-Edit-Redesign---Unscheduled?node-id=2835%3A7067

Note that this depends on https://github.com/ShelterTechSF/askdarcel-api/pull/587.

## Apologies and Warnings
Let me first start by apologizing for the quality of my code here. This is not code that I am proud of, and if someone had presented it to me, I probably would have found it to be one of the most unreadable, arcane, and dense patches I have ever seen.

This code is not pretty. It represents a lot trial and error with trying to handle all the possible cases that can occur on the Edit page. We have a combinatorial explosion of possibilities, where data must be assembled from multiple different locations, and where the "latest" info will be in one place before any edits are made, another place when certain types of edits are made, and yet other places when other types of edits are made. I can assure you that almost every line that I added in OrganizationEditPage.jsx is necessary and accounts for some scenario, and I did not even predict 50% of these scenarios when first implementing these changes.

I think we should do very heavy testing of this on staging before deploying to production, since it's very brittle. I would even appreciate it if people could check out this branch locally and try messing around with adding/removing addresses on Services before this is merged into master.

## Technical Approach
The fundamental idea behind my approach is to re-normalize the data coming from the API by collapsing all instances of an Address into a single instance, replacing all other instances with handles. Normally the API will completely duplicate the Address information if it is present on an individual Service, especially if it is present on multiple Services. On readonly pages, this is fine, but on the Edit page, it could lead to a lot of inconsistent state if we need to propagate changes from the Resource's Addresses to all of the Services' addresses.

I chose to make the version of the Address on the Resource the canonical one, and I replaced all other instances on the Services with handles. My choice of representation for the handle is the index into the Addresses array on the Resource. I chose to do it this way because we have no other unique identifier for Addresses that have been added but not yet saved to the DB. Although I could have attempted to assign each address a unique ID, similar to what we do with the negative IDs for Services, I was afraid that this would be too invasive of a change to the page and affect the previously existing logic. In hindsight, this might have been less invasive than the changes that I actually ended up making.

## Unimplemented Scenario: Creating a New Address and Associating It With A Service
There is one important scenario that I did not implement, and I added additional code to explicitly prevent from happening. It is impossible for us to handle the case where a user adds a new address to the resource, and then attempts to add that address to the service, all within the same session on the Edit page. This is because when creating a new address, we do not have a database primary key identifier yet, which is needed to associate the new address with a service. The API endpoint for creating addresses _does not return the new address's ID_; this is because it's not actually an API endpoint for creating addresses, but rather an API endpoint for creating a _ChangeRequest_ for creating an address.

I spoke with @jjfreund about this, and we decided that it would be best to just prevent users from even being able to select new addresses. The workaround for uses would be to first create a new address and hit the save button on the page, and then to go back to the Edit page to associate the address with Services. @fredciaramaglia, does that sound acceptable to you?

## Other remarks

I did not exactly follow the Figma designs. This is partially because the designs are incompatible with the actual data model, and partially because I am/was under the impression that only ShelterTech internal staff will ever access these pages (although I am apparently already wrong about that...).

The Figma designs have a checkbox for inheriting addresses from the resource. This is not compatible with either our DB schema nor with the [OpenReferral data model](http://docs.openreferral.org/en/latest/_images/entity_relationship_diagram.svg). According to our DB schema and OpenReferral, addresses (locations) must primarily live on resources (organizations), but services may optionally have specific pointers to those addresses (ServiceAtLocation).

The distinction here is important with regards to edits. In the [language of Domain Driven Design](https://martinfowler.com/bliki/EvansClassification.html), our addresses are Entities, not Value Objects, and therefore edits to an address should impact all services at that address. Addresses are entities in that they have their own identities and change over time.

To hammer that idea into the UI, I removed both the "edit" and "add" address buttons from the Services section, only allowing one to select an address from the resource via a dropdown menu or removing that address, but not allowing a user to actually modify or delete the address from the Services section of the page.

## Screenshots

<img width="873" alt="Screen Shot 2021-06-07 at 10 32 53 PM" src="https://user-images.githubusercontent.com/1002748/121129829-5d7de480-c7e2-11eb-84b3-780065ff069c.png">
<img width="880" alt="Screen Shot 2021-06-07 at 10 32 58 PM" src="https://user-images.githubusercontent.com/1002748/121129835-5fe03e80-c7e2-11eb-9964-cf03b89f3b65.png">
