### PR TITLE
Add GA4 Google Analytics tag to tracking code

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -72,10 +72,9 @@ export const App = () => {
   const [userLocation, setUserLocation] = useState<GeoCoordinates | null>(null);
 
   useEffect(() => {
-    getLocation()
-      .then((loc) => {
-        setUserLocation(loc);
-      });
+    getLocation().then((loc) => {
+      setUserLocation(loc);
+    });
 
     ReactGA.initialize(config.GOOGLE_ANALYTICS_ID);
     ReactGA_4.initialize(config.GOOGLE_ANALYTICS_GA4_ID);

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from "react";
+
+// Todo: Once GA sunsets the UA analytics tracking come July 2023, we can remove the "react-ga"
+// package and all references to it:
+// https://support.google.com/analytics/answer/12938611#zippy=%2Cin-this-article
 import ReactGA from "react-ga";
+import ReactGA_4 from "react-ga4";
+
 import Intercom from "react-intercom";
 import { Helmet } from "react-helmet-async";
 import { Redirect, Route, Switch, useHistory } from "react-router-dom";
@@ -69,17 +75,17 @@ export const App = () => {
     getLocation()
       .then((loc) => {
         setUserLocation(loc);
-      })
-      .catch((err) => {
-        console.log(
-          "Could not obtain location, defaulting to San Francisco.",
-          err
-        ); // eslint-disable-line no-console
       });
 
     ReactGA.initialize(config.GOOGLE_ANALYTICS_ID);
+    ReactGA_4.initialize(config.GOOGLE_ANALYTICS_GA4_ID);
     return history.listen((loc) => {
       const page = loc.pathname + loc.search;
+      ReactGA_4.send({
+        hitType: "pageview",
+        page,
+      });
+
       ReactGA.set({ page });
       ReactGA.pageview(page);
     });

--- a/app/config.ts
+++ b/app/config.ts
@@ -17,11 +17,11 @@ const config: Config = {
   ALGOLIA_APPLICATION_ID: CONFIG.ALGOLIA_APPLICATION_ID,
   ALGOLIA_INDEX_PREFIX: CONFIG.ALGOLIA_INDEX_PREFIX,
   ALGOLIA_READ_ONLY_API_KEY: CONFIG.ALGOLIA_READ_ONLY_API_KEY,
-  GOOGLE_ANALYTICS_ID: // When GA sunsets Universal Analytics wit GA4 in July 2023, this prop can be removed
-    process.env.NODE_ENV === "production"
-      ? "UA-116318550-1"
-      : "UA-116318550-2",
-  GOOGLE_ANALYTICS_GA4_ID: process.env.NODE_ENV === "production" ? "G-91R319RLN0" : "G-NSEENP26HN",
+  // When GA sunsets Universal Analytics wit GA4 in July 2023, this prop can be removed
+  GOOGLE_ANALYTICS_ID:
+    process.env.NODE_ENV === "production" ? "UA-116318550-1" : "UA-116318550-2",
+  GOOGLE_ANALYTICS_GA4_ID:
+    process.env.NODE_ENV === "production" ? "G-91R319RLN0" : "G-NSEENP26HN",
   GOOGLE_API_KEY: CONFIG.GOOGLE_API_KEY,
   INTERCOM_APP_ID: "w50oz3tb",
   LINKSF_DOMAIN: CONFIG.LINKSF_DOMAIN,

--- a/app/config.ts
+++ b/app/config.ts
@@ -4,6 +4,7 @@ declare global {
 
 interface Config {
   GOOGLE_ANALYTICS_ID: string;
+  GOOGLE_ANALYTICS_GA4_ID: string;
   LINKSF_DOMAIN: string;
   MOHCD_DOMAIN: string;
   MOHCD_SUBDOMAIN: string;
@@ -16,11 +17,11 @@ const config: Config = {
   ALGOLIA_APPLICATION_ID: CONFIG.ALGOLIA_APPLICATION_ID,
   ALGOLIA_INDEX_PREFIX: CONFIG.ALGOLIA_INDEX_PREFIX,
   ALGOLIA_READ_ONLY_API_KEY: CONFIG.ALGOLIA_READ_ONLY_API_KEY,
-  GOOGLE_ANALYTICS_ID:
-    process.env.NODE_ENV === "production" ||
-    window.location.host === "www.askdarcel.org"
+  GOOGLE_ANALYTICS_ID: // When GA sunsets Universal Analytics wit GA4 in July 2023, this prop can be removed
+    process.env.NODE_ENV === "production"
       ? "UA-116318550-1"
-      : "UA-116318550-2", // TODO This should probably be in whitelabel
+      : "UA-116318550-2",
+  GOOGLE_ANALYTICS_GA4_ID: process.env.NODE_ENV === "production" ? "G-91R319RLN0" : "G-NSEENP26HN",
   GOOGLE_API_KEY: CONFIG.GOOGLE_API_KEY,
   INTERCOM_APP_ID: "w50oz3tb",
   LINKSF_DOMAIN: CONFIG.LINKSF_DOMAIN,

--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.tsx
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from "react";
 import { Redirect, useHistory, useRouteMatch } from "react-router-dom";
 import qs from "qs";
+
+// Todo: Once GA sunsets the UA analytics tracking come July 2023, we can remove the "react-ga"
+// package and all references to it:
+// https://support.google.com/analytics/answer/12938611#zippy=%2Cin-this-article
 import ReactGA from "react-ga";
+import ReactGA_4 from "react-ga4";
 
 import {
   useEligibilitiesForCategory,
@@ -242,6 +247,11 @@ const Content = ({
       const eligibilitiesRefinements =
         searchState.refinementList.eligibilities.join("; ") || "NONE";
       ReactGA.event({
+        category: "Resource Inquiry",
+        action: "Refined Resource Inquiry",
+        label: `${categorySlug} Inquiry | Category Refinements: ${categoriesRefinements} | Eligibility Refinements: ${eligibilitiesRefinements}`,
+      });
+      ReactGA_4.event({
         category: "Resource Inquiry",
         action: "Refined Resource Inquiry",
         label: `${categorySlug} Inquiry | Category Refinements: ${categoriesRefinements} | Eligibility Refinements: ${eligibilitiesRefinements}`,

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from "react";
 import { useHistory, useRouteMatch } from "react-router-dom";
 import qs from "qs";
+
+// Todo: Once GA sunsets the UA analytics tracking come July 2023, we can remove the "react-ga"
+// package and all references to it:
+// https://support.google.com/analytics/answer/12938611#zippy=%2Cin-this-article
 import ReactGA from "react-ga";
+import ReactGA_4 from "react-ga4";
 
 import { Button } from "components/ui/inline/Button/Button";
 import { Section } from "components/ucsf/Section/Section";
@@ -102,6 +107,11 @@ const Page = () => {
       const search = qs.stringify(searchState, { encodeValuesOnly: true });
 
       ReactGA.event({
+        category: "UCSF Resource Inquiry",
+        action: "Refined UCSF Resource Inquiry",
+        label: `${slug} Inquiry | Category Refinements: ${categoriesRefinements} | Eligibility Refinements: ${eligibilitiesRefinements}`,
+      });
+      ReactGA_4.event({
         category: "UCSF Resource Inquiry",
         action: "Refined UCSF Resource Inquiry",
         label: `${slug} Inquiry | Category Refinements: ${categoriesRefinements} | Eligibility Refinements: ${eligibilitiesRefinements}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-cookie": "^4.1.1",
         "react-dom": "^16.8.6",
         "react-ga": "^2.4.1",
+        "react-ga4": "^2.1.0",
         "react-helmet-async": "^1.0.4",
         "react-hot-loader": "^4.12.12",
         "react-icons": "^4.2.0",
@@ -22533,6 +22534,11 @@
         "prop-types": "^15.6.0",
         "react": "^15.6.2 || ^16.0"
       }
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-helmet-async": {
       "version": "1.3.0",
@@ -46174,6 +46180,11 @@
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
       "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==",
       "requires": {}
+    },
+    "react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "react-helmet-async": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-cookie": "^4.1.1",
     "react-dom": "^16.8.6",
     "react-ga": "^2.4.1",
+    "react-ga4": "^2.1.0",
     "react-helmet-async": "^1.0.4",
     "react-hot-loader": "^4.12.12",
     "react-icons": "^4.2.0",


### PR DESCRIPTION
Our `react-ga` package [has no plans to support the new GA 4 property](https://github.com/react-ga/react-ga/issues/460), so I needed to use a package that does. Come July when Google sunsets its UA tracking ,we can remove the `react-ga` package and its references.
