### PR TITLE
Check for null addresses on ServiceDiscoveryResults page.

### DIFF
--- a/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
+++ b/app/pages/ServiceDiscoveryResults/SearchResults/SearchResults.jsx
@@ -56,7 +56,7 @@ const SearchResult = ({ hit, index }) => {
   );
 
   const renderAddressMetadata = hit_ => {
-    if (hit_.addresses.length === 0) {
+    if (!hit_.addresses || hit_.addresses.length === 0) {
       return <span>No address found</span>;
     }
     if (hit_.addresses.length > 1) {


### PR DESCRIPTION
@jjfreund let me know that the ServiceDiscoveryResults pages break if an organization is missing any addresses, which might be related to the multiple addresses project regarding how orgs with no addresses are represented. Previously there would be a dummy, blank address on an org, but now it's probably just returning null.

This adds an extra check to the search results page so that we handle the case where Algolia returns null or undefined for the addresses property.

Tested this locally by creating an org with no addresses, which initially broke the guided pathways results page before this one-line change.