### PR TITLE
Fix silent ESLint errors by upgrading babel-eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,7 @@ module.exports = {
     {
       // Non-TypeScript, JavaScript files
       files: ['*.js', '*.jsx'],
-      parser: 'babel-eslint',
+      parser: '@babel/eslint-parser',
       rules: {
         'react/sort-comp': 'off',
         // Disable TypeScript-specific rules on regular JavaScript files.

--- a/app/components/listing/feedback/FeedbackModal.jsx
+++ b/app/components/listing/feedback/FeedbackModal.jsx
@@ -110,7 +110,7 @@ const FeedbackModal = ({ service, resource, closeModal }) => {
         <SubmitMessage closeModal={closeModal} />
       ) : (
         <div className={styles.stepsContainer}>
-          {<VoteButtons vote={vote} onVoteChange={handleVoteChange} />}
+          <VoteButtons vote={vote} onVoteChange={handleVoteChange} />
           {STEPS[step]}
           <NavigationButtons
             step={step}

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,25 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.15.4.tgz",
+      "integrity": "sha512-hPMIAmGNbmQzXJIo2P43Zj9UhRmGev5f9nqdBFOWNGDGh6XKmjby79woBvg6y0Jur6yRfQBneDbUQ8ZVc1krFw==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
@@ -3852,38 +3871,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        }
-      }
     },
     "babel-loader": {
       "version": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",
+    "@babel/eslint-parser": "^7.15.4",
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-react": "^7.0.0",
@@ -61,7 +62,6 @@
     "@types/redux": "^3.6.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
-    "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
     "chai": "^4.1.2",
     "cross-env": "^6.0.3",


### PR DESCRIPTION
## Problem summary

We're getting silent errors with ESLint right now, due to our babel-eslint being too old to parse TypeScript files, which is an issue when we have plain JavaScript files import TypeScript files. An example of the silent errors can be seen in this [passing CI run](https://github.com/ShelterTechSF/askdarcel-web/runs/3553457316), under the "Run npm run lint" section:

```
Run npm run lint

> ShelterTech@1.0.0 lint /home/runner/work/askdarcel-web/askdarcel-web
> eslint --ext=.js,.jsx,.ts,.tsx .


Error while parsing /home/runner/work/askdarcel-web/askdarcel-web/app/utils/whitelabel.ts
Line 65, column 2: Line 65: Missing semicolon.

  63 |   title: 'SF Families',
  64 |   userWay: true,
> 65 | } as const;
     |  ^
  66 |
  67 | const SFServiceGuide: WhiteLabelSite = {
  68 |   appImages: {
`parseForESLint` from parser `/home/runner/work/askdarcel-web/askdarcel-web/node_modules/babel-eslint/lib/index.js` is invalid and will just be ignored
```

This does not cause the ESLint process to fail, so it still exits with non-zero status when no lint errors are detected. This still isn't good, since this could hide other issues due to the imports not being properly resolved.

## Background on our ESLint configuration
Our setup is a bit complicated, but we use two separate JavaScript parsers for ESLint: `@typescript-eslint/parser` for the TypeScript files and `babel-eslint` for the normal JavaScript files. The issue is that sometimes our JavaScript files import TypeScript files, and then `babel-eslint` will attempt to parse the file being imported, but fails due to not understanding newer TypeScript syntax.

The [babel-eslint](https://github.com/babel/babel-eslint) package was deprecated two years ago, and it was moved into [@babel/eslint-parser](https://www.npmjs.com/package/@babel/eslint-parser) to be under the `@babel` namespace.

## What this PR changes
This PR removes `babel-eslint` and switches to `@babel/eslint-parser`, since that's the new name of the package, which has actually been receiving updates over the past two years.

Since this upgrades the package by a couple of years, we picked up one more lint rule that we didn't have before which yells at you if you have unnecessary curly braces in JSX/TSX code. We only had one instance of that, so I fixed in this PR as well.

This should make https://github.com/ShelterTechSF/askdarcel-web/pull/1075 unnecessary, as the root cause of the silent ESLint issues was not the TypeScript parser but rather the Babel parser for TypeScript.