### PR TITLE
2093 Fix broken resource/organization links on search results page.

### DIFF
--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -175,6 +175,15 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
   const url = hit.url || hit.website;
   const serviceId = hit.service_id;
   const resourceId = hit.resource_id;
+  const { type } = hit;
+
+  // Href structure varies depending on whether the hit is a resource or location
+  let basePath = 'organizations';
+  let entryId = hit.resource_id;
+  if (type === 'service') {
+    basePath = 'services';
+    entryId = hit.service_id;
+  }
 
   return (
     <div className={styles.searchResult}>
@@ -183,7 +192,7 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
       }
       <div className={styles.searchText}>
         <div className={styles.title}>
-          <Link to={`/services/${serviceId}`}>{`${index + 1}. ${hit.name}`}</Link>
+          <Link to={{ pathname: `/${basePath}/${entryId}` }}>{`${index + 1}. ${hit.name}`}</Link>
         </div>
         <div className={styles.serviceOf}>
           <Link to={`/organizations/${resourceId}`}>{hit.service_of}</Link>


### PR DESCRIPTION
This bug was introduced by my consolidation of the code for the search results and "service pathway results" pages. I missed that orgs can be returned by search queries as well.
https://app.shortcut.com/sheltertech/story/2093/cannot-open-organizations-found-by-top-level-search