### PR TITLE
Add timeout to GA page view event to delay event trigger for a reason…

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -88,7 +88,7 @@ export const App = () => {
 
         ReactGA.set({ page });
         ReactGA.pageview(page);
-      }, 500)
+      }, 500);
     });
   }, [history]);
 

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -80,6 +80,9 @@ export const App = () => {
     ReactGA_4.initialize(config.GOOGLE_ANALYTICS_GA4_ID);
     return history.listen((loc) => {
       setTimeout(() => {
+        /* We call setTimeout here to give our views time to update the document title before
+           GA sends its page view event
+        */
         const page = loc.pathname + loc.search;
         ReactGA_4.send({
           hitType: "pageview",

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -79,14 +79,16 @@ export const App = () => {
     ReactGA.initialize(config.GOOGLE_ANALYTICS_ID);
     ReactGA_4.initialize(config.GOOGLE_ANALYTICS_GA4_ID);
     return history.listen((loc) => {
-      const page = loc.pathname + loc.search;
-      ReactGA_4.send({
-        hitType: "pageview",
-        page,
-      });
+      setTimeout(() => {
+        const page = loc.pathname + loc.search;
+        ReactGA_4.send({
+          hitType: "pageview",
+          page,
+        });
 
-      ReactGA.set({ page });
-      ReactGA.pageview(page);
+        ReactGA.set({ page });
+        ReactGA.pageview(page);
+      }, 500)
     });
   }, [history]);
 

--- a/app/components/listing/ServiceDetails.tsx
+++ b/app/components/listing/ServiceDetails.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
+import { Link } from "react-router-dom";
 import { Notes } from "./Notes";
 import { Service, RecurringSchedule } from "../../models";
 
@@ -16,14 +17,10 @@ export const ServiceDetails = ({ service }: { service: Service }) => {
       id={`service-${service.id}`}
       data-cy="service-list-item"
     >
-      {/* <div className="service--meta disabled-feature">
-        <p><ServiceCategory category={service.category} /></p>
-        <p>updated {service.updated_at}</p>
-      </div> */}
       <h2 className="service--header">
-        <a href={`/services/${service.id}`} translate="no">
+        <Link to={{ pathname: `/services/${service.id}` }} translate="no">
           {service.name}
-        </a>
+        </Link>
       </h2>
       <ReactMarkdown
         className="rendered-markdown service--description"

--- a/app/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/app/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -91,12 +91,14 @@ const InnerSearchResults = ({
   return (
     <div className={styles.container}>
       <Helmet>
-        <title>{`${searchState.query ?? 'Services'} in San Francisco | ${
+        <title>{`${searchState.query ?? "Services"} in San Francisco | ${
           whiteLabel.title
         }`}</title>
         <meta
           name="description"
-          content={`A list of ${searchState.query ?? 'services'} in San Francisco`}
+          content={`A list of ${
+            searchState.query ?? "services"
+          } in San Francisco`}
         />
       </Helmet>
       <Header

--- a/app/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/app/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
 import algoliasearch from "algoliasearch/lite";
 import { InstantSearch, Configure, SearchBox } from "react-instantsearch/dom";
 import qs, { ParsedQs } from "qs";
 
-import { GeoCoordinates, useAppContext } from "utils";
+import { GeoCoordinates, useAppContext, whiteLabel } from "utils";
 
 import { Loader } from "components/ui";
 import SearchResults from "components/search/SearchResults/SearchResults";
@@ -89,6 +90,15 @@ const InnerSearchResults = ({
 
   return (
     <div className={styles.container}>
+      <Helmet>
+        <title>{`${searchState.query ?? 'Services'} in San Francisco | ${
+          whiteLabel.title
+        }`}</title>
+        <meta
+          name="description"
+          content={`A list of ${searchState.query ?? 'services'} in San Francisco`}
+        />
+      </Helmet>
       <Header
         resultsTitle={searchState.query || ""}
         expandList={expandList}

--- a/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.tsx
+++ b/app/pages/ServiceDiscoveryForm/ServiceDiscoveryForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Redirect, useHistory, useRouteMatch } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
 import qs from "qs";
 
 // Todo: Once GA sunsets the UA analytics tracking come July 2023, we can remove the "react-ga"
@@ -8,6 +9,7 @@ import qs from "qs";
 import ReactGA from "react-ga";
 import ReactGA_4 from "react-ga4";
 
+import { whiteLabel } from "utils";
 import {
   useEligibilitiesForCategory,
   useSubcategoriesForCategory,
@@ -89,7 +91,7 @@ const InnerServiceDiscoveryForm = ({
   selectedSubcategory: number | null;
   setSelectedSubcategory: (item: number | null) => void;
 }) => {
-  const { steps, slug: categorySlug } = category;
+  const { name, steps, slug: categorySlug } = category;
 
   const [currentStep, setCurrentStep] = useState(0);
   const history = useHistory();
@@ -128,6 +130,13 @@ const InnerServiceDiscoveryForm = ({
 
   return (
     <>
+      <Helmet>
+        <title>{`Search for ${name} in San Francisco | ${whiteLabel.title}`}</title>
+        <meta
+          name="description"
+          content={`Find ${name} in San Francisco that meet your needs`}
+        />
+      </Helmet>
       <Header onGoBack={goBack} />
       <Content
         steps={steps}

--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.tsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.tsx
@@ -148,7 +148,10 @@ const InnerServiceDiscoveryResults = ({
     <div className={styles.container}>
       <Helmet>
         <title>{`${categoryName} in San Francisco | ${whiteLabel.title}`}</title>
-        <meta name="description" content={`A list of ${categoryName} in San Francisco`} />
+        <meta
+          name="description"
+          content={`A list of ${categoryName} in San Francisco`}
+        />
       </Helmet>
       <Header
         resultsTitle={categoryName}

--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.tsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.tsx
@@ -2,11 +2,12 @@ import React, { useState, useEffect } from "react";
 import algoliasearch from "algoliasearch/lite";
 import { InstantSearch, Configure } from "react-instantsearch/dom";
 import qs from "qs";
+import { Helmet } from "react-helmet-async";
 
 import { match as Match, RouteComponentProps } from "react-router-dom";
 
 import * as dataService from "utils/DataService";
-import { useAppContext } from "utils";
+import { useAppContext, whiteLabel } from "utils";
 
 import { Loader } from "components/ui";
 import SearchResults from "components/search/SearchResults/SearchResults";
@@ -145,6 +146,10 @@ const InnerServiceDiscoveryResults = ({
 
   return (
     <div className={styles.container}>
+      <Helmet>
+        <title>{`${categoryName} in San Francisco | ${whiteLabel.title}`}</title>
+        <meta name="description" content={`A list of ${categoryName} in San Francisco`} />
+      </Helmet>
       <Header
         resultsTitle={categoryName}
         expandList={expandList}

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -169,7 +169,7 @@ const defaultWhiteLabel: WhiteLabelSite = {
   ...whiteLabelDefaults,
   intercom: true,
   siteUrl: "https://askdarcel.org",
-  title: "AskDarcel",
+  title: "SF Service Guide",
   showReportCrisis: true,
 } as const;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-dom": "^16.8.6",
         "react-ga": "^2.4.1",
         "react-ga4": "^2.1.0",
-        "react-helmet-async": "^1.0.4",
+        "react-helmet-async": "^1.3.0",
         "react-hot-loader": "^4.12.12",
         "react-icons": "^4.2.0",
         "react-instantsearch": "^5.0.1",
@@ -22544,7 +22544,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
       "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "invariant": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^16.8.6",
     "react-ga": "^2.4.1",
     "react-ga4": "^2.1.0",
-    "react-helmet-async": "^1.0.4",
+    "react-helmet-async": "^1.3.0",
     "react-hot-loader": "^4.12.12",
     "react-icons": "^4.2.0",
     "react-instantsearch": "^5.0.1",


### PR DESCRIPTION
…able period of time so that our Helmet package will have time to update the page title.

I add a 500ms delay to our GA page view event code to give time for our page titles to resolve prior to sending the event.  I also updated our Helmet package to see if it would fix things. It did not but I decided updating it can't hurt so included it in this PR. We have already been using the forked version of Helmet.

I also added more descriptive page titles to our search pages. 

Lastly, I changed our whitelabel default title from AskDarcel, which is only displayed locally, to SF Service Guide. I think we may have outgrown this title, and it could be confusing for newer devs. Any objections here?