### PR TITLE
Replace SearchBox widget inside the InstantSearch component so that A…

### DIFF
--- a/app/pages/SearchResultsPage/SearchResults.module.scss
+++ b/app/pages/SearchResultsPage/SearchResults.module.scss
@@ -1,5 +1,8 @@
 @use '~components/search/SearchAndServiceResultsPage.module.scss';
 
-.searchBox {
+.hiddenSearchBox {
+  // Hides the SearchBox component. Though we are not explicitly using it,
+  // the component needs to be present within the InstantSearch parent component
+  // for the query to be passed to the Algolia Instant Search internals.
   display: none;
 }

--- a/app/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/app/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import algoliasearch from 'algoliasearch/lite';
 import {
-  InstantSearch, Configure,
+  InstantSearch, Configure, SearchBox,
 } from 'react-instantsearch/dom';
 import qs, { ParsedQs } from 'qs';
 
@@ -102,6 +102,11 @@ const InnerSearchReslts = ({
             setExpandList={setExpandList}
           />
         </div>
+      </div>
+      <div className={styles.hiddenSearchBox}>
+        {/* The SearchBox component needs to be insde the InstantSearch component for the
+        search query term to be passed to InstantSearch internals but it can be hidden */}
+        <SearchBox />
       </div>
     </InstantSearch>
   </div>


### PR DESCRIPTION
…lgolia search accepts query parameter.

Discovered a bad bug where the query was not being passed to Algolia when searching via the search box in the nav. I had removed this component from the SearchPage originally, having thought it wasn't doing anything. My staging algolia index seems messed up for text searches in particular, so this went undiscovered for a while