### PR TITLE
Migrate Edit Page to TypeScript Part 4

### DIFF
--- a/app/components/edit/EditServices.tsx
+++ b/app/components/edit/EditServices.tsx
@@ -1,6 +1,18 @@
 import React from "react";
-import PropTypes from "prop-types";
 import ProvidedService from "./ProvidedService";
+
+import type { InternalFlattenedService } from "../../pages/OrganizationEditPage";
+
+type Props = {
+  addService: () => void;
+  editServiceById: (
+    id: number,
+    changes: Partial<InternalFlattenedService>
+  ) => void;
+  handleDeactivation: (type: "resource" | "service", id: number) => void;
+  services: InternalFlattenedService[];
+  resourceAddresses: Record<any, any>[];
+};
 
 const EditServices = ({
   addService,
@@ -8,7 +20,7 @@ const EditServices = ({
   handleDeactivation,
   services,
   resourceAddresses,
-}) => (
+}: Props) => (
   <li className="edit--section--list--item">
     <ul className="edit--section--list--item--sublist edit--service--list">
       {services.map((service, index) => (
@@ -33,12 +45,5 @@ const EditServices = ({
     </button>
   </li>
 );
-
-EditServices.propTypes = {
-  handleDeactivation: PropTypes.func.isRequired,
-  editServiceById: PropTypes.func.isRequired,
-  addService: PropTypes.func.isRequired,
-  services: PropTypes.array.isRequired,
-};
 
 export default EditServices;

--- a/app/components/edit/EditSidebar.tsx
+++ b/app/components/edit/EditSidebar.tsx
@@ -1,10 +1,19 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { withRouter } from "react-router-dom";
+import type { RouteComponentProps } from "react-router";
 
+import type {
+  InternalOrganization,
+  InternalTopLevelService,
+} from "../../pages/OrganizationEditPage";
 import styles from "./EditSidebar.module.scss";
 
-const SaveButton = ({ children, disabled, onClick }) => (
+type SaveButtonProps = {
+  children: React.ReactNode;
+  disabled: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+const SaveButton = ({ children, disabled, onClick }: SaveButtonProps) => (
   <button
     type="button"
     className={styles.actionButton}
@@ -15,6 +24,19 @@ const SaveButton = ({ children, disabled, onClick }) => (
   </button>
 );
 
+type EditSidebarProps = RouteComponentProps & {
+  addService: () => void;
+  certifyHAP: () => void;
+  createResource: () => void;
+  handleCancel: () => void;
+  handleDeactivation: (type: "resource" | "service", id: number) => void;
+  handleSubmit: React.MouseEventHandler<HTMLButtonElement>;
+  newResource: boolean;
+  newServices?: Record<number, InternalTopLevelService>;
+  resource: InternalOrganization;
+  submitting: boolean;
+};
+
 const EditSidebar = ({
   addService,
   certifyHAP,
@@ -23,25 +45,32 @@ const EditSidebar = ({
   handleDeactivation,
   handleSubmit,
   newResource,
-  newServices,
+  newServices = {},
   resource,
   submitting,
-}: any) => {
-  let actionButtons = [
-    <SaveButton key="submit" disabled={submitting} onClick={handleSubmit}>
-      Save Changes
-    </SaveButton>,
-    <button
-      type="button"
-      className={`${styles.actionButton} ${styles.deactivate}`}
-      key="deactive"
-      disabled={submitting || resource.status === "inactive"}
-      onClick={() => handleDeactivation("resource", resource.id)}
-    >
-      Deactivate
-    </button>,
-  ];
-  if (newResource) {
+}: EditSidebarProps) => {
+  let actionButtons: JSX.Element[];
+  if (!newResource) {
+    const resourceID = resource.id;
+    if (resourceID === undefined)
+      throw new Error(
+        "resource.id should not be undefined for existing resource"
+      );
+    actionButtons = [
+      <SaveButton key="submit" disabled={submitting} onClick={handleSubmit}>
+        Save Changes
+      </SaveButton>,
+      <button
+        type="button"
+        className={`${styles.actionButton} ${styles.deactivate}`}
+        key="deactive"
+        disabled={submitting || resource.status === "inactive"}
+        onClick={() => handleDeactivation("resource", resourceID)}
+      >
+        Deactivate
+      </button>,
+    ];
+  } else {
     actionButtons = [
       <SaveButton key="submit" disabled={submitting} onClick={createResource}>
         Submit
@@ -123,24 +152,5 @@ const EditSidebar = ({
     </nav>
   );
 };
-
-EditSidebar.defaultProps = {
-  newServices: {},
-};
-
-// Leaving propTypes definitions here for reference. Remove when we add proper
-// TypeScript types to this component's props.
-//
-// EditSidebar.propTypes = {
-//   certifyHAP: PropTypes.func.isRequired,
-//   createResource: PropTypes.func.isRequired,
-//   handleDeactivation: PropTypes.func.isRequired,
-//   handleCancel: PropTypes.func.isRequired,
-//   handleSubmit: PropTypes.func.isRequired,
-//   newResource: PropTypes.bool.isRequired,
-//   newServices: PropTypes.object,
-//   resource: PropTypes.object.isRequired,
-//   submitting: PropTypes.bool.isRequired,
-// };
 
 export default withRouter(EditSidebar);

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -546,7 +546,7 @@ interface InternalOrganizationService extends Omit<Service, "addresses"> {
  * type that is mostly like InternalOrganizationServices except that the `id`
  * field is required.
  */
-interface InternalFlattenedService extends InternalTopLevelService {
+export interface InternalFlattenedService extends InternalTopLevelService {
   id: number;
 }
 
@@ -948,11 +948,14 @@ class OrganizationEditPage extends React.Component<Props, State> {
 
   /** @method editServiceById
    * @description Updates the service with any changes made
-   * @param {number} id a unique identifier to find a service
-   * @param {object} service the service to be updated
-   * @returns {void}
+   * @param id a unique identifier to find a service
+   * @param service the service to be updated
+   * @returns
    */
-  editServiceById = (id, changes) => {
+  editServiceById = (
+    id: number,
+    changes: Partial<InternalTopLevelService>
+  ): void => {
     this.setState(({ services }) => {
       const oldService = services[id] || {};
       const newService = { ...oldService, ...changes };
@@ -966,7 +969,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
   /** @method addService
    * @description Creates a brand new service
    */
-  addService = () => {
+  addService = (): void => {
     const { services, latestServiceId } = this.state;
     const nextServiceId = latestServiceId - 1;
 

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -473,7 +473,7 @@ const getAddresses = (state) => {
  * - `services` is an array of `InternalService`s. See `InternalService`'s
  *   comments for more details.
  */
-interface InternalOrganization
+export interface InternalOrganization
   extends Partial<Omit<Organization, "schedule" | "services">> {
   schedule: Record<string, never> | Schedule;
   services?: InternalOrganizationService[];
@@ -487,7 +487,7 @@ interface InternalOrganization
  * few new properties. See documentation on the individual fields for more
  * information.
  */
-interface InternalTopLevelService
+export interface InternalTopLevelService
   extends Partial<Omit<Service, "addresses" | "schedule">> {
   /** References to addresses in the parent Organization.
    *
@@ -1281,7 +1281,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
       });
   }
 
-  handleDeactivation(type, id) {
+  handleDeactivation(type: "resource" | "service", id: number): void {
     const { history } = this.props;
     let confirmMessage: string | null = null;
     let path: string | null = null;
@@ -1535,7 +1535,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
 
     const showPrompt = inputsDirty && !submitting;
 
-    return !resource && !newResource ? (
+    return !resource ? (
       <Loader />
     ) : (
       <div className="edit">


### PR DESCRIPTION
Refs #1175.

This is the next chunk of work I've done to increase type strictness on the Edit Page. Most of these changes revolve around the Service type, which I actually had to split into three separate types (not including the one that already exists in `app/models/`!).

The complexity of the types is a reflection of the complexity of the code, and although this could probably be simplified in the future, I tried to make as few functional code changes as possible while adding type annotations to this code.

_Warning: there's a huge wall of text ahead, so apologies for not being able to describe these changes more succinctly._ I won't hold it against you if you don't read the rest of this PR description, and it might even be easier to review this PR if you start with the actual code diff and then only come back to this PR description to get some additional details.


## Four variations of the Service type

`Service`, this is defined in `app/models/Service.ts`, and this is supposed to be a reflection of what the API returns when we make a GET request to either the `/resources/` or the `/services/` routes.

`InternalService`, which I had just created in https://github.com/ShelterTechSF/askdarcel-web/pull/1236, was renamed to `InternalOrganizationService` to reflect the fact that this is the variant that appears nested on the `resource` state variable on the main `OrganizationEditPage` component. This is a transformation of the API `Service` where we've removed the `addresses` field and replaced it with an `addressHandles` field. This transformation was done because otherwise, addresses could be duplicated between the Organization and the Service, so this effectively turns the duplicate Address objects under the Services into "pointers" or "handles".

`InternalTopLevelService` is a new type added in this PR, where it represents the type of the `services` state variable on the `OrganizationEditPage` component. In addition to also having the `addressHandles` transformation, it also has two new fields that never appear on either `Service` or `InternalOrganizationService`: `scheduleObj` and `shouldInheritScheduleFromParent`. `scheduleObj` is similar to the `schedule` field except its type is `InternalSchedule` rather than `Schedule` (the shape that comes directly from the API). Also, the `InternalTopLevelService`'s `schedule` field was modified such that it supports the [kind of strange shape it has when you create a new service](https://github.com/ShelterTechSF/askdarcel-web/blob/ed9352d00cfad52e0a303bbb9ddb76177c2fdb4c/app/pages/OrganizationEditPage.tsx#L916-L918), which is that it only has a `schedule_days` field with no elements in it. This does not satisfy the type of `Schedule`, so we have to make a special accommodation for it in the type of `InternalTopLevelService`. Lastly, almost all the fields on `InternalTopLevelService` are optional, since we generally only save _changes_ to a service here, rather than to the `InternalOrganizationService`, so in some places, it really acts more like a "diff" of changes to make to a Service rather than a fully-formed, self-contained Service. More on this in the final variant of Service I'll describe.

Finally, `InternalFlattenedService` is the return type of the `applyChanges()` function, which is [only ever called once](https://github.com/ShelterTechSF/askdarcel-web/blob/ed9352d00cfad52e0a303bbb9ddb76177c2fdb4c/app/pages/OrganizationEditPage.tsx#L1477-L1481), and in that one place, it only gets called on the `InternalOrganizationService`s and the `InternalTopLevelService`s. This basically applies all the "diff"s represented by the `InternalTopLevelService`s to the `InternalOrganizationService`s, although there are some subtleties related to adding brand new services or deleting services. It's this flattened view of a Service that generally gets passed into other components on this page.


## Other Functional Changes to the Code

Aside from the variations of the Service type I defined above, I wanted to call attention to two functional changes that I made to the code in order for it to pass type checking.

In the `render()` method of the `OrganizationEditPage`, I changed the conditional expression that guarded the `<Loader>` component from `!resource && !newResource` to `!resource`. The reason for this is because the fact that `resource` was not falsy couldn't be propagated to the else branch, since it could possibly be null in the case where `newResource` is `true`. However, we only ever set [`newResource`](https://github.com/ShelterTechSF/askdarcel-web/blob/ed9352d00cfad52e0a303bbb9ddb76177c2fdb4c/app/pages/OrganizationEditPage.tsx#L569-L570) to true in one place, which is in the `componentDidMount()` hook and only when we're on the `/new/` route, and in that one place, we simultaneously set `resource` to a non-falsy value. Since the case where `resource == null/undefined && newResource == true` is impossible, we can eliminate that from the loader check and then allow TypeScript to properly infer that `resource` is not null in the other case.

The second functional change I made was in the `applyChanges()` method, where I had to stare at the code a lot and experiment with type annotations that TypeScript would yell at more for until I finally realized that one of the `if` branches in that method was impossible to reach. That function is responsible for applying the diffs represented by the `InternalTopLevelService`s ("diffs") to the `InternalOrganizationService`s ("base items"), and there is a particular expression where we `.map()` over the base items and check if the ID matches the ID of some diff. Due to how we create and modify these objects outside of `applyChanges()`, it should never be possible for us to encounter the case where we have a base item whose ID doesn't match some diff's ID. In other words, the diffs are always a superset of the services in the base items.

The original code would just return the base item unmodified, but I changed it to throw an exception. This was necessary in order to prove to the type checker that the returned values have a combination of the fields in `InternalOrganizationService` and `InternalTopLevelService`. This is not a limitation of TypeScript or anything; the correctness of our code really depends on this fact being true, so if we ever returned the base item unmodified, it'd be missing some important fields added by the `InternalTopLevelService` (e.g. `scheduleObj`) and cause later code to fail.