### PR TITLE
Migrate Edit Page to TypeScript Part 5

### DIFF
--- a/app/components/edit/EditServiceChildCollection.tsx
+++ b/app/components/edit/EditServiceChildCollection.tsx
@@ -31,7 +31,7 @@ export const EditServiceChildCollection = <T extends CollectionItem>({
   buttonText,
   propertyKeyName,
 }: {
-  initialCollectionData: any[];
+  initialCollectionData: any[] | undefined;
   handleCollectionChange: (field: string, value: T[]) => void;
   CollectionItemComponent: FC<ComponentProps>;
   label: string;

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -8,6 +8,7 @@ import { AddressListItem } from "./EditAddress";
 import EditPatientHandout from "./EditPatientHandout";
 import { EditServiceChildCollection } from "./EditServiceChildCollection";
 import type { Schedule } from "../../models";
+import type { InternalFlattenedService } from "../../pages/OrganizationEditPage";
 
 import s from "./ProvidedService.module.scss";
 
@@ -52,9 +53,9 @@ export interface InternalSchedule {
  * Returns an InternalSchedule.
  */
 const buildScheduleDays = (
-  schedule: Schedule | undefined
+  schedule: Schedule | { schedule_days: never[] } | undefined
 ): InternalSchedule => {
-  const scheduleId = schedule ? schedule.id : null;
+  const scheduleId = schedule && "id" in schedule ? schedule.id : null;
   const currSchedule: Partial<InternalSchedule> = {};
 
   const is24Hours = {
@@ -220,13 +221,24 @@ const TEXT_AREAS = [
   },
 ];
 
+type ProvidedServiceProps = {
+  editServiceById: (
+    id: number,
+    changes: Partial<InternalFlattenedService>
+  ) => void;
+  handleDeactivation: (type: "resource" | "service", id: number) => void;
+  index: number;
+  service: InternalFlattenedService;
+  resourceAddresses: Record<any, any>[];
+};
+
 const ProvidedService = ({
   editServiceById,
   handleDeactivation,
   index,
   service,
   resourceAddresses,
-}) => {
+}: ProvidedServiceProps) => {
   const handleChange = (field, value) => {
     const { id } = service;
     editServiceById(id, { id, [field]: value });
@@ -387,7 +399,9 @@ const ProvidedService = ({
           canInheritFromParent
           shouldInheritFromParent={service.shouldInheritScheduleFromParent}
           setShouldInheritFromParent={setShouldInheritScheduleFromParent}
-          scheduleId={service.schedule.id}
+          scheduleId={
+            "id" in service.schedule ? service.schedule.id : undefined
+          }
           scheduleDaysByDay={service.scheduleObj}
           handleScheduleChange={(value) => handleChange("scheduleObj", value)}
         />
@@ -408,28 +422,6 @@ const ProvidedService = ({
       </ul>
     </li>
   );
-};
-
-ProvidedService.propTypes = {
-  service: PropTypes.shape({
-    id: PropTypes.number,
-    fee: PropTypes.string,
-    categories: PropTypes.array,
-    notes: PropTypes.array,
-    schedule: PropTypes.object,
-    documents: PropTypes.array,
-    eligibilities: PropTypes.array,
-    email: PropTypes.string,
-    instructions: PropTypes.array,
-    name: PropTypes.string,
-    required_documents: PropTypes.string,
-    application_process: PropTypes.string,
-    long_description: PropTypes.string,
-    shouldInheritScheduleFromParent: PropTypes.bool.isRequired,
-  }).isRequired,
-  handleDeactivation: PropTypes.func.isRequired,
-  editServiceById: PropTypes.func.isRequired,
-  index: PropTypes.number.isRequired,
 };
 
 export default ProvidedService;

--- a/app/models/Service.ts
+++ b/app/models/Service.ts
@@ -11,6 +11,11 @@ import {
   Program,
 } from "./Meta";
 
+export interface Instruction {
+  id: number;
+  instruction: string;
+}
+
 // A Service is provided by an Organization
 export interface Service {
   id: number;
@@ -22,10 +27,12 @@ export interface Service {
   categories: Category[];
   certified_at: string | null;
   certified: boolean;
+  documents: unknown[];
   eligibilities: Eligibility[];
   email: string | null;
   featured: boolean | null;
   fee: string | null;
+  instructions: Instruction[];
   interpretation_services: string | null;
   long_description: string;
   notes: Note[];


### PR DESCRIPTION
Refs #1175

Major Edit: The original version that I submitted as a PR here was incorrect and was causing the Edit Page to completely break. I've pushed up a new version to this branch, and I've rewritten this PR description to reflect the new changes.

This adds TypeScript type annotations to the ProvidedService component.

In order for the types to validate, this required modifying the definition of InternalFlattenedService to make the `schedule` property required. This appears to be true in practice, where either the `schedule` property is defined by the original API response, or it gets set by the frontend code when creating a new Service, so there shouldn't be a case where it is undefined.

This adds an additional runtime check to the `applyChanges()` method to assert that the final, flattened service indeed has a `schedule` property.