### PR TITLE
Wire up PDF handouts and Clinician Actions modal to display and expec…

### DIFF
--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -277,7 +277,7 @@ const ProvidedService = ({
           <FormTextArea
             label="Clinician Actions (Include any COVID Actions)"
             placeholder="Add a list of actions to be taken by clinician and/or client prior to providing service referral"
-            value={(service.instructions[0] && service.instructions[0].instruction) || ''}
+            value={(service.instructions[0] && service.instructions[0].instruction) ?? ''}
             setValue={value => handleChange('instructions', [{ instruction: value }])}
           />
         </li>
@@ -354,6 +354,7 @@ ProvidedService.propTypes = {
     schedule: PropTypes.object,
     eligibilities: PropTypes.array,
     email: PropTypes.string,
+    instructions: PropTypes.array,
     name: PropTypes.string,
     required_documents: PropTypes.string,
     application_process: PropTypes.string,

--- a/app/components/edit/ProvidedService.jsx
+++ b/app/components/edit/ProvidedService.jsx
@@ -277,7 +277,7 @@ const ProvidedService = ({
           <FormTextArea
             label="Clinician Actions (Include any COVID Actions)"
             placeholder="Add a list of actions to be taken by clinician and/or client prior to providing service referral"
-            value={(service.instructions[0] && service.instructions[0].instruction) ?? ''}
+            value={service?.instructions?.[0]?.instruction ?? ''}
             setValue={value => handleChange('instructions', [{ instruction: value }])}
           />
         </li>

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -100,7 +100,7 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
   const clinicianActionsLink = (
     <div className={styles.sideLink} role="button" tabIndex={0} onClick={toggleClinicianActionsModal}>
       <img src={icon('clinician-action')} alt="clinician action" className={styles.sideLinkIcon} />
-      <div className={styles.sideLinkText}>Clinician action</div>
+      <div className={styles.sideLinkText}>Clinician actions</div>
     </div>
   );
 
@@ -152,26 +152,18 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
     entryId = serviceId;
   }
 
-  // Todo: mock data until API returns handouts on the service model
-  const handoutCollection = [
-    { id: '1', description: 'English', link: 'https://ucsf.app.box.com/s/233qfwg6eilw1i1tipo9ts2jnh3mqz00' },
-    { id: '2', description: 'Cantonese', link: 'https://ucsf.app.box.com/s/233qfwg6eilw1i1tipo9ts2jnh3mqz00' },
-    { id: '3', description: 'Mandarin', link: 'https://ucsf.app.box.com/s/233qfwg6eilw1i1tipo9ts2jnh3mqz00' },
-    { id: '4', description: 'Filipino', link: 'https://ucsf.app.box.com/s/233qfwg6eilw1i1tipo9ts2jnh3mqz00' },
-    { id: '5', description: 'Spanish', link: 'https://ucsf.app.box.com/s/233qfwg6eilw1i1tipo9ts2jnh3mqz00' },
-  ];
-
   return (
     <div className={styles.searchResult}>
       <Texting closeModal={toggleTextingModal} service={service} isShowing={textingIsOpen} />
       <ClinicianActions
         isOpen={clinicianActionsIsOpen}
         setIsOpen={toggleClinicianActionsModal}
+        actions={(hit.instructions && hit.instructions[0]) || []}
       />
       <ClientHandouts
         isOpen={handoutModalIsOpen}
         setIsOpen={toggleHandoutModal}
-        handoutCollection={handoutCollection}
+        handoutCollection={hit.documents || []}
       />
       <div className={styles.searchText}>
         <div className={styles.title}>

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -158,7 +158,7 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
       <ClinicianActions
         isOpen={clinicianActionsIsOpen}
         setIsOpen={toggleClinicianActionsModal}
-        actions={(hit.instructions && hit.instructions[0]) ?? []}
+        actions={(hit?.instructions?.[0]) ?? ''}
       />
       <ClientHandouts
         isOpen={handoutModalIsOpen}
@@ -196,8 +196,8 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
           )
         }
         { texting }
-        { whiteLabel.showClinicianAction && clinicianActionsLink }
-        { whiteLabel.showHandoutsIcon && handoutsLink }
+        { (whiteLabel.showClinicianAction && !!hit.documents?.length) && clinicianActionsLink }
+        { (whiteLabel.showHandoutsIcon && !!hit.instructions?.length) && handoutsLink }
       </div>
     </div>
   );

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -107,7 +107,7 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
   const handoutsLink = (
     <div className={styles.sideLink} role="button" tabIndex={0} onClick={toggleHandoutModal}>
       <img src={icon('print-blue')} alt="printout icon" className={styles.sideLinkIcon} />
-      <div className={styles.sideLinkText}>Client handouts</div>
+      <div className={styles.sideLinkText}>Print</div>
     </div>
   );
 
@@ -158,12 +158,12 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
       <ClinicianActions
         isOpen={clinicianActionsIsOpen}
         setIsOpen={toggleClinicianActionsModal}
-        actions={(hit.instructions && hit.instructions[0]) || []}
+        actions={(hit.instructions && hit.instructions[0]) ?? []}
       />
       <ClientHandouts
         isOpen={handoutModalIsOpen}
         setIsOpen={toggleHandoutModal}
-        handoutCollection={hit.documents || []}
+        handoutCollection={hit.documents ?? []}
       />
       <div className={styles.searchText}>
         <div className={styles.title}>

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -176,7 +176,6 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
         <ReactMarkdown className={`rendered-markdown ${styles.description}`} source={hit.long_description} linkTarget="_blank" />
       </div>
       <div className={styles.sideLinks}>
-        { whiteLabel.showHandoutsIcon && handoutsLink }
         {
           phoneNumber
           && (
@@ -198,6 +197,7 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
         }
         { texting }
         { whiteLabel.showClinicianAction && clinicianActionsLink }
+        { whiteLabel.showHandoutsIcon && handoutsLink }
       </div>
     </div>
   );

--- a/app/components/ucsf/ClinicianActions/ClinicianActions.module.scss
+++ b/app/components/ucsf/ClinicianActions/ClinicianActions.module.scss
@@ -11,10 +11,9 @@
   color: #000;
 }
 
-.actionLists {
+.modalContent {
   display: grid;
-  gap: 16px;
-  padding: 32px 0 40px;
+  gap: 32px;
 }
 
 .actionListContainer {

--- a/app/components/ucsf/ClinicianActions/ClinicianActions.module.scss
+++ b/app/components/ucsf/ClinicianActions/ClinicianActions.module.scss
@@ -16,7 +16,7 @@
   gap: 32px;
 }
 
-.actionListContainer {
+.actionContainer {
   padding: 16px;
   font-size: 20px;
   box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);

--- a/app/components/ucsf/ClinicianActions/ClinicianActions.tsx
+++ b/app/components/ucsf/ClinicianActions/ClinicianActions.tsx
@@ -1,47 +1,29 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 
 import { Modal } from 'components/ui/Modal/Modal';
 import { Button } from 'components/ui/inline/Button/Button';
 
 import styles from './ClinicianActions.module.scss';
 
-interface ActionItem {
-  action: string;
-  id: string;
-}
-
-// TODO: mock data until we get data back from the service
-const serviceActions = [
-  { id: '1', action: 'Ask the patient to self-refer' },
-  { id: '2', action: 'Call the intake office before sending patient over' },
-  { id: '3', action: 'Tell patient to self-refer at the admissions depot' },
-];
-
-const serviceCovidActions = [
-  { id: '1', action: 'Patient must undergo a covid test to eat dinner' },
-  { id: '2', action: 'Ensure patient is vaccinated' },
-];
-// TODO: end mock data
-
 const ActionList = ({
   header, actions,
 }: {
-  header: string;
-  actions: ActionItem[];
+  header?: string;
+  actions: string;
 }) => (
   <div className={styles.actionListContainer}>
     <p className={styles.actionType}>{header}</p>
-    <ul className={styles.actionList}>
-      {actions.map(actionItem => (<li key={actionItem.id}>{actionItem.action}</li>))}
-    </ul>
+    <ReactMarkdown className="rendered-markdown" source={actions} />
   </div>
 );
 
 export const ClinicianActions = ({
-  isOpen, setIsOpen,
+  isOpen, setIsOpen, actions,
 }: {
   isOpen: boolean;
   setIsOpen: (val: boolean) => void;
+  actions: string;
 }) => {
   const closeModal = () => {
     setIsOpen(false);
@@ -55,9 +37,8 @@ export const ClinicianActions = ({
     >
       <div className={styles.modalContent}>
         <h2 className={styles.title}>Actions</h2>
-        <div className={styles.actionLists}>
-          <ActionList header="Clinician Actions" actions={serviceActions} />
-          <ActionList header="COVID-19 Actions" actions={serviceCovidActions} />
+        <div className={styles.actionListContainer}>
+          <ReactMarkdown className="rendered-markdown" source={actions} />
         </div>
         <div className={styles.buttonBar}>
           <Button onClick={closeModal} addClass={styles.closeBtn} tabIndex={0}>

--- a/app/components/ucsf/ClinicianActions/ClinicianActions.tsx
+++ b/app/components/ucsf/ClinicianActions/ClinicianActions.tsx
@@ -6,18 +6,6 @@ import { Button } from 'components/ui/inline/Button/Button';
 
 import styles from './ClinicianActions.module.scss';
 
-const ActionList = ({
-  header, actions,
-}: {
-  header?: string;
-  actions: string;
-}) => (
-  <div className={styles.actionListContainer}>
-    <p className={styles.actionType}>{header}</p>
-    <ReactMarkdown className="rendered-markdown" source={actions} />
-  </div>
-);
-
 export const ClinicianActions = ({
   isOpen, setIsOpen, actions,
 }: {
@@ -37,7 +25,7 @@ export const ClinicianActions = ({
     >
       <div className={styles.modalContent}>
         <h2 className={styles.title}>Actions</h2>
-        <div className={styles.actionListContainer}>
+        <div className={styles.actionContainer}>
           <ReactMarkdown className="rendered-markdown" source={actions} />
         </div>
         <div className={styles.buttonBar}>

--- a/app/components/ui/ClientHandoutsModal/ClientHandouts.tsx
+++ b/app/components/ui/ClientHandoutsModal/ClientHandouts.tsx
@@ -25,7 +25,7 @@ export const ClientHandouts = ({
       closeModal={closeModal}
     >
       <div className={styles.modalContent}>
-        <h2 className={styles.title}>Handouts</h2>
+        <h2 className={styles.title}>Print</h2>
         {handoutCollection.map(handout => (
           <a href={handout.url} target="_blank" rel="noreferrer" className={styles.handoutLink} key={handout.id}>
             <img src={icon('pdf-red')} alt="PDF icon" className={styles.sideLinkIcon} />

--- a/app/components/ui/ClientHandoutsModal/ClientHandouts.tsx
+++ b/app/components/ui/ClientHandoutsModal/ClientHandouts.tsx
@@ -25,9 +25,9 @@ export const ClientHandouts = ({
       closeModal={closeModal}
     >
       <div className={styles.modalContent}>
-        <h2 className={styles.title}>Print Handout</h2>
+        <h2 className={styles.title}>Handouts</h2>
         {handoutCollection.map(handout => (
-          <a href={handout.link} target="_blank" rel="noreferrer" className={styles.handoutLink} key={handout.id}>
+          <a href={handout.url} target="_blank" rel="noreferrer" className={styles.handoutLink} key={handout.id}>
             <img src={icon('pdf-red')} alt="PDF icon" className={styles.sideLinkIcon} />
             <span>
               {handout.description}


### PR DESCRIPTION
…t the correct data types and props coming from API.

To test these, I worked off of a copy of the Staging DB. In the rails console, I edited a specific service's `instructions` and `documents` props (both of the documents routing to google.com as you can see :)). I also had to make a change to the API repo, adding those props to the Algolia index logic in the `service.rb` file and manually triggering a reindex on my Algolia index.  See PR [here](https://github.com/ShelterTechSF/askdarcel-api/pull/646/files)

It was somewhat cumbersome to add markup in the rails console. I used this: `"**Clinician Actions (test)**\n - Go to the clinic\n - Self Register\n\n **Covid Actions (test)**\n - Show vaccination status\n - Take test\n"
=> "**Clinician Actions (test)**\n - Go to the clinic\n - Self Register\n\n **Covid Actions (test)**\n - Show vaccination status\n - Take test\n"`

<img width="1119" alt="Screen Shot 2022-09-22 at 11 45 42 AM" src="https://user-images.githubusercontent.com/3012520/191861203-82a40d2e-4775-406f-9dbe-0c9abce8f3f5.png">

<img width="1114" alt="Screen Shot 2022-09-22 at 1 10 17 PM" src="https://user-images.githubusercontent.com/3012520/191861199-5134351c-fb7e-4945-beac-eb01973b6904.png">



