### PR TITLE
Add refinementListLimit value to whitelabel config and pass to eligib…

### DIFF
--- a/app/components/search/Sidebar/Sidebar.tsx
+++ b/app/components/search/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 
+import { whiteLabel } from 'utils';
 import { eligibilitiesMapping, categoriesMapping } from 'utils/refinementMappings';
 import ClearAllFilters from 'components/search/Refinements/ClearAllFilters';
 import OpenNowFilter from 'components/search/Refinements/OpenNowFilter';
@@ -69,6 +70,7 @@ const Sidebar = ({
       eligibilityRefinementJsx = (
         <RefinementListFilter
           attribute="eligibilities"
+          limit={whiteLabel.refinementListLimit}
           transformItems={transformEligibilities}
         />
       );
@@ -77,6 +79,7 @@ const Sidebar = ({
       categoryRefinementJsx = (
         <RefinementListFilter
           attribute="categories"
+          limit={whiteLabel.refinementListLimit}
           transformItems={(items: { label: string }[]) => items
             .filter(({ label }) => subcategoryNames.includes(label))
             .sort(orderByLabel)}

--- a/app/pages/UcsfClientEligibilityPage/ucsfEligibilitiesMap.ts
+++ b/app/pages/UcsfClientEligibilityPage/ucsfEligibilitiesMap.ts
@@ -22,6 +22,13 @@ interface UcsfEligibilityMap {
   [key: string]: EligibilityGroup[];
 }
 
+// N.B.: Until we have found a way to make use of Algolia's "Show More" refinements button,
+// none of the below resource groups should have a _total_ eligibility amount that exceeds the
+// refinementListLimit value defined in the UCSF whitelabel config in whitelabel.ts.
+// E.g., The ucsf-mental-health-resources should not have more than a sum total of X eligibilities
+// among all of its eligibility groups. This excludes any "See All" eligibilities, which we do not
+// display in the sidebar.
+
 /* eslint-disable object-curly-newline */
 export const eligibilityMap: Readonly<UcsfEligibilityMap> = {
   'ucsf-mental-health-resources': [

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -25,6 +25,7 @@ interface WhiteLabelSite {
   intercom: boolean;
   logoLinkDestination: string;
   navLogoStyle: string;
+  refinementListLimit: number;
   showBanner: boolean;
   showClinicianAction: boolean;
   showHandoutsIcon: boolean;
@@ -59,6 +60,7 @@ const whiteLabelDefaults = {
   intercom: false,
   logoLinkDestination: '/',
   navLogoStyle: styles.siteNav,
+  refinementListLimit: 10,
   showPrintResultsBtn: true,
   showBanner: true,
   showClinicianAction: false,
@@ -146,6 +148,7 @@ const Ucsf: WhiteLabelSite = {
   ...whiteLabelDefaults,
   enableTranslation: false,
   homePageComponent: 'UcsfHomePage',
+  refinementListLimit: 15,
   showBanner: false,
   showClinicianAction: true,
   showHandoutsIcon: true,


### PR DESCRIPTION
…ility and subcategory list in sidebar.

The Algolia refinement list widget has a default list limit of 10. This increases the limit for UCSF refinements as some were being cut off. In the future, when we have a better, more consolidated eligibility/subcategories, we can consider removing this config prop.