### PR TITLE
1157 translation widget

### DIFF
--- a/app/components/listing/MapOfLocations.tsx
+++ b/app/components/listing/MapOfLocations.tsx
@@ -47,7 +47,7 @@ export const MapOfLocations = ({ locationRenderer, locations }: {
                             {i + 1}
                             .
                           </td>
-                          <td><strong>{loc.address.address_1}</strong></td>
+                          <td><strong translate="no">{loc.address.address_1}</strong></td>
                           <td className="iconcell">
                             <div className="selector">
                               <i className="material-icons">keyboard_arrow_down</i>

--- a/app/components/listing/OrganizationDetails.tsx
+++ b/app/components/listing/OrganizationDetails.tsx
@@ -57,7 +57,7 @@ const buildLocation = (address: Address) => {
 };
 
 export const AddressInfoRenderer = ({ address }: { address: Address }) => (
-  <span className="address">
+  <span className="address" translate="no">
     {buildLocation(address)}
   </span>
 );

--- a/app/components/listing/ServiceDetails.tsx
+++ b/app/components/listing/ServiceDetails.tsx
@@ -17,7 +17,7 @@ export const ServiceDetails = ({ service }: { service: Service }) => {
         <p>updated {service.updated_at}</p>
       </div> */}
       <h2 className="service--header">
-        <a href={`/services/${service.id}`}>
+        <a href={`/services/${service.id}`} translate="no">
           {service.name}
         </a>
       </h2>

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -167,12 +167,12 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
       />
       <div className={styles.searchText}>
         <div className={styles.title}>
-          <Link to={{ pathname: `/${basePath}/${entryId}` }}>{`${index + 1}. ${hit.name}`}</Link>
+          <Link to={{ pathname: `/${basePath}/${entryId}` }} translate="no">{`${index + 1}. ${hit.name}`}</Link>
         </div>
         <div className={styles.serviceOf}>
-          <Link to={`/organizations/${resourceId}`}>{hit.service_of}</Link>
+          <Link to={`/organizations/${resourceId}`} translate="no">{hit.service_of}</Link>
         </div>
-        <div className={styles.address}>{renderAddressMetadata(hit)}</div>
+        <div className={styles.address} translate="no">{renderAddressMetadata(hit)}</div>
         <ReactMarkdown className={`rendered-markdown ${styles.description}`} source={hit.long_description} linkTarget="_blank" />
       </div>
       <div className={styles.sideLinks}>

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -138,6 +138,9 @@
 .sideLinks {
   flex-shrink: 0;
   width: auto;
+  @media screen and (min-width: $min-tablet-p) {
+    max-width: 325px;
+  }
   margin-left: 25px;
   font-weight: bold;
   font-size: 18px;

--- a/app/components/search/SearchResults/SearchResults.module.scss
+++ b/app/components/search/SearchResults/SearchResults.module.scss
@@ -51,24 +51,23 @@
 }
 
 .searchResult {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: space-between;
-  padding-top: 21px;
-  padding-bottom: 24px;
-  padding-left: 24px;
+  display: grid;
+  grid-template-columns: 7fr 3fr;
+  gap: 25px;
+  justify-items: end;
+  padding: 21px 0 24px 24px;
   border-left: 1px solid $color-grey3;
   border-bottom: 1px solid $color-grey3;
 
   @media screen and (max-width: $break-desktop) {
-    flex-direction: column;
+    gap: 32px;
+    grid-template-columns: none;
+    justify-items: start;
   }
 
   @media screen and (max-width: $break-tablet-l) {
     padding-left: 30px;
   }
-
 
   @media screen and (max-width: 600px) {
     padding: 18px 20px;
@@ -84,15 +83,6 @@
     border-bottom: 1px solid $color-grey3;
     padding: 24px 0;
   }
-
-  // Todo: Look into replacing this with :last-child
-  // &_addressLast {
-  //   padding-top: 24px;
-  // }
-}
-
-.searchText {
-  flex-grow: 2;
 }
 
 .title {
@@ -115,7 +105,7 @@
 
 .description {
   font-size: 18px;
-  margin: 32px 0;
+  padding-top: 32px;
   a {
     word-break: break-word;
   }
@@ -136,26 +126,11 @@
 }
 
 .sideLinks {
-  flex-shrink: 0;
-  width: auto;
-  @media screen and (min-width: $min-tablet-p) {
-    max-width: 325px;
-  }
-  margin-left: 25px;
   font-weight: bold;
   font-size: 18px;
   color: $color-brand;
 
-  @media screen and (max-width: $break-desktop) {
-    flex-direction: column;
-    margin-left: 0;
-    margin-right: 0;
-    width: inherit;
-  }
-
   @media screen and (max-width: 600px) {
-    padding-top: 16px;
-    margin-top: 0;
     font-size: 16px;
   }
 }
@@ -172,7 +147,7 @@
 }
 
 .sideLinkText {
-  padding: 0 8px;
+  padding-left: 8px;
   overflow: auto;
 }
 

--- a/app/components/ui/Translate.tsx
+++ b/app/components/ui/Translate.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
-
-// This is a prototype component for testing out the Google Translate widget. The logic below
-// dictates that this component only be displayed on staging; i.e. the widget will be displayed IF
-// location.hostname === 'staging.sfserviceguide.org'.
-//
-// Note: At least while testing, this is a <li> element as it goes within the
-// nav <ul> site links element.
+import { whiteLabel } from '../../utils';
 
 const Translate = () => {
-  const isStaging = window.location.hostname === 'staging.sfserviceguide.org';
-  if (isStaging) {
+  if (whiteLabel.enableTranslation) {
     return (
-      <li className="googleTranslateContainer">
-        {/* todo: When we go live with Google Translate the scripts within this Helmet snippet
-         /* maybe should be moved to index.html, depending on specific whitelabel needs too  */}
+      <li>
         <Helmet>
           <script type="text/javascript">
             {`

--- a/app/pages/OrganizationListingPage.tsx
+++ b/app/pages/OrganizationListingPage.tsx
@@ -72,7 +72,7 @@ export const OrganizationListingPage = () => {
           <div className="org--main--left">
             <header className="org--main--header">
               <div className="org--main--header--title-container">
-                <h1 data-cy="org-page-title" className="org--main--header--title">{org.name}</h1>
+                <h1 data-cy="org-page-title" className="org--main--header--title" translate="no">{org.name}</h1>
                 <MOHCDBadge resource={org} />
               </div>
               <div className="org--main--header--hours">

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -51,27 +51,43 @@ function determineWhiteLabelSite(): WhiteLabelSiteKey {
 
 const configKey = determineWhiteLabelSite();
 
+const whiteLabelDefaults = {
+  homePageComponent: 'HomePage',
+  intercom: false,
+  logoLinkDestination: '/',
+  navLogoStyle: styles.siteNav,
+  showBanner: true,
+  showClinicianAction: false,
+  showHandoutsIcon: false,
+  showHeaderQrCode: false,
+  showMobileNav: true,
+  showSearch: true,
+  siteNavStyle: styles.siteNav,
+  userWay: false,
+} as const;
+
+const appImageDefaults = {
+  background: BackgroundImage,
+  algolia: SearchByAlgoliaImage,
+  mohcdSeal: SFSeal,
+} as const;
+
 /*
   Specify what is viewed in each white label.
   A '/' (which is a forward-slash) as a value for logoLinkDestination
   denotes that the link is internal to the application.
 */
+
 const SFFamilies: WhiteLabelSite = {
   appImages: {
-    background: BackgroundImage,
+    ...appImageDefaults,
     logoLarge: SFFamiliesLogo,
     logoSmall: SFFamiliesLogo,
-    algolia: SearchByAlgoliaImage,
-    mohcdSeal: SFSeal,
   },
-  homePageComponent: 'HomePage',
-  intercom: false,
+  ...whiteLabelDefaults,
   logoLinkDestination: 'https://www.sffamilies.org/',
   navLogoStyle: styles.navLogoSFFamilies,
   showBanner: false,
-  showClinicianAction: false,
-  showHandoutsIcon: false,
-  showHeaderQrCode: false,
   showMobileNav: false,
   showSearch: false,
   siteNavStyle: styles.siteNavSFFamilies,
@@ -82,98 +98,53 @@ const SFFamilies: WhiteLabelSite = {
 
 const SFServiceGuide: WhiteLabelSite = {
   appImages: {
-    background: BackgroundImage,
+    ...appImageDefaults,
     logoLarge: SFServiceLogo,
     logoSmall: SFServiceLogo,
-    algolia: SearchByAlgoliaImage,
-    mohcdSeal: SFSeal,
   },
-  homePageComponent: 'HomePage',
+  ...whiteLabelDefaults,
   intercom: true,
-  logoLinkDestination: '/',
-  navLogoStyle: styles.siteNav,
-  showBanner: true,
-  showClinicianAction: false,
-  showHandoutsIcon: false,
-  showHeaderQrCode: false,
-  showMobileNav: true,
-  showSearch: true,
-  siteNavStyle: styles.siteNav,
   siteUrl: 'https://sfserviceguide.org',
   title: 'SF Service Guide',
-  userWay: false,
 } as const;
 
 const LinkSF: WhiteLabelSite = {
   appImages: {
-    background: BackgroundImage,
+    ...appImageDefaults,
     logoLarge: LinkSFLogo,
     logoSmall: LinkSFLogo,
-    algolia: SearchByAlgoliaImage,
-    mohcdSeal: SFSeal,
   },
-  homePageComponent: 'HomePage',
-  intercom: false,
-  logoLinkDestination: '/',
-  navLogoStyle: styles.siteNav,
-  showBanner: true,
-  showClinicianAction: false,
-  showHandoutsIcon: false,
-  showHeaderQrCode: false,
-  showMobileNav: true,
-  showSearch: true,
-  siteNavStyle: styles.siteNav,
+  ...whiteLabelDefaults,
   siteUrl: 'https://linksf.sfserviceguide.org',
   title: 'Link SF',
-  userWay: false,
 } as const;
 
 const defaultWhiteLabel: WhiteLabelSite = {
   appImages: {
-    background: BackgroundImage,
+    ...appImageDefaults,
     logoLarge: SFServiceLogo,
     logoSmall: SFServiceLogo,
-    algolia: SearchByAlgoliaImage,
-    mohcdSeal: SFSeal,
   },
-  homePageComponent: 'HomePage',
+  ...whiteLabelDefaults,
   intercom: true,
-  logoLinkDestination: '/',
-  navLogoStyle: styles.siteNav,
-  showBanner: true,
-  showClinicianAction: false,
-  showHandoutsIcon: false,
-  showHeaderQrCode: false,
-  showMobileNav: true,
-  showSearch: true,
-  siteNavStyle: styles.siteNav,
   siteUrl: 'https://askdarcel.org',
   title: 'AskDarcel',
-  userWay: false,
 } as const;
 
 const Ucsf: WhiteLabelSite = {
   appImages: {
-    background: BackgroundImage,
+    ...appImageDefaults,
     logoLarge: UcsfServiceLogo,
     logoSmall: UcsfServiceLogo,
-    algolia: SearchByAlgoliaImage,
-    mohcdSeal: SFSeal,
   },
+  ...whiteLabelDefaults,
   homePageComponent: 'UcsfHomePage',
-  intercom: false,
-  logoLinkDestination: '/',
-  navLogoStyle: styles.siteNav,
   showBanner: false,
   showClinicianAction: true,
   showHandoutsIcon: true,
   showHeaderQrCode: true,
-  showMobileNav: true,
-  showSearch: true,
-  siteNavStyle: styles.siteNav,
   siteUrl: 'https://ucsf.sfserviceguide.org', // todo: get the desired siteUrl from UCSF
   title: 'UCSF Outpatient Services',
-  userWay: false,
 } as const;
 
 /*

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -20,6 +20,7 @@ interface WhiteLabelSite {
     algolia: string;
     mohcdSeal: string;
   };
+  enableTranslation: boolean;
   homePageComponent: homepageComponentEnums;
   intercom: boolean;
   logoLinkDestination: string;
@@ -52,6 +53,7 @@ function determineWhiteLabelSite(): WhiteLabelSiteKey {
 const configKey = determineWhiteLabelSite();
 
 const whiteLabelDefaults = {
+  enableTranslation: true,
   homePageComponent: 'HomePage',
   intercom: false,
   logoLinkDestination: '/',
@@ -85,6 +87,7 @@ const SFFamilies: WhiteLabelSite = {
     logoSmall: SFFamiliesLogo,
   },
   ...whiteLabelDefaults,
+  enableTranslation: false,
   logoLinkDestination: 'https://www.sffamilies.org/',
   navLogoStyle: styles.navLogoSFFamilies,
   showBanner: false,
@@ -138,6 +141,7 @@ const Ucsf: WhiteLabelSite = {
     logoSmall: UcsfServiceLogo,
   },
   ...whiteLabelDefaults,
+  enableTranslation: false,
   homePageComponent: 'UcsfHomePage',
   showBanner: false,
   showClinicianAction: true,


### PR DESCRIPTION
Adds logic to the white label sites to enable/disable the Google Translate widget. Also adds translate=no attributes to HTML elements where we do not want translation to occur (addresses, org names, etc). Lastly, this adds a whiteLabelDefaults object with default props that are merged into all of our white label site objects.

Also this changes how layout is handled for services on the search result page – it replaces Flex with Grid

The first screenshot shows comparison between my local dev and Staging to demonstrate that mobile layout is the same after changing to grid. The second screenshot is of my local environment using grid on a standard desktop screen size.

<img width="1013" alt="Screen Shot 2022-10-04 at 11 23 46 AM" src="https://user-images.githubusercontent.com/3012520/193901839-77d55525-80b2-40d0-b768-6b2f5d473dd2.png">

<img width="1512" alt="Screen Shot 2022-10-04 at 11 48 02 AM" src="https://user-images.githubusercontent.com/3012520/193901920-526d891d-4892-44c9-812d-3abfdf5b30e1.png">



