### PR TITLE
Map white label subdomains to a staging name

### DIFF
--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -32,8 +32,9 @@ interface WhiteLabelSite {
 
 // Include a domain in config.js
 function determineWhiteLabelSite(): WhiteLabelSiteKey {
-  if (window.location.host.split('.')[0] === String(config.SFFAMILIES_DOMAIN) || window.location.host.split('.')[0] === `${String(config.SFFAMILIES_DOMAIN)}-staging`) return 'SFFamilies';
-  if (window.location.host.split('.')[0] === String(config.MOHCD_DOMAIN) || window.location.host.split('.')[0] === `${String(config.MOHCD_DOMAIN)}-staging`) return 'SFServiceGuide';
+  const subdomain = window.location.host.split('.')[0];
+  if (subdomain === String(config.SFFAMILIES_DOMAIN) || subdomain === `${String(config.SFFAMILIES_DOMAIN)}-staging`) return 'SFFamilies';
+  if (subdomain === String(config.MOHCD_DOMAIN) || subdomain === `${String(config.MOHCD_DOMAIN)}-staging`) return 'SFServiceGuide';
   return 'defaultWhiteLabel';
 }
 

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -32,8 +32,8 @@ interface WhiteLabelSite {
 
 // Include a domain in config.js
 function determineWhiteLabelSite(): WhiteLabelSiteKey {
-  if (window.location.host.split('.')[0] === config.SFFAMILIES_DOMAIN || window.location.host.split('.')[0] === config.SFFAMILIES_DOMAIN.concat("-staging")) return 'SFFamilies';
-  if (window.location.host.split('.')[0] === config.MOHCD_DOMAIN || window.location.host.split('.')[0] === config.MOHCD_DOMAIN.concat("-staging")) return 'SFServiceGuide';
+  if (window.location.host.split('.')[0] === String(config.SFFAMILIES_DOMAIN) || window.location.host.split('.')[0] === `${String(config.SFFAMILIES_DOMAIN)}-staging`) return 'SFFamilies';
+  if (window.location.host.split('.')[0] === String(config.MOHCD_DOMAIN) || window.location.host.split('.')[0] === `${String(config.MOHCD_DOMAIN)}-staging`) return 'SFServiceGuide';
   return 'defaultWhiteLabel';
 }
 

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -32,8 +32,8 @@ interface WhiteLabelSite {
 
 // Include a domain in config.js
 function determineWhiteLabelSite(): WhiteLabelSiteKey {
-  if (window.location.host === config.SFFAMILIES_DOMAIN) return 'SFFamilies';
-  if (window.location.host === config.MOHCD_DOMAIN) return 'SFServiceGuide';
+  if (window.location.host.split('.')[0] === config.SFFAMILIES_DOMAIN || window.location.host.split('.')[0] === config.SFFAMILIES_DOMAIN.concat("-staging")) return 'SFFamilies';
+  if (window.location.host.split('.')[0] === config.MOHCD_DOMAIN || window.location.host.split('.')[0] === config.MOHCD_DOMAIN.concat("-staging")) return 'SFServiceGuide';
   return 'defaultWhiteLabel';
 }
 


### PR DESCRIPTION
Added one fix, the env configed domain is just the subdomain key, "sffamilies" etc for sffamilies.sfserviceguide.org

Also support same mapping for sffamilies-staging.sfserviceguide.org etc.