### PR TITLE
Migrate Edit Page to TypeScript Part 3

### DIFF
--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import EditNotes from "./EditNotes";
 import EditSchedule from "./EditSchedule";
@@ -7,10 +7,22 @@ import FormTextArea from "./FormTextArea";
 import { AddressListItem } from "./EditAddress";
 import EditPatientHandout from "./EditPatientHandout";
 import { EditServiceChildCollection } from "./EditServiceChildCollection";
+import type { Schedule } from "../../models";
 
 import s from "./ProvidedService.module.scss";
 
-/** Build UI state schedule from API schedule.
+interface InternalScheduleDay {
+  opens_at: number | null;
+  closes_at: number | null;
+  /** The DB ID of the ScheduleDay. */
+  id?: number | null;
+  /** The DB ID of the Schedule that this ScheduleDay is attached to. */
+  scheduleId?: number | null;
+  openChanged?: boolean;
+  closeChanged?: boolean;
+}
+
+/** Schedule model used internally on the Edit Page.
  *
  * The difference between the schedule that comes from the API and the schedule
  * that is saved as React UI state is that the UI state schedule's schema groups
@@ -20,11 +32,30 @@ import s from "./ProvidedService.module.scss";
  * no open and close time but that is attached to a day of week. This feature is
  * required for the UI because the blank time needs to appear under a day of
  * week before an open and close time is set.
+ *
+ * We also have a number of extra fields on the InternalScheduleDay that keep
+ * track of which properties have been edited and therefore need to be synced
+ * back to the server.
  */
-const buildScheduleDays = (schedule) => {
+interface InternalSchedule {
+  Monday: InternalScheduleDay[];
+  Tuesday: InternalScheduleDay[];
+  Wednesday: InternalScheduleDay[];
+  Thursday: InternalScheduleDay[];
+  Friday: InternalScheduleDay[];
+  Saturday: InternalScheduleDay[];
+  Sunday: InternalScheduleDay[];
+}
+
+/** Build UI state schedule from API schedule.
+ *
+ * Returns an InternalSchedule.
+ */
+const buildScheduleDays = (
+  schedule: Schedule | undefined
+): InternalSchedule => {
   const scheduleId = schedule ? schedule.id : null;
-  const currSchedule = {};
-  let finalSchedule = {};
+  const currSchedule: Partial<InternalSchedule> = {};
 
   const is24Hours = {
     Monday: false,
@@ -62,8 +93,9 @@ const buildScheduleDays = (schedule) => {
           ];
         } else {
           Object.assign(day, { openChanged: false, closeChanged: false });
-          if (currSchedule[currDay]) {
-            currSchedule[day.day].unshift(day);
+          const currScheduleDay = currSchedule[currDay];
+          if (currScheduleDay) {
+            currScheduleDay.unshift(day);
           } else {
             currSchedule[day.day] = [day];
           }
@@ -71,8 +103,7 @@ const buildScheduleDays = (schedule) => {
       }
     });
   }
-  finalSchedule = { ...tempSchedule, ...currSchedule };
-  return finalSchedule;
+  return { ...tempSchedule, ...currSchedule };
 };
 export { buildScheduleDays };
 

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -37,7 +37,7 @@ interface InternalScheduleDay {
  * track of which properties have been edited and therefore need to be synced
  * back to the server.
  */
-interface InternalSchedule {
+export interface InternalSchedule {
   Monday: InternalScheduleDay[];
   Tuesday: InternalScheduleDay[];
   Wednesday: InternalScheduleDay[];


### PR DESCRIPTION
Refs #1175.

This is the next unit of work I've done in terms of migrating the Edit Page to TypeScript. Here, I've defined types for the internal versions of Schedule, ScheduleDay, Organization (Resource), and Service, which differ from the versions that the API endpoints respond with. I won't detail the differences in this PR description, but I wrote comments next to the type definitions explaining the differences. The short summary is that the Edit Page has to keep track of certain state in its UI, so it can't maintain that state using the exact same shape of the data as stored in the DB.

These internal data type aren't great, and if I were to rewrite this page from scratch, I would do it very differently, but I am glad that TypeScript has allowed me to at least annotate exactly what things are like today.

One other notable change is that for some of the `<input>` fields directly on the Organization, I had to add a `resource.some_field ?? ""` to places where we were setting the `defaultValue` prop on the `<input>` element. This was because the builtin type definitions say that `defaultValue` cannot be `null`, but some of our resource fields can be `null`. I did a bit of debugging in a live browser, and it looks like if you pass in a `null`, the net effect is that it basically gets treated as the empty string, so I decided to explicitly coerce them to the empty string.

I did some light testing of this locally, and I think it works, but I can't honestly say that I've done any comprehensive testing, since there's so many possible scenarios to test.