### PR TITLE
Reload service page in Cypress test rather than fetching to bypass po…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,14 @@ jobs:
       - run: yarn cypress run
       - if: always()
         run: docker-compose -f docker-compose.test.yml logs -t # Output all docker logs from API and frontend to help debugging after the fact
-
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: E2E screenshot(s) and video(s)
+          path: |
+            /home/runner/work/askdarcel-web/askdarcel-web/cypress/videos/
+            /home/runner/work/askdarcel-web/askdarcel-web/cypress/screenshots/
+          retention-days: 3
 
   publish-latest:
     runs-on: ubuntu-latest

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:8080",
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "requestTimeout": 10000
 }

--- a/cypress/integration/organization_page.e2e.ts
+++ b/cypress/integration/organization_page.e2e.ts
@@ -82,8 +82,13 @@ describe('Organization Page', () => {
           shouldInheritScheduleFromParent: false,
         },
       ];
+
+      // Intercept client's AJAX request to services endpoint and alias as "getServiceData". Pass
+      // the alias to #wait method below to delay test execution until the request has returned
+      cy.intercept('GET', `/api/resources/${orgId}`).as('getServiceData');
       cy.request<{ services: Service[] }>('POST', `/api/resources/${orgId}/services`, { services: newServices }).its('status').should('eq', 201);
-      cy.visit(page.url(orgId))
+      cy.reload(true)
+        .wait('@getServiceData').its('response.statusCode').should('eq', 200)
         .get(page.ORG_SERVICES_SECTION).should('contain.text', 'Services')
         .get(page.ORG_SERVICES_LIST).should('exist')
         .get(page.ORG_SERVICES_LIST_ITEM).should(items => {

--- a/cypress/integration/organization_page.e2e.ts
+++ b/cypress/integration/organization_page.e2e.ts
@@ -83,12 +83,12 @@ describe('Organization Page', () => {
         },
       ];
 
-      // Intercept client's AJAX request to services endpoint and alias as "getServiceData". Pass
+      // Intercept client's AJAX request to services endpoint and alias as "getResourceData". Pass
       // the alias to #wait method below to delay test execution until the request has returned
-      cy.intercept('GET', `/api/resources/${orgId}`).as('getServiceData');
+      cy.intercept('GET', `/api/resources/${orgId}`).as('getResourceData');
       cy.request<{ services: Service[] }>('POST', `/api/resources/${orgId}/services`, { services: newServices }).its('status').should('eq', 201);
       cy.reload(true)
-        .wait('@getServiceData').its('response.statusCode').should('eq', 200)
+        .wait('@getResourceData').its('response.statusCode').should('eq', 200)
         .get(page.ORG_SERVICES_SECTION).should('contain.text', 'Services')
         .get(page.ORG_SERVICES_LIST).should('exist')
         .get(page.ORG_SERVICES_LIST_ITEM).should(items => {


### PR DESCRIPTION
This adds an [intercept/wait](https://docs.cypress.io/api/commands/intercept) to some client side API requests during our e2e tests. The intercept/wait ensures that the request is returned before the subsequent tests execute. My hunch is that there was a race condition where sometimes the request would return prior to the test execution and sometimes after, causing the flakiness. 

I've also replaced some of the `cy.visit()` methods with `cy.reload(forceReload)` to ensure that an uncached copy of the page is loaded prior to the tests running. Lastly, I've added a step in the E2E job to upload a screenshot and video of the tests when they fail, per Richard's very good suggestion.

I've run the E2E job probably a couple dozen times and haven't gotten a failure for the main flakey test that we were seeing. However, there is another spec that has been failing occasionally on the organization page e2e tests—Cypress times out trying to find an element (see: https://github.com/ShelterTechSF/askdarcel-web/runs/4755264042?check_suite_focus=true). I added an intercept/wait there to make sure the resource API request returns first, but sometimes the wait times out too, because the request never occurs. I think this could actually be a problem with our code rather than the test; in the videos of this failed test, the API request is never actually logged. Thus it may not happen at all in rare circumstances. I'll look into this.

For now, I hope this PR makes the process a little more smooth for everyone. Suggestions/requests much appreciated, especially as I become re-familiarized with our conventions. Thanks!