### PR TITLE
Service discovery form typescript

### DIFF
--- a/app/pages/ServiceDiscoveryForm/constants.ts
+++ b/app/pages/ServiceDiscoveryForm/constants.ts
@@ -1,4 +1,4 @@
-type Step = 'eligibilities' | 'subcategories' | 'results';
+export type Step = 'eligibilities' | 'subcategories' | 'results';
 
 export interface ServiceCategory {
   algoliaCategoryName: string;


### PR DESCRIPTION
We are adding a Long Term Housing tile which will have several steps on the form page, rather than the standard single step that other tiles have. (The single step for our other tiles is the client eligibilities checkboxes; the LTH will have 2-3 of these steps/checkbox groups). 

Before starting the LTH work, I wanted to convert the form page to typescript to make any changes to this file safer and easier. I'm branching off of this branch to do my LTH work