### PR TITLE
Update Cypress to v 12. Add TS interface to app Config const.

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -3,6 +3,7 @@ declare global {
 }
 
 interface Config {
+  GOOGLE_ANALYTICS_ID: string;
   LINKSF_DOMAIN: string;
   MOHCD_DOMAIN: string;
   MOHCD_SUBDOMAIN: string;

--- a/app/config.ts
+++ b/app/config.ts
@@ -2,7 +2,16 @@ declare global {
   const CONFIG: any;
 }
 
-const config = {
+interface Config {
+  LINKSF_DOMAIN: string;
+  MOHCD_DOMAIN: string;
+  MOHCD_SUBDOMAIN: string;
+  SFFAMILIES_DOMAIN: string;
+  UCSF_DOMAIN: string;
+  [key: string]: any;
+}
+
+const config: Config = {
   ALGOLIA_APPLICATION_ID: CONFIG.ALGOLIA_APPLICATION_ID,
   ALGOLIA_INDEX_PREFIX: CONFIG.ALGOLIA_INDEX_PREFIX,
   ALGOLIA_READ_ONLY_API_KEY: CONFIG.ALGOLIA_READ_ONLY_API_KEY,

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -42,7 +42,7 @@ interface WhiteLabelSite {
 function determineWhiteLabelSite(): WhiteLabelSiteKey {
   const domain = window.location.host;
   const subdomain = domain.split('.')[0];
-  const checkWhiteLabelSubdomain = (whiteLabelSubdomain: any) => (
+  const checkWhiteLabelSubdomain = (whiteLabelSubdomain: string) => (
     subdomain === whiteLabelSubdomain || subdomain === `${whiteLabelSubdomain}-staging`
   );
 

--- a/cypress/e2e/organization_page.cy.ts
+++ b/cypress/e2e/organization_page.cy.ts
@@ -17,11 +17,11 @@ describe('Organization Page', () => {
   };
 
   it('should correctly set info with a change request', () => {
-    cy.request('POST', `/api/resources/${orgId}/change_requests`, { change_request }).should(r => {
+    cy.request('POST', `/api/resources/${orgId}/change_requests`, { change_request }).then(r => {
       expect(r.status).to.eq(201);
     });
 
-    cy.request<{ resource: Organization }>(`/api/resources/${orgId}`).should(res => {
+    cy.request<{ resource: Organization }>(`/api/resources/${orgId}`).then(res => {
       expect(res.status).to.eq(200);
       expect(res.body.resource).to.include.all.keys('id', 'name', 'email', 'notes');
 
@@ -45,7 +45,7 @@ describe('Organization Page', () => {
   });
 
   it('should render services section with multiple services', () => {
-    cy.request<{ resource: Organization }>(`/api/resources/${orgId}`).should(res => {
+    cy.request<{ resource: Organization }>(`/api/resources/${orgId}`).then(res => {
       expect(res.status).to.eq(200);
       expect(res.body.resource).to.include.all.keys('id', 'name', 'email', 'services');
 

--- a/cypress/e2e/service_page.cy.ts
+++ b/cypress/e2e/service_page.cy.ts
@@ -50,7 +50,7 @@ describe('Service Page', () => {
         delete req.headers['if-none-match'];
       }).as('getServiceData');
 
-      cy.request(`/api/services/${serviceId}`).should((res: Cypress.Response<{ service: Service }>) => {
+      cy.request(`/api/services/${serviceId}`).then((res: Cypress.Response<{ service: Service }>) => {
         expect(res.status).to.eq(200);
         const { service } = res.body;
 
@@ -73,7 +73,7 @@ describe('Service Page', () => {
             .should('contain.text', '8:00 AM - 10:00 AM');
       });
 
-      cy.request<{ service: Service }>(`/api/services/${serviceId}`).should(res => {
+      cy.request<{ service: Service }>(`/api/services/${serviceId}`).then(res => {
         expect(res.status).to.eq(200);
         const { service } = res.body;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "chai": "^4.3.6",
         "cross-env": "^6.0.3",
         "css-loader": "^6.7.0",
-        "cypress": "^10.3.0",
+        "cypress": "^12.2.0",
         "enzyme": "^3.3.0",
         "enzyme-adapter-react-16": "^1.12.1",
         "eslint": "^7.2.0",
@@ -2527,6 +2527,8 @@
     },
     "node_modules/@cypress/xvfb/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9414,6 +9416,8 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -9778,9 +9782,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.1.tgz",
-      "integrity": "sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
+      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9803,7 +9807,7 @@
         "dayjs": "^1.10.4",
         "debug": "^4.3.2",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
@@ -9831,7 +9835,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -11576,6 +11580,8 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11650,6 +11656,8 @@
     },
     "node_modules/eslint-module-utils/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -12348,11 +12356,10 @@
       }
     },
     "node_modules/eventemitter2": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.6.tgz",
-      "integrity": "sha512-OHqo4wbHX5VbvlbB6o6eDwhYmiTjrpWACjF8Pmof/GTD6rdBNdZFNck3xlhqOiQFGCOoq3uzHvA0cQpFHIGVAQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
+      "dev": true
     },
     "node_modules/eventemitter3": {
       "version": "1.2.0",
@@ -17567,6 +17574,8 @@
     },
     "node_modules/jsonwebtoken/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -21838,6 +21847,8 @@
     },
     "node_modules/portfinder/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -25045,6 +25056,8 @@
     },
     "node_modules/sockjs-client/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -31353,6 +31366,8 @@
         },
         "ms": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -36551,7 +36566,9 @@
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -36824,9 +36841,9 @@
       }
     },
     "cypress": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.1.tgz",
-      "integrity": "sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
+      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -36848,7 +36865,7 @@
         "dayjs": "^1.10.4",
         "debug": "^4.3.2",
         "enquirer": "^2.3.6",
-        "eventemitter2": "^6.4.3",
+        "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
         "extract-zip": "2.0.1",
@@ -38369,6 +38386,8 @@
         },
         "ms": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "resolve": {
@@ -38424,6 +38443,8 @@
         },
         "ms": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "p-limit": {
@@ -38734,9 +38755,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter2": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.6.tgz",
-      "integrity": "sha512-OHqo4wbHX5VbvlbB6o6eDwhYmiTjrpWACjF8Pmof/GTD6rdBNdZFNck3xlhqOiQFGCOoq3uzHvA0cQpFHIGVAQ==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+      "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
       "dev": true
     },
     "eventemitter3": {
@@ -42458,6 +42479,8 @@
       "dependencies": {
         "ms": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -45649,6 +45672,8 @@
         },
         "ms": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
@@ -48037,6 +48062,8 @@
         },
         "ms": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chai": "^4.3.6",
     "cross-env": "^6.0.3",
     "css-loader": "^6.7.0",
-    "cypress": "^10.3.0",
+    "cypress": "^12.2.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "eslint": "^7.2.0",


### PR DESCRIPTION
Makes updates in reference to @richardxia 's helpful comments on https://github.com/ShelterTechSF/askdarcel-web/pull/1206

I updated Cypress from v10 to 12 which fixed an issue with caching the response to Cypress intercepts and negated a need for us to add a funky fix for that. Bumping the version caused a few of our tests to faill; we were using a `.should` after requests where we should have been using a `.then`. i'm not sure why this was done to begin with but it seemed like a pretty straightforward and reasonable change to make as part of this PR.

I also added an interface for our config object.