### PR TITLE
Resource pathway tracking

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -70,8 +70,7 @@ export const App = () => {
     return history.listen(loc => {
       const page = loc.pathname + loc.search;
       ReactGA.set({ page });
-      ReactGA.pageview(loc.pathname);
-      window.scrollTo(0, 0); // TODO Is this necessary anymore?
+      ReactGA.pageview(page);
     });
   }, []);
 

--- a/app/components/listing/feedback/FeedbackForm.jsx
+++ b/app/components/listing/feedback/FeedbackForm.jsx
@@ -67,7 +67,7 @@ export const FeedbackForm = ({ service, resource, closeModal }) => {
       .then(() => {
         setIsSubmitted('submitted');
       })
-      .catch(err => console.log(err));
+      .catch(err => console.log(err)); // eslint-disable-line no-console
   };
 
   const isReviewRequired = (

--- a/app/init.tsx
+++ b/app/init.tsx
@@ -14,8 +14,10 @@ require('./styles/main.scss');
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({ dsn: `https://${config.SENTRY_PUBLIC_KEY}@sentry.io/${config.SENTRY_PROJECT_ID}` });
 } else {
+  /* eslint-disable no-console */
   (Sentry as any).captureException = (e: any) => console.error(e);
   (Sentry as any).captureMessage = (m: any) => console.error(m);
+  /* eslint-enable no-console */
 }
 
 const rootElement = document.getElementById('root')!;

--- a/app/pages/OrganizationEditPage.jsx
+++ b/app/pages/OrganizationEditPage.jsx
@@ -869,15 +869,15 @@ class OrganizationEditPage extends React.Component {
     dataService.post(requestString, { resources: [newResource] })
       .then(response => {
         if (response.ok) {
-          alert('Resource successfuly created. Thanks!');
+          alert('Resource successfuly created. Thanks!'); // eslint-disable-line no-alert
           response.json().then(res => history.push(`/organizations/${res.resources[0].resource.id}`));
         } else {
           Promise.reject(response);
         }
       })
       .catch(error => {
-        alert('Issue creating resource, please try again.');
-        console.log(error);
+        alert('Issue creating resource, please try again.'); // eslint-disable-line no-alert
+        console.log(error); // eslint-disable-line no-console
         setNotSubmitting();
       });
   }
@@ -962,7 +962,7 @@ class OrganizationEditPage extends React.Component {
         message: 'Successfully saved your changes.',
       });
     }).catch(err => {
-      console.log(err);
+      console.log(err); // eslint-disable-line no-console
       showPopUpMessage({
         type: 'error',
         message: 'Sorry! An error occurred.',
@@ -981,8 +981,8 @@ class OrganizationEditPage extends React.Component {
       confirmMessage = 'Are you sure you want to remove this service?';
       path = `/api/services/${id}`;
     }
-    // eslint-disable-next-line no-restricted-globals
-    if (confirm(confirmMessage) === true) {
+    // eslint-disable-next-line no-alert
+    if (window.confirm(confirmMessage) === true) {
       if (id < 0) {
         this.setState(({ deactivatedServiceIds }) => {
           const newDeactivatedServiceIds = new Set(deactivatedServiceIds);
@@ -992,7 +992,7 @@ class OrganizationEditPage extends React.Component {
       } else {
         dataService.APIDelete(path, { change_request: { status: '2' } })
           .then(() => {
-            alert('Successful! \n \nIf this was a mistake, please let someone from the ShelterTech team know.');
+            alert('Successful! \n \nIf this was a mistake, please let someone from the ShelterTech team know.'); // eslint-disable-line no-alert
             if (type === 'resource') {
               // Resource successfully deactivated. Redirect to home.
               history.push({ pathname: '/' });

--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
@@ -2,6 +2,7 @@ import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, useHistory } from 'react-router-dom';
 import qs from 'qs';
+import ReactGA from 'react-ga';
 
 import { useEligibilitiesForCategory, useSubcategoriesForCategory } from '../../hooks/APIHooks';
 
@@ -99,6 +100,15 @@ const InnerServiceDiscoveryForm = ({
               .map(c => c.name),
           },
         };
+
+        const categoriesRefinements = searchState?.refinementList?.categories?.join('; ') || 'NONE';
+        const eligibilitiesRefinements = searchState?.refinementList?.eligibilities?.join('; ') || 'NONE';
+        ReactGA.event({
+          category: 'Resource Inquiry',
+          action: 'Refined Resource Inquiry',
+          label: `${categorySlug} Inquiry | Category Refinements: ${categoriesRefinements} | Eligibility Refinements: ${eligibilitiesRefinements}`,
+        });
+
         const search = qs.stringify(searchState, { encodeValuesOnly: true });
         return (
           <Redirect

--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.jsx
@@ -101,8 +101,8 @@ const InnerServiceDiscoveryForm = ({
           },
         };
 
-        const categoriesRefinements = searchState?.refinementList?.categories?.join('; ') || 'NONE';
-        const eligibilitiesRefinements = searchState?.refinementList?.eligibilities?.join('; ') || 'NONE';
+        const categoriesRefinements = searchState.refinementList.categories.join('; ') || 'NONE';
+        const eligibilitiesRefinements = searchState.refinementList.eligibilities.join('; ') || 'NONE';
         ReactGA.event({
           category: 'Resource Inquiry',
           action: 'Refined Resource Inquiry',

--- a/app/utils/location.ts
+++ b/app/utils/location.ts
@@ -34,16 +34,16 @@ export const getLocationBrowser = () => new Promise<GeoCoordinates>((resolve, re
         resolve(coords);
       } else {
         const msg = `User location out of bounds: ${coords.lat},${coords.lng}`;
-        console.log(msg);
+        console.log(msg); // eslint-disable-line no-console
         reject(msg);
       }
     }, error => {
-      console.log(error);
+      console.log(error); // eslint-disable-line no-console
       reject(error);
     });
   } else {
     const msg = 'Geolocation is not supported by this browser.';
-    console.log(msg);
+    console.log(msg); // eslint-disable-line no-console
     reject(msg);
   }
 });
@@ -64,7 +64,7 @@ export const getLocationGoogle = () => new Promise<GeoCoordinates>((resolve, rej
         resolve(data.location);
       } else {
         const msg = 'User location out of bounds';
-        console.log(msg);
+        console.log(msg); // eslint-disable-line no-console
         reject(msg);
       }
     })


### PR DESCRIPTION
This PR adds a page's URL search query to page view tracking in Google Analytics. Ruochen asked for that here: https://docs.google.com/document/d/12IPTzG5y60StBQQdZ8_Jg9oR7N5pcom2Y3QQ85FTN3I/edit 

I also added a GA event to track when a user searches for a service with eligibility/category refinements per his request.

Finally, I added a second commit that disabled es-lint on our remaining console/alert statements to clean up our linting CI checks. Hopefully this is just a holdover until we devise a better solution. Perhaps we can add some kind of client side error tracking (maybe in GA itself?) rather than using console.log. If there's any logs we can just plain remove, let me know. I wasn't sure if we want to leave them for prod debugging or not.