### PR TITLE
Check if addressHandles is undefined before continuing to add/remove addresses on Services.

### DIFF
--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -626,6 +626,14 @@ class OrganizationEditPage extends React.Component {
           // Compute the added and removed addresses by comparing the original
           // address handles to the new address handles, and submit API requests
           // that add/remove addresses from the service.
+
+          // Special case: if addressHandles is undefined, then skip all the
+          // remaining logic, since the addresses on the service were not
+          // touched. This is important because without this early exit, the
+          // rest of this code will think that we are trying to remove all
+          // addresses from the service.
+          if (addressHandles === undefined) return;
+
           const originalService = resource.services.find(s => s.id === currentService.id);
           const oldAddressHandleSet = new Set(originalService.addressHandles);
           const newAddressHandleSet = new Set(addressHandles);


### PR DESCRIPTION
We were receiving reports that sometimes addresses on the services get dropped when making unrelated edits to the service. This is actually a bit subtle to even notice, since our default behavior when Services don't have explicit addresses is to inherit the parent Resource's (Organization's) addresses.

I narrowed it down to this part of the `postServices()` method, which handles updates to a Service's addresses by diffing between the original Service's addresses and what has been modified by the user. The diffing logic itself was faulty, since when a service started out with having addresses but a user does not modify the service's addresses, the `addressHandles` property on the service ends up being `undefined`. The diffing logic treated `undefined` as being the same as "empty collection", and assumed that we intended to remove all existing addresses from the Service.

This adds a small hotfix to the code to abort early if `addressesHandles` is `undefined`, which seems to fix the issue for me locally.