### PR TITLE
Migrate Edit Page to TypeScript Part 2

### DIFF
--- a/app/components/edit/FormTextArea.tsx
+++ b/app/components/edit/FormTextArea.tsx
@@ -1,7 +1,12 @@
-import React, { Fragment } from "react";
-import PropTypes from "prop-types";
+import React from "react";
 
-const FormTextArea = ({ label, placeholder, value, setValue }) => (
+type Props = {
+  label: string;
+  placeholder: string;
+  value: string;
+  setValue: (x: string) => void;
+};
+const FormTextArea = ({ label, placeholder, value, setValue }: Props) => (
   <>
     <label htmlFor="textarea">{label}</label>
     <textarea
@@ -11,12 +16,5 @@ const FormTextArea = ({ label, placeholder, value, setValue }) => (
     />
   </>
 );
-
-FormTextArea.propTypes = {
-  label: PropTypes.string.isRequired,
-  placeholder: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  setValue: PropTypes.func.isRequired, // A function to call when setting a new value
-};
 
 export default FormTextArea;

--- a/app/components/ui/PopUpMessage.tsx
+++ b/app/components/ui/PopUpMessage.tsx
@@ -14,5 +14,5 @@ export const PopUpMessage = ({
 export interface PopupMessageProp {
   message: string;
   type: "success" | "error";
-  visible: boolean;
+  visible?: boolean;
 }

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Prompt, withRouter } from "react-router-dom";
+import type { RouteComponentProps } from "react-router";
 import _ from "lodash";
 
 import { Loader } from "components/ui";
@@ -11,6 +12,7 @@ import EditSchedule from "../components/edit/EditSchedule";
 import EditPhones from "../components/edit/EditPhones";
 import EditSidebar from "../components/edit/EditSidebar";
 import { buildScheduleDays } from "../components/edit/ProvidedService";
+import type { PopupMessageProp } from "../components/ui/PopUpMessage";
 import * as dataService from "../utils/DataService";
 import "./OrganizationEditPage.scss";
 
@@ -439,8 +441,20 @@ const getAddresses = (state) => {
   return addresses;
 };
 
-class OrganizationEditPage extends React.Component<any, any> {
-  constructor(props) {
+/** The type of route parameters coming from react-router, based on our routes.
+ *
+ * The `id` property comes from the `:id` in our edit route, where it is
+ * mandatory, but is optional in this type because it is not present in the new
+ * route.
+ */
+type RouteParams = { id?: string };
+
+type Props = RouteComponentProps<RouteParams> & {
+  showPopUpMessage: (p: PopupMessageProp) => void;
+};
+
+class OrganizationEditPage extends React.Component<Props, any> {
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -1390,21 +1404,5 @@ class OrganizationEditPage extends React.Component<any, any> {
     );
   }
 }
-
-// Leaving propTypes definitions here for reference. Remove when we add proper
-// TypeScript types to this component's props.
-//
-// OrganizationEditPage.propTypes = {
-//   location: PropTypes.shape({
-//     pathname: PropTypes.string.isRequired,
-//   }).isRequired,
-//   match: PropTypes.shape({
-//     params: PropTypes.shape({
-//       id: PropTypes.string,
-//     }).isRequired,
-//   }).isRequired,
-//   history: PropTypes.object.isRequired,
-//   showPopUpMessage: PropTypes.func.isRequired,
-// };
 
 export default withRouter(OrganizationEditPage);

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -999,7 +999,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
     });
   };
 
-  keepOnPage(e) {
+  keepOnPage(e: BeforeUnloadEvent): void {
     const { inputsDirty } = this.state;
     if (inputsDirty) {
       const message =
@@ -1205,8 +1205,14 @@ class OrganizationEditPage extends React.Component<Props, State> {
     this.setState({ phones: phoneCollection, inputsDirty: true });
   }
 
-  handleResourceFieldChange(e) {
+  handleResourceFieldChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
     const { field } = e.target.dataset;
+    assertDefined(
+      field,
+      "Called handleResourceFieldChange() on a form element missing the data-field attribute."
+    );
     const { value } = e.target;
     const object = {
       [field]: value,


### PR DESCRIPTION
Refs #1175.

This deals with some of the lower-hanging fruit on the Edit Page, where either the type is totally known due to the values coming purely from the frontend (as opposed to the backend API), such as event handlers or `setState()` being called with known keys on the object. Notably, this adds a type for the props of the main page component as well as one for the state of that component, though the current version of the state type definition has a lot of `any`'s in it.

I've been cautious about not using the types defined in `app/models` until I can confirm that they actually match the Edit Page, since the `app/models` types mostly reflect what the API sends back, but the Edit Page performs a lot of transformations internally. For now, leaving the types as `any` or even `Record<any, any>` makes it a bit more typesafe since we at least acknowledge the existence of certain properties.

One other thing to note is that I've added an `assertDefined()` helper function for purely type checking purposes. It's similar to the `!` (postfix) operator in TypeScript, which will promote a type of `T | undefined` to just `T`, but my version is real JavaScript, so it performs an actual runtime check, which makes it a bit safer than the `!` operator. This was mostly used to deal with `this.state.resource`, which is only initialized after the `componentDidMount()` hook fires, which makes a request to the API endpoint to get the existing resource data.