### PR TITLE
Pin Node.js version to 10.x for release workflow.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,6 +6,7 @@ on:
       - '*'
 
 env:
+  NODE_VERSION: 10.x
   DOCKER_REPO: sheltertechsf/askdarcel-web
 
 jobs:


### PR DESCRIPTION
Some of our dependencies are too old and don't have precompiled versions
that are packaged for Node.js 16, which causes the publish workflow to
attempt to compile them from source. We're missing some of the libraries
necessary to compile the libraries from source, so this just ends up
failing.

Pinning to 10.x should fix the issue, and it's exactly what we're doing
for the CI workflow anyway.