### PR TITLE
Swap see all logic in UCSF eligibility and subcategory pages - if see…

### DIFF
--- a/app/pages/UcsfClientEligibilityPage/UcsfClientEligibilityPage.tsx
+++ b/app/pages/UcsfClientEligibilityPage/UcsfClientEligibilityPage.tsx
@@ -37,41 +37,25 @@ const ClientEligibilities = ({
     eligibility: Eligibility,
     eligibilities: Eligibility[],
   ) => {
-    const seeAllEligibilityItem = eligibilities.find(e => e.isSeeAll);
+    const seeAllEligibilityItem = eligibilities.find(e => e.isSeeAll)!;
     const newValue = !selectedEligibilities[eligibility.checkedId];
+    const updatedEligibilities = { ...selectedEligibilities, [eligibility.checkedId]: newValue };
 
-    if (eligibility.isSeeAll) {
-      // Check or uncheck all boxes in accordance with "See All" checked value
-      massToggleGroupEligibilities(eligibilities, newValue);
-    } else {
-      const updatedEligibilities = {
-        ...selectedEligibilities,
-        [eligibility.checkedId]: newValue,
-      };
-
-      // If new checked value is false, uncheck "See All" box as well
-      if (!newValue && seeAllEligibilityItem) {
+    if (newValue) {
+      if (eligibility.isSeeAll) {
+        // If "See All" is target refinement, deselect all other eligibilities. This is done because
+        // showing all services requires that we do not include any refinements in our query
+        eligibilities.forEach(el => {
+          updatedEligibilities[el.checkedId] = false;
+        });
+      } else {
+        // If new refinement will be checked, uncheck "See All" box since now the query will include
+        // refinements
         updatedEligibilities[seeAllEligibilityItem.checkedId] = false;
       }
-
-      setSelectedEligibilities(updatedEligibilities);
     }
-  };
 
-  // Toggles all eligibilities in accordance with the toggleState argument
-  const massToggleGroupEligibilities = (
-    eligibilities: Eligibility[],
-    toggleState: boolean,
-  ) => {
-    const updatedEligibilities = {
-      ...selectedEligibilities,
-    };
-
-    eligibilities.forEach(eligibility => {
-      updatedEligibilities[eligibility.checkedId] = toggleState;
-    });
-
-    setSelectedEligibilities(updatedEligibilities);
+    setSelectedEligibilities({ ...updatedEligibilities, [eligibility.checkedId]: newValue });
   };
 
   return (

--- a/app/pages/UcsfServiceTypePage/UcsfServiceTypePage.tsx
+++ b/app/pages/UcsfServiceTypePage/UcsfServiceTypePage.tsx
@@ -32,31 +32,23 @@ const ServiceTypes = ({ subcategories, selectedSubcategories, setSelectedSubcate
   const handleSubcategoryClick = (targetSubcategoryId: number) => {
     const seeAllIsTargetElement = targetSubcategoryId === seeAllPseudoId;
     const newValue = !selectedSubcategories[targetSubcategoryId];
-    if (seeAllIsTargetElement) {
-      // Check or uncheck all boxes in accordance with "See All" checked value
-      massUpdateSelectedSubcategories(newValue);
-    } else {
-      const updatedSubcategories = {
-        ...selectedSubcategories,
-        [targetSubcategoryId]: newValue,
-      };
+    const updatedSubcategories = { ...selectedSubcategories };
 
-      // If new checked value is false, uncheck "See All" box as well
-      if (!newValue) {
+    if (newValue) {
+      if (seeAllIsTargetElement) {
+        // If "See All" is target refinement, deselect all other subcategories. This is done because
+        // showing all services requires that we do not include any refinements in our query
+        subcategories.forEach(category => {
+          updatedSubcategories[category.id] = false;
+        });
+      } else {
+        // If new refinement will be checked, uncheck "See All" box since now the query will include
+        // refinements
         updatedSubcategories[seeAllPseudoId] = false;
       }
-
-      setSelectedSubcategories(updatedSubcategories);
     }
-  };
 
-  const massUpdateSelectedSubcategories = (newValue: boolean) => {
-    const massUpdatedSubcategories: SelectedSubcategories = {};
-    subcategories.forEach(category => {
-      massUpdatedSubcategories[category.id] = newValue;
-    });
-
-    setSelectedSubcategories(massUpdatedSubcategories);
+    setSelectedSubcategories({ ...updatedSubcategories, [targetSubcategoryId]: newValue });
   };
 
   return (


### PR DESCRIPTION
… all is selected, deselect all other refinements so as to not restrict results.

UCSF gave us feedback that the current flow was confusing. Turns out, I had the logic wrong here. When "See All" is selected, all refinements should then be unselected. This is because selecting  refinement(s) can restrict query results