### PR TITLE
Allow Texting modal to be scrollable.

### DIFF
--- a/app/App.module.scss
+++ b/app/App.module.scss
@@ -1,0 +1,7 @@
+.outerContainer {
+  /* Creates a stacking context such that everything inside of the
+   * .outerContainer is either above or below anything outside of the
+   * .outerContainer. One example of something outside of the .outerContainer is
+   * modals. */
+  z-index: 0;
+}

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -43,6 +43,8 @@ import OrganizationEditPage from './pages/OrganizationEditPage';
 import { ServiceDiscoveryForm } from './pages/ServiceDiscoveryForm';
 import { ServiceDiscoveryResults } from './pages/ServiceDiscoveryResults';
 
+import styles from './App.module.scss';
+
 const {
   homePageComponent,
   intercom,
@@ -84,7 +86,7 @@ export const App = () => {
   }, []);
 
   return (
-    <div id={outerContainerId}>
+    <div id={outerContainerId} className={styles.outerContainer}>
       { /* eslint-disable-next-line react/jsx-no-constructed-context-values */ }
       <AppContext.Provider value={{ userLocation }}>
         <Helmet>

--- a/app/components/Texting/Texting.module.scss
+++ b/app/components/Texting/Texting.module.scss
@@ -6,6 +6,7 @@
   width: 100%;
   top: 70px;
   background: rgba(0, 0, 0, 0.2);
+  overflow: auto; /* Needed to allow the modal to scroll, rather than the page. */
   @media screen and (max-width: 900px ){
     top: 50px;
   }


### PR DESCRIPTION
This is important for shorter screens (< ~700px), where the submit button on the Texting modal may not be visible.

This also adds a somewhat unrelated (though kind of related) fix to the Texting modal, where the Filters bar from the search results page was above the Texting modal along the z dimension. Forcing the main page and the modal to be in different stacking contexts fixes this issue and overall makes the stacking and scrolling a bit easier to reason about.

### Before

<img width="1018" alt="Screen Shot 2022-12-12 at 5 43 00 PM" src="https://user-images.githubusercontent.com/1002748/207205806-acfea0f4-77ee-4ee2-b532-7f1b9333504c.png">

### After (Filters menu z-index fix)

<img width="1031" alt="Screen Shot 2022-12-12 at 5 43 14 PM" src="https://user-images.githubusercontent.com/1002748/207205847-820884e8-75ca-4fda-b365-127fcf04dcf1.png">

### After (Demonstrating that modal can be scrolled)

<img width="1035" alt="Screen Shot 2022-12-12 at 5 43 20 PM" src="https://user-images.githubusercontent.com/1002748/207205875-b66f6aea-8809-4015-8e4d-730bf3a946a9.png">

---

FWIW, the way I tested this was with Chrome's responsive mode, setting the resolution to 1024 x 600 px, since my display resolution is far taller than 600 px.