### PR TITLE
Fix broken new organization page. Improve a few UI issues.

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -113,9 +113,13 @@ export const App = () => {
               <Route exact path="/about" component={AboutPage} />
               <Route exact path="/covid" component={CovidPage} />
               <Route exact path="/demo/listing" component={ListingDebugPage} />
+
+              {/* NB: /organizations/new must be listed before /organizations/:id or else the "/new" step
+                will be interpreted as an ID and will thus break the OrganizationEditPage */}
+              <Route exact path="/organizations/new" component={() => <OrganizationEditPage showPopUpMessage={setPopUpMessage} />} />
               <Route exact path="/organizations/:id" component={OrganizationListingPage} />
               <Route exact path="/organizations/:id/edit" component={() => <OrganizationEditPage showPopUpMessage={setPopUpMessage} />} />
-              <Route exact path="/organizations/new" component={() => <OrganizationEditPage showPopUpMessage={setPopUpMessage} />} />
+
               <Route exact path="/privacy-policy" component={PrivacyPolicyPage} />
               <Route exact path="/resource-guides" component={ResourceGuides} />
               <Route exact path="/resource-guides/:id" component={ResourceGuide} />

--- a/app/components/edit/EditAddress.module.scss
+++ b/app/components/edit/EditAddress.module.scss
@@ -1,4 +1,4 @@
-@import 'app/styles/utils/_colors.scss';
+@import 'app/styles/utils/_helpers.scss';
 
 // react-modal styles
 
@@ -21,6 +21,7 @@
   right: 0;
   top: 0;
   overflow: auto;
+  z-index: $z-index-edit-address-modal;
 }
 
 // Layout/container styles

--- a/app/components/edit/EditSchedule.jsx
+++ b/app/components/edit/EditSchedule.jsx
@@ -75,7 +75,7 @@ EditSchedule.propTypes = {
   shouldInheritFromParent: PropTypes.bool.isRequired,
   setShouldInheritFromParent: PropTypes.func,
   handleScheduleChange: PropTypes.func.isRequired,
-  scheduleId: PropTypes.number.isRequired,
+  scheduleId: PropTypes.number,
 };
 
 EditSchedule.defaultProps = {

--- a/app/components/edit/EditSidebar.module.scss
+++ b/app/components/edit/EditSidebar.module.scss
@@ -155,4 +155,9 @@
       color: $color-white;
     }
   }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }

--- a/app/styles/utils/_layoututils.scss
+++ b/app/styles/utils/_layoututils.scss
@@ -20,6 +20,7 @@ $header-height: 70px;
 $header-mobile-height: 50px;
 
 // Z-Index values
+$z-index-edit-address-modal: 1;
 $z-index-site-nav: 3;
 $z-index-filters-menu: 4;
 


### PR DESCRIPTION
I'm not sure if we should fix it this way or perhaps change the `organizations/new` path altogether so it won't be matched by the `organization/:id` path?

I also fixed an issue where the buttons overlay the address modal on smaller screens, and I added disabled styling to the submit button since creating an org can take some time and lead to a confusing experience for the user.

button overlay bug:
<img width="632" alt="Screen Shot 2022-06-06 at 6 06 47 PM" src="https://user-images.githubusercontent.com/3012520/172275836-cbb694fc-1456-4adf-b7a2-4cb5ddc0934d.png">

