### PR TITLE
Allow lang query param to translate sites

### DIFF
--- a/app/components/ui/Translate.tsx
+++ b/app/components/ui/Translate.tsx
@@ -1,16 +1,38 @@
 import React from 'react';
+import { useCookies } from 'react-cookie';
 import { Helmet } from 'react-helmet-async';
+import { useLocation } from 'react-router-dom';
 import { whiteLabel } from '../../utils';
 
+const INCLUDED_LANGUAGES = ['en', 'es', 'tl', 'zh-TW'];
+const INCLUDED_LANGUAGES_STR = INCLUDED_LANGUAGES.join(',');
+
 const Translate = () => {
+  const [, setCookie] = useCookies(['googtrans']);
+  const { search } = useLocation();
+
   if (whiteLabel.enableTranslation) {
+    // Google Translate determines translation source and target
+    // with a "googtrans" cookie.
+    // When the user navigates with a `lang` query param,
+    // interpret that as an explicit ask to translate the site
+    // into that target language.
+    const params = new URLSearchParams(search);
+    const targetLangCode = params.get('lang');
+    if (targetLangCode && INCLUDED_LANGUAGES.includes(targetLangCode)) {
+      setCookie('googtrans', `/en/${targetLangCode}`, { path: '/' });
+    }
+
     return (
       <li>
         <Helmet>
           <script type="text/javascript">
             {`
               function googleTranslateElementInit() {
-                new google.translate.TranslateElement({includedLanguages: 'en,es,tl,zh-TW'}, 'google_translate_element');
+                new google.translate.TranslateElement({
+                  includedLanguages: '${INCLUDED_LANGUAGES_STR}',
+                  pageLanguage: 'en',
+                }, 'google_translate_element');
               }
             `}
           </script>

--- a/app/init.tsx
+++ b/app/init.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import ReactModal from 'react-modal';
 import { BrowserRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
+import { CookiesProvider } from 'react-cookie';
 import * as Sentry from '@sentry/browser';
 
 import config from './config';
@@ -27,7 +28,9 @@ ReactDOM.render(
   (
     <BrowserRouter>
       <HelmetProvider>
-        <App />
+        <CookiesProvider>
+          <App />
+        </CookiesProvider>
       </HelmetProvider>
     </BrowserRouter>
   ), rootElement,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "qs": "^6.5.1",
         "react": "^16.8.6",
         "react-burger-menu": "^2.6.0",
+        "react-cookie": "^4.1.1",
         "react-dom": "^16.8.6",
         "react-ga": "^2.4.1",
         "react-helmet-async": "^1.0.4",
@@ -4656,6 +4657,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "node_modules/@types/enzyme": {
       "version": "3.10.12",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.12.tgz",
@@ -4738,6 +4744,15 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
@@ -4844,7 +4859,6 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -4858,7 +4872,6 @@
       "version": "17.0.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
       "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4982,7 +4995,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/responselike": {
@@ -4999,7 +5011,6 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -9212,6 +9223,14 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
@@ -22421,6 +22440,19 @@
         "react-dom": ">=0.14.0 <17.0.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-devtools-core": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
@@ -27702,6 +27734,15 @@
         "unist-util-is": "^3.0.0"
       }
     },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -32940,6 +32981,11 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/enzyme": {
       "version": "3.10.12",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.12.tgz",
@@ -33015,6 +33061,15 @@
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
@@ -33110,8 +33165,7 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -33123,7 +33177,6 @@
       "version": "17.0.48",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
       "integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
-      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -33133,8 +33186,7 @@
         "csstype": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-          "devOptional": true
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
         }
       }
     },
@@ -33251,8 +33303,7 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -36375,6 +36426,11 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -46011,6 +46067,16 @@
         "snapsvg-cjs": "0.0.6"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-devtools-core": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
@@ -49921,6 +49987,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
       "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
     },
     "universalify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qs": "^6.5.1",
     "react": "^16.8.6",
     "react-burger-menu": "^2.6.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^16.8.6",
     "react-ga": "^2.4.1",
     "react-helmet-async": "^1.0.4",


### PR DESCRIPTION
* Enables `lang=` query param to specify a target translation language so SFFamilies portal site may link to the visitor's preferred language

This is done by overriding the (undocumented, as far as I can tell) `googtrans` cookie that the Google Translate widget inspects - this seems to be the only method out of other [suggested options to set a target language](https://stackoverflow.com/questions/1773687/google-translate-set-default-language/8493765#8493765) that works reliably.

Technically only the SFFamilies whitelabel is requesting this feature, but I think the language override could potentially be useful across sites. This shouldn't do anything if translation isn't enabled.

For example, with `lang=zh-TW`:
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/834403/205524469-c65c8082-6572-449a-9c36-0684b75d963b.png">

This session cookie should be scoped to the domain (and root + child paths):
<img width="302" alt="image" src="https://user-images.githubusercontent.com/834403/205524778-cf60934d-bf06-473c-85af-e8652af48460.png">
