### PR TITLE
Add about page text to whitelabel config and add UCSF specific text a…

### DIFF
--- a/app/pages/AboutPage/AboutPage.tsx
+++ b/app/pages/AboutPage/AboutPage.tsx
@@ -1,7 +1,7 @@
 import whiteLabel from "../../utils/whitelabel";
 
-import { LinkSfJsx } from "./AboutPageMarkup/LinkSf";
-import { SfServiceGuideJsx } from "./AboutPageMarkup/SfServiceGuide";
+import { LinkSf } from "./AboutPageMarkup/LinkSf";
+import { SfServiceGuide } from "./AboutPageMarkup/SfServiceGuide";
 
 // Disable max line length rule, since this file is mostly just text-heavy HTML content.
 /* eslint-disable max-len */
@@ -13,8 +13,8 @@ export const AboutPage = () => {
   // web domain is a whitelabel or not
   // Todo: The different About page JSX components can be more DRY
   if (title === "Link SF") {
-    return LinkSfJsx();
+    return LinkSf();
   }
 
-  return SfServiceGuideJsx();
+  return SfServiceGuide();
 };

--- a/app/pages/AboutPage/AboutPageMarkup/LinkSf.tsx
+++ b/app/pages/AboutPage/AboutPageMarkup/LinkSf.tsx
@@ -16,7 +16,7 @@ import HomeownershipSFLogo from "../assets/HomeownershipSF.png";
 import ZenDeskLogo from "../assets/ZenDeskLogo.jpg";
 import TLTechLabLogo from "../assets/TLTechLabLogo.png";
 
-export const LinkSfJsx = () => (
+export const LinkSf = () => (
   <div className={styles.about}>
     <article className={styles.textPage} id="about">
       <header className={styles.aboutHeader}>

--- a/app/pages/AboutPage/AboutPageMarkup/SfServiceGuide.tsx
+++ b/app/pages/AboutPage/AboutPageMarkup/SfServiceGuide.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { whiteLabel } from "../../../utils";
+
 import { Footer } from "../../../components/ui";
 
 import styles from "../AboutPage.module.scss";
@@ -14,23 +16,18 @@ import CompassLogo from "../assets/Compass.png";
 import EDCLogo from "../assets/EDC.png";
 import HomeownershipSFLogo from "../assets/HomeownershipSF.png";
 
-export const SfServiceGuideJsx = () => (
+const { aboutPageText, aboutPageTitle } = whiteLabel;
+
+export const SfServiceGuide = () => (
   <div className={styles.about}>
     <article className={styles.textPage} id="about">
       <header className={styles.aboutHeader}>
         <h1>
           About the
           <br />
-          SF Service Guide
+          {aboutPageTitle}
         </h1>
-        <p>
-          The SF Service Guide is an online directory of human services in San
-          Francisco. Our goal is to help anyone with access to a smartphone,
-          tablet, or computer find the services they need. The guide&apos;s
-          focus is on homelessness and housing services, but also covers a
-          variety of other services, from education and legal aid to senior
-          services and re-entry programs.{" "}
-        </p>
+        <p>{aboutPageText} </p>
       </header>
       <section className={styles.aboutSection}>
         <h3>Powered by:</h3>
@@ -43,7 +40,7 @@ export const SfServiceGuideJsx = () => (
             <img src={STLogo} alt="ShelterTech" />
           </a>
           <p>
-            The SF Service Guide is developed and maintained by ShelterTech, a
+            The {aboutPageTitle} is developed and maintained by ShelterTech, a
             volunteer-only 501c(3) non-profit that builds tech products for
             homeless and at risk communities.{" "}
             <a href="http://sheltertech.org" rel="noopener">
@@ -63,7 +60,7 @@ export const SfServiceGuideJsx = () => (
             <img src={MOHCDLogo} alt="MOHCD" />
           </a>
           <p>
-            The SF Service Guide is supported by a grant from the SF
+            The {aboutPageTitle} is supported by a grant from the SF
             Mayor&apos;s Office of Housing and Community Development.
           </p>
         </div>

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -18,6 +18,8 @@ type WhiteLabelSiteKey =
 type homepageComponentEnums = "HomePage" | "UcsfHomePage";
 
 interface WhiteLabelSite {
+  aboutPageText: string;
+  aboutPageTitle: string;
   appImages: {
     background: string;
     logoLarge: string;
@@ -69,6 +71,13 @@ function determineWhiteLabelSite(): WhiteLabelSiteKey {
 const configKey = determineWhiteLabelSite();
 
 const whiteLabelDefaults = {
+  aboutPageText: `The SF Service Guide is an online directory of human services in San
+Francisco. Our goal is to help anyone with access to a smartphone,
+tablet, or computer find the services they need. The guide's
+focus is on homelessness and housing services, but also covers a
+variety of other services, from education and legal aid to senior
+services and re-entry programs.`,
+  aboutPageTitle: "SF Service Guide",
   enableTranslation: true,
   homePageComponent: "HomePage",
   intercom: false,
@@ -160,6 +169,13 @@ const Ucsf: WhiteLabelSite = {
     logoSmall: UcsfServiceLogo,
   },
   ...whiteLabelDefaults,
+  aboutPageText: `The Discharge Navigator is a clinician-focused tool designed to empower medical providers
+with real-time access to information about social resources around San Francisco. Clinicians
+can utilize this database to identify and share targeted resources for patients based on social
+needs, language requirements, and demographics. This project is the result of collaboration
+among experts across the SF Department of Public Health, Zuckerberg SF General Emergency
+Department, and UCSF School of Medicine in partnership with SF Service Guide.`,
+  aboutPageTitle: "Discharge Navigator",
   enableTranslation: false,
   homePageComponent: "UcsfHomePage",
   navLogoStyle: styles.navLogoUcsf,


### PR DESCRIPTION
…nd title. Small refactor to existing about page logic

<img width="1504" alt="Screen Shot 2023-01-30 at 7 04 09 PM" src="https://user-images.githubusercontent.com/3012520/215652968-23b4c774-96ad-4ed9-8add-aaecdeaa8cb0.png">
<img width="1512" alt="Screen Shot 2023-01-30 at 7 03 20 PM" src="https://user-images.githubusercontent.com/3012520/215652899-3c52250c-1f12-48b6-8f4a-7aaa82a5ffa7.png">
2890-a68ff608-4207-447a-9dee-0c039f9f6eaf.png">
<img width="1512" alt="Screen Shot 2023-01-30 at 7 02 13 PM" src="https://user-images.githubusercontent.com/3012520/215652907-35b01249-3c06-4826-b8af-98699f505c02.png">
