### PR TITLE
Unset banner content alignment in mobile view

### DIFF
--- a/app/components/ui/Banner.module.scss
+++ b/app/components/ui/Banner.module.scss
@@ -29,6 +29,7 @@
   @media screen and (max-width: $break-tablet-s) {
     width: 96%;
     gap: 12px;
+    align-items: unset;
   }
 }
 

--- a/app/components/ui/Banner.module.scss
+++ b/app/components/ui/Banner.module.scss
@@ -25,17 +25,19 @@
   display: grid;
   grid-template-columns: 24px 1fr;
   gap: 30px;
-  align-items: center;
   @media screen and (max-width: $break-tablet-s) {
     width: 96%;
     gap: 12px;
-    align-items: unset;
   }
 }
 
 .alertIcon {
   width: 24px;
   height: 24px;
+  margin-top: 2px;
+  @media screen and (max-width: $break-tablet-s) {
+    margin-top: 0;
+  }
 }
 
 .bannerLink {


### PR DESCRIPTION
Changing the property `align-items: unset` in the mobile view top aligns the icon. However, if this is not the best implementation I will take a look at the resource provided again.