### PR TITLE
Fix side bar refinement bug where the refinement checkboxes were not …

### DIFF
--- a/app/components/search/Refinements/RefinementListFilter.jsx
+++ b/app/components/search/Refinements/RefinementListFilter.jsx
@@ -12,8 +12,7 @@ const RefinementListFilter = ({ items, refine }) => (
           className={styles.refinementInput}
           type="checkbox"
           checked={item.isRefined}
-          onChange={e => {
-            e.preventDefault();
+          onChange={() => {
             refine(item.value);
           }}
         />


### PR DESCRIPTION
…reflecting the state of the value represented. 

This bug has been driving me crazy - where the checkbox UI does not update to reflect the state of its data/or it only partially updates. It requires two clicks to update the checked UI one way or the other and there seems to be partial data updates on each click despite there not being any UI change.

UCSF will be reviewing our beta soon, and I imagine they might comment on this behavior. 

A part of me is skeptical that it was so easy to fix by removing `e.preventDefault` (like was that there for some other reason of which I'm unaware?), but it does seem to fix the problem and to not introduce any other issues.

See videos of the before and after:
Broken:
https://user-images.githubusercontent.com/3012520/197306474-98d5264b-3449-4a06-88af-71a6cbcd9911.mov

Fixed:
https://user-images.githubusercontent.com/3012520/197306569-558aec02-6c88-4005-b503-bf412c65ae6b.mov

