### PR TITLE
Hide Add Organization button per request from content team.

### DIFF
--- a/app/components/search/Pagination/ResultsPagination.module.scss
+++ b/app/components/search/Pagination/ResultsPagination.module.scss
@@ -56,29 +56,3 @@
     height: 16px;
   }
 }
-
-.addResource {
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-items: center;
-  margin: 20px 0 30px;
-  font-size: 0.87rem;
-  @media screen and (max-width: $break-tablet-s) {
-    margin: 20px 0 30px;
-  }
-}
-
-.addResourceButton {
-  display: block;
-  padding: 11px 14px;
-  border: 1px solid rgba(0,0,0,0.2);
-  border-radius: 3px;
-  color: #666;
-  margin-top: 15px;
-  &:hover, &:active {
-    border: 1px solid #276ce5;
-    color: #276ce5;
-  }
-}

--- a/app/components/search/Pagination/ResultsPagination.tsx
+++ b/app/components/search/Pagination/ResultsPagination.tsx
@@ -25,14 +25,6 @@ const ResultsPagination = ({ noResults }: {noResults: boolean}) => (
         <img src={algolia} alt="Search by Algolia" />
       </div>
     </div>
-    <div className={styles.addResource}>
-      Can&apos;t find the organization you&apos;re looking for?
-      <Link to="/organizations/new" className={styles.addResourceButton}>
-        <i className="material-icons">add_circle</i>
-        {' '}
-        Add an organization
-      </Link>
-    </div>
   </div>
 );
 

--- a/app/components/search/Pagination/ResultsPagination.tsx
+++ b/app/components/search/Pagination/ResultsPagination.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Pagination } from 'react-instantsearch/dom';
-import { Link } from 'react-router-dom';
 import whiteLabel from 'utils/whitelabel';
 
 import styles from './ResultsPagination.module.scss';


### PR DESCRIPTION
Hides "Add Org" button per Amanda's request. Fortunately it only exists in one component.
<img width="398" alt="image" src="https://user-images.githubusercontent.com/3012520/172749914-b1871d9d-b293-4047-bd26-bc29db56696a.png">
<img width="1511" alt="Screen Shot 2022-06-08 at 7 08 53 PM" src="https://user-images.githubusercontent.com/3012520/172749966-5ec35923-7afb-44ba-b273-87fc0a961ccb.png">

