### PR TITLE
Ucsf UI improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+// Disabling eslint quote props because prettier clashes with eslint here
+/* eslint-disable quote-props */
 const path = require("path");
 
 module.exports = {
@@ -20,7 +22,7 @@ module.exports = {
     },
   },
   rules: {
-    "camelcase": "off",
+    camelcase: "off",
     "import/extensions": [
       "error",
       {
@@ -144,7 +146,7 @@ module.exports = {
       rules: {
         "newline-per-chained-call": "off",
         "lines-between-class-members": "off",
-        "indent": "off",
+        indent: "off",
       },
     },
     // Node.js scripts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-// Disabling eslint quote props because prettier clashes with eslint here
-/* eslint-disable quote-props */
 const path = require("path");
 
 module.exports = {
@@ -174,10 +172,6 @@ module.exports = {
         // CJS-style imports.
         // https://github.com/benmosher/eslint-plugin-import/issues/1469
         "import/no-unused-modules": "off",
-        // Most ESLint rules names have characters which must be quoted, such as
-        // '-' or '/', so it's easier to read if all things under "rules" are
-        // consistently quoted.
-        "quote-props": ["error", "consistent-as-needed"],
       },
     },
   ],

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,3 @@ build
 !.*.js
 cypress.config.ts
 node_modules
-.eslintrc.js

--- a/app/components/ucsf/Layout/Layout.module.scss
+++ b/app/components/ucsf/Layout/Layout.module.scss
@@ -5,7 +5,7 @@
   grid-template-columns: repeat(12, 1fr);
   grid-column-gap: 16px;
   max-width: 1450px;
-  padding: (200px - $header-height) 48px 20px;
+  padding: 114px 48px 20px;
   @media screen and (max-width: $break-tablet-s) {
     padding: 25px 20px 20px;
   }

--- a/app/components/ucsf/Layout/Layout.module.scss
+++ b/app/components/ucsf/Layout/Layout.module.scss
@@ -5,7 +5,7 @@
   grid-template-columns: repeat(12, 1fr);
   grid-column-gap: 16px;
   max-width: 1450px;
-  padding: 90px 48px 20px;
+  padding: 114px 48px 20px;
   @media screen and (max-width: $break-tablet-s) {
     padding: 25px 20px 20px;
   }

--- a/app/components/ucsf/Layout/Layout.module.scss
+++ b/app/components/ucsf/Layout/Layout.module.scss
@@ -5,7 +5,7 @@
   grid-template-columns: repeat(12, 1fr);
   grid-column-gap: 16px;
   max-width: 1450px;
-  padding: 114px 48px 20px;
+  padding: 90px 48px 20px;
   @media screen and (max-width: $break-tablet-s) {
     padding: 25px 20px 20px;
   }

--- a/app/components/ucsf/Layout/Layout.tsx
+++ b/app/components/ucsf/Layout/Layout.tsx
@@ -2,6 +2,10 @@ import React, { ReactNode } from "react";
 
 import styles from "./Layout.module.scss";
 
-export const Layout = ({ children }: { children: ReactNode }) => (
-  <div className={styles.grid}>{children}</div>
-);
+export const Layout = ({
+  children,
+  customClass = "",
+}: {
+  children: ReactNode;
+  customClass?: string;
+}) => <div className={`${styles.grid} ${customClass}`}>{children}</div>;

--- a/app/components/ucsf/RefinementLists/EligibilityRefinements.tsx
+++ b/app/components/ucsf/RefinementLists/EligibilityRefinements.tsx
@@ -2,13 +2,13 @@ import React from "react";
 
 import { Checkbox } from "components/ui/inline/Checkbox/Checkbox";
 
-import { Eligibility, EligibilityGroup } from "./ucsfEligibilitiesMap";
+import {
+  Eligibility,
+  EligibilityGroup,
+  SelectedEligibilities,
+} from "./ucsfEligibilitiesMap";
 
 import styles from "./Refinements.module.scss";
-
-interface SelectedEligibilities {
-  [key: string]: boolean;
-}
 
 export const EligibilityRefinements = ({
   resourceEligibilityGroups,

--- a/app/components/ucsf/RefinementLists/SubcategoryRefinements.tsx
+++ b/app/components/ucsf/RefinementLists/SubcategoryRefinements.tsx
@@ -13,11 +13,11 @@ export interface SelectedSubcategories {
   [key: number]: boolean;
 }
 
-export const defaultSelectedSubcategories: Readonly<SelectedSubcategories> = {
-  "-1": true,
-};
-
 const seeAllPseudoId = -1;
+
+export const defaultSelectedSubcategories: Readonly<SelectedSubcategories> = {
+  [seeAllPseudoId]: true,
+};
 
 export const SubcategoryRefinements = ({
   subcategories,

--- a/app/components/ucsf/RefinementLists/SubcategoryRefinements.tsx
+++ b/app/components/ucsf/RefinementLists/SubcategoryRefinements.tsx
@@ -9,9 +9,13 @@ interface SubcategoryRefinement {
   id: number;
 }
 
-interface SelectedSubcategories {
+export interface SelectedSubcategories {
   [key: number]: boolean;
 }
+
+export const defaultSelectedSubcategories: Readonly<SelectedSubcategories> = {
+  "-1": true,
+};
 
 const seeAllPseudoId = -1;
 

--- a/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
+++ b/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
@@ -230,3 +230,22 @@ export const eligibilityMap: Readonly<UcsfEligibilityMap> = {
     },
   ],
 };
+
+export interface SelectedEligibilities {
+  [key: string]: boolean;
+}
+
+export const defaultSelectedEligibilities = (
+  eligibilityGroup: EligibilityGroup[]
+): SelectedEligibilities => {
+  const selectedEligibilities: SelectedEligibilities = {};
+  const mergedEligibilities = eligibilityGroup.flatMap(
+    (group) => group.eligibilities
+  );
+
+  mergedEligibilities.forEach((eligibility: Eligibility) => {
+    selectedEligibilities[eligibility.checkedId] = eligibility.isSeeAll
+  })
+
+  return selectedEligibilities;
+};

--- a/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
+++ b/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
@@ -244,8 +244,8 @@ export const defaultSelectedEligibilities = (
   );
 
   mergedEligibilities.forEach((eligibility: Eligibility) => {
-    selectedEligibilities[eligibility.checkedId] = eligibility.isSeeAll
-  })
+    selectedEligibilities[eligibility.checkedId] = eligibility.isSeeAll;
+  });
 
   return selectedEligibilities;
 };

--- a/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
+++ b/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
@@ -243,7 +243,7 @@ export const defaultSelectedEligibilities = (
     (group) => group.eligibilities
   );
 
-  mergedEligibilities.forEach((eligibility: Eligibility) => {
+  mergedEligibilities.forEach((eligibility) => {
     selectedEligibilities[eligibility.checkedId] = eligibility.isSeeAll;
   });
 

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.module.scss
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.module.scss
@@ -1,5 +1,9 @@
 @import "~styles/utils/_helpers.scss";
 
+.discoveryLayout {
+  padding-top: 48px;
+}
+
 .discoveryFormPage {
   grid-column: 2 / span 10;
 

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.module.scss
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.module.scss
@@ -12,6 +12,11 @@
   margin-top: 21px;
 }
 
+.refinementsContainer {
+  display: grid;
+  gap: 16px;
+}
+
 .refinementsBox {
   display: flex;
   margin-top: 16px;
@@ -22,15 +27,6 @@
     flex-direction: column;
     align-items: center;
   }
-}
-
-.buttonBarBorder {
-  position: sticky;
-  bottom: 0;
-  padding: 15px 0;
-  z-index: $z-index-button-bar;
-  border-top: solid 1px $color-grey3;
-  background-color: #fff;
 }
 
 .navigationButtons {

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.module.scss
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.module.scss
@@ -14,7 +14,7 @@
 
 .refinementsBox {
   display: flex;
-  margin: 16px 0;
+  margin-top: 16px;
   padding: 32px;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1), 0px 0px 4px rgba(0, 0, 0, 0.1);
 
@@ -24,26 +24,35 @@
   }
 }
 
+.buttonBarBorder {
+  position: sticky;
+  bottom: 0;
+  padding: 15px 0;
+  z-index: $z-index-button-bar;
+  border-top: solid 1px $color-grey3;
+  background-color: #fff;
+}
+
 .navigationButtons {
   display: flex;
   justify-content: right;
-  column-gap: 8px;
-  // position: sticky;
-  // top: 10px;
-  // bottom: 20px;
+  gap: 8px;
 
-  @media screen and (max-width: $break-tablet-s) {
+  @media screen and (max-width: $break-tablet-p) {
     justify-content: center;
+    flex-direction: column-reverse;
   }
 }
 
-// .nextBtn,
-// .goBackBtn {
-//   border-radius: 3px;
-//   height: 49px;
-//   padding: 12px 72px;
-// }
+.nextBtn,
+.goBackBtn {
+  border-radius: 3px;
+  height: 49px;
+  padding: 12px 72px;
+}
 
-// .goBackBtn {
-//   background-color: #fff;
-// }
+.goBackBtn {
+  background-color: #fff;
+  color: $color-brand;
+  border: solid 1px $color-brand;
+}

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -6,10 +6,12 @@ import ReactGA from "react-ga";
 import { Button } from "components/ui/inline/Button/Button";
 import { Section } from "components/ucsf/Section/Section";
 import { Layout } from "components/ucsf/Layout/Layout";
-import { SubcategoryRefinements, SelectedSubcategories, defaultSelectedSubcategories } from "components/ucsf/RefinementLists/SubcategoryRefinements";
 import {
-  EligibilityRefinements,
-} from "components/ucsf/RefinementLists/EligibilityRefinements";
+  SubcategoryRefinements,
+  SelectedSubcategories,
+  defaultSelectedSubcategories,
+} from "components/ucsf/RefinementLists/SubcategoryRefinements";
+import { EligibilityRefinements } from "components/ucsf/RefinementLists/EligibilityRefinements";
 import {
   eligibilityMap,
   defaultSelectedEligibilities,
@@ -158,7 +160,10 @@ const Page = () => {
         <div className={styles.refinementsBox}>{refinementsComponent}</div>
         <div className={styles.buttonBarBorder}>
           <div className={styles.navigationButtons}>
-            <Button addClass={styles.goBackBtn} onClick={backToResourceSelection}>
+            <Button
+              addClass={styles.goBackBtn}
+              onClick={backToResourceSelection}
+            >
               Back
             </Button>
             <Button

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -156,18 +156,20 @@ const Page = () => {
       <Section addClass={styles.subtitleMargin} subtitle={stepSubtitle} />
       <div className={styles.eligibilitiesContainer}>
         <div className={styles.refinementsBox}>{refinementsComponent}</div>
-        <div className={styles.navigationButtons}>
-          <Button addClass={styles.goBackBtn} onClick={backToResourceSelection}>
-            Back
-          </Button>
-          <Button
-            addClass={styles.nextBtn}
-            onClick={() => {
-              goToNextStep(selectedResourceSlug);
-            }}
-          >
-            {nextButtonText}
-          </Button>
+        <div className={styles.buttonBarBorder}>
+          <div className={styles.navigationButtons}>
+            <Button addClass={styles.goBackBtn} onClick={backToResourceSelection}>
+              Back
+            </Button>
+            <Button
+              addClass={styles.nextBtn}
+              onClick={() => {
+                goToNextStep(selectedResourceSlug);
+              }}
+            >
+              {nextButtonText}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -177,7 +177,7 @@ const Page = () => {
 };
 
 export const UcsfDiscoveryForm = () => (
-  <Layout>
+  <Layout customClass={styles.discoveryLayout}>
     <Page />
   </Layout>
 );

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -156,25 +156,20 @@ const Page = () => {
     <div className={styles.discoveryFormPage}>
       <Section title={servicesName} />
       <Section addClass={styles.subtitleMargin} subtitle={stepSubtitle} />
-      <div className={styles.eligibilitiesContainer}>
+      <div className={styles.refinementsContainer}>
         <div className={styles.refinementsBox}>{refinementsComponent}</div>
-        <div className={styles.buttonBarBorder}>
-          <div className={styles.navigationButtons}>
-            <Button
-              addClass={styles.goBackBtn}
-              onClick={backToResourceSelection}
-            >
-              Back
-            </Button>
-            <Button
-              addClass={styles.nextBtn}
-              onClick={() => {
-                goToNextStep(selectedResourceSlug);
-              }}
-            >
-              {nextButtonText}
-            </Button>
-          </div>
+        <div className={styles.navigationButtons}>
+          <Button addClass={styles.goBackBtn} onClick={backToResourceSelection}>
+            Back
+          </Button>
+          <Button
+            addClass={styles.nextBtn}
+            onClick={() => {
+              goToNextStep(selectedResourceSlug);
+            }}
+          >
+            {nextButtonText}
+          </Button>
         </div>
       </div>
     </div>

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -6,9 +6,15 @@ import ReactGA from "react-ga";
 import { Button } from "components/ui/inline/Button/Button";
 import { Section } from "components/ucsf/Section/Section";
 import { Layout } from "components/ucsf/Layout/Layout";
-import { SubcategoryRefinements } from "components/ucsf/RefinementLists/SubcategoryRefinements";
-import { EligibilityRefinements } from "components/ucsf/RefinementLists/EligibilityRefinements";
-import { eligibilityMap } from "components/ucsf/RefinementLists/ucsfEligibilitiesMap";
+import { SubcategoryRefinements, SelectedSubcategories, defaultSelectedSubcategories } from "components/ucsf/RefinementLists/SubcategoryRefinements";
+import {
+  EligibilityRefinements,
+} from "components/ucsf/RefinementLists/EligibilityRefinements";
+import {
+  eligibilityMap,
+  defaultSelectedEligibilities,
+  SelectedEligibilities,
+} from "components/ucsf/RefinementLists/ucsfEligibilitiesMap";
 
 import { CATEGORIES } from "../ServiceDiscoveryForm/constants";
 import { useSubcategoriesForCategory } from "../../hooks/APIHooks";
@@ -20,30 +26,25 @@ interface SubcategoryRefinement {
   id: number;
 }
 
-interface SelectedSubcategories {
-  [key: number]: boolean;
-}
-
 const seeAllPseudoId = -1;
 
 const Page = () => {
-  interface SelectedEligibilities {
-    [key: string]: boolean;
-  }
-
-  const [selectedEligibilities, setSelectedEligibilities] =
-    useState<SelectedEligibilities>({});
-  const [selectedSubcategories, setSelectedSubcategories] =
-    useState<SelectedSubcategories>({});
-
   const history = useHistory();
   const match = useRouteMatch();
   interface MatchParams {
     selectedResourceSlug: string;
   }
+
   const { selectedResourceSlug } = match.params as MatchParams;
   const resourceEligibilityGroups = eligibilityMap[selectedResourceSlug];
   const category = CATEGORIES.find((c) => c.slug === selectedResourceSlug);
+
+  const [selectedEligibilities, setSelectedEligibilities] =
+    useState<SelectedEligibilities>(
+      defaultSelectedEligibilities(resourceEligibilityGroups)
+    );
+  const [selectedSubcategories, setSelectedSubcategories] =
+    useState<SelectedSubcategories>(defaultSelectedSubcategories);
   const [currentStep, setCurrentStep] = useState(0);
 
   const subcategories: SubcategoryRefinement[] =

--- a/app/styles/utils/_layoututils.scss
+++ b/app/styles/utils/_layoututils.scss
@@ -20,6 +20,7 @@ $header-height: 70px;
 $header-mobile-height: 50px;
 
 // Z-Index values
+$z-index-button-bar: 1;
 $z-index-edit-address-modal: 1;
 $z-index-site-nav: 3;
 $z-index-filters-menu: 4;

--- a/app/styles/utils/_layoututils.scss
+++ b/app/styles/utils/_layoututils.scss
@@ -20,7 +20,6 @@ $header-height: 70px;
 $header-mobile-height: 50px;
 
 // Z-Index values
-$z-index-button-bar: 1;
 $z-index-edit-address-modal: 1;
 $z-index-site-nav: 3;
 $z-index-filters-menu: 4;


### PR DESCRIPTION
This PR adds code to select "See All" checkboxes by default on the UCSF Discovery Form page, per product discussion -- the eligibility and subcategory refinements state vars are initialized with a hash that has all See All refinements selected. 

This PR also implements floating buttons on the UCSF Discovery Form page per the [Figma designs](https://www.figma.com/file/HUTUyVuJf8lctj5fAFIY32/UCSF?node-id=5626%3A10024&t=pdo86f0CTBULiX2V-0) and product discussion.

<img width="1139" alt="Screen Shot 2023-02-16 at 8 51 02 PM" src="https://user-images.githubusercontent.com/3012520/219552778-beb17dac-1ba5-4999-9d03-54f0ab865d2a.png">
