### PR TITLE
Minor tweaks to whitelabel enabledTranslations property.

### DIFF
--- a/app/components/ui/Translate.tsx
+++ b/app/components/ui/Translate.tsx
@@ -9,7 +9,7 @@ const Translate = () => {
   const { search } = useLocation();
 
   const languages = whiteLabel.enabledTranslations;
-  if (languages && languages.length > 0) {
+  if (languages.length > 0) {
     // Google Translate determines translation source and target
     // with a "googtrans" cookie.
     // When the user navigates with a `lang` query param,

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -27,7 +27,14 @@ interface WhiteLabelSite {
     algolia: string;
     mohcdSeal: string;
   };
-  enabledTranslations: ReadonlyArray<string>; // empty to disable translation
+  /** A list of languages to enable automatic translations for.
+   *
+   * The language codes must match the Google Translate API [1].
+   * Set to the empty array to disable automatic translation.
+   *
+   * [1]: https://cloud.google.com/translate/docs/languages
+   */
+  enabledTranslations: readonly string[];
   homePageComponent: homepageComponentEnums;
   intercom: boolean;
   logoLinkDestination: string;


### PR DESCRIPTION
These are the minor changes that I suggested as a post-merge review comment in https://github.com/ShelterTechSF/askdarcel-web/pull/1225#pullrequestreview-1300787255.

- Change the spelling of the type to `readonly string[]`, which is equivalent
- Change the comment to a documentation comment, which allows it to show up on hover
- Remove an unnecessary nullness check, since the type cannot be null

Here's an example of what the documentation comments look like in my editor of choice (vim), but it should be similar in other modern editors:
<img width="627" alt="Screen Shot 2023-02-15 at 10 28 50 PM" src="https://user-images.githubusercontent.com/1002748/219286395-4e876358-8cdc-43af-88ea-9301c5e8121d.png">
