### PR TITLE
Run Prettier in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           restore-keys: npm-
       - run: npm ci
       - run: cp config.example.yml config.yml
+      - run: npm run prettier
       - run: npm run lint
 
   test_unit:

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "dev": "cross-env NODE_ENV=development webpack serve --inline --open --mode=development",
     "lint": "eslint --ext=.js,.jsx,.ts,.tsx .",
     "lint:fix": "eslint --fix --ext=.js,.jsx,.ts,.tsx .",
+    "prettier": "prettier --check .",
+    "prettier:fix": "prettier --write .",
     "test": "cross-env NODE_ENV=test mocha --require ts-node/register --exit --reporter spec testing/mocha.js app/**/*.spec.{j,t}s*",
     "test:coverage": "nyc --extension .jsx --reporter=text npm test -- --exit",
     "test:watch": "npm run test -- --watch --watch-extensions jsx --inspect",


### PR DESCRIPTION
I noticed that Prettier doesn't seem to actually be checked in CI, since `npm run lint` only runs ESLint, not Prettier. This adds new `prettier` and `prettier:fix` scripts to our package.json, and then it adds `npm run prettier` to our CI job.