### PR TITLE
Stop using legacy eligibility field.

### DIFF
--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -347,7 +347,6 @@ ProvidedService.propTypes = {
     categories: PropTypes.array,
     notes: PropTypes.array,
     schedule: PropTypes.object,
-    eligibility: PropTypes.bool,
     eligibilities: PropTypes.array,
     email: PropTypes.string,
     name: PropTypes.string,

--- a/app/components/listing/ServiceDetails.tsx
+++ b/app/components/listing/ServiceDetails.tsx
@@ -43,7 +43,6 @@ export const ServiceDetails = ({ service }: { service: Service }) => {
           <ul className="service--details">
             <ServiceContactDetails email={service.email} website={service.url} />
             <ServiceEligibility subject="How to apply" result={service.application_process} />
-            <ServiceEligibility subject="Eligibilities" result={service.eligibility} />
             <ServiceEligibility subject="Required documents" result={service.required_documents} />
             <ServiceEligibility subject="Fees" result={service.fee} />
             {service.notes.length ? <Notes notes={service.notes} /> : null }

--- a/app/models/Service.ts
+++ b/app/models/Service.ts
@@ -23,7 +23,6 @@ export interface Service {
   certified_at: string | null;
   certified: boolean;
   eligibilities: Eligibility[];
-  eligibility: string;
   email: string | null;
   featured: boolean | null;
   fee: string | null;


### PR DESCRIPTION
Eligibility used to be a text field on Service. It was later replaced
with a many-to-many relationship between Services and a dedicated
Eligibilities table, but a couple places in the askdarcel-web app still
read from the legacy field.

This removes the last instances of this older field.