### PR TITLE
Expose activate function on edit page when resource is deactivated

### DIFF
--- a/app/components/edit/EditServiceChildCollection.tsx
+++ b/app/components/edit/EditServiceChildCollection.tsx
@@ -31,7 +31,7 @@ export const EditServiceChildCollection = <T extends CollectionItem>({
   buttonText,
   propertyKeyName,
 }: {
-  initialCollectionData: any[];
+  initialCollectionData: any[] | undefined;
   handleCollectionChange: (field: string, value: T[]) => void;
   CollectionItemComponent: FC<ComponentProps>;
   label: string;

--- a/app/components/edit/EditSidebar.tsx
+++ b/app/components/edit/EditSidebar.tsx
@@ -56,17 +56,19 @@ const EditSidebar = ({
   const handleActivation = (id: number): void => {
     /* eslint-disable no-alert */
     if (window.confirm("Are you sure you want to reactivate this resource?")) {
-      dataService.post(`/api/resources/${resource.id}/change_requests`, {
-        change_request: { status: "approved" },
-      }).then(() => {
-        alert(
-          "The resource has been activated. Thank you for your assistance!"
-        );
-        history.go(0);
-      });
+      dataService
+        .post(`/api/resources/${resource.id}/change_requests`, {
+          change_request: { status: "approved" },
+        })
+        .then(() => {
+          alert(
+            "The resource has been activated. Thank you for your assistance!"
+          );
+          history.go(0);
+        });
     }
     /* eslint-enable no-alert */
-  }
+  };
 
   if (!newResource) {
     const resourceID = resource.id;
@@ -89,7 +91,7 @@ const EditSidebar = ({
             : handleDeactivation("resource", resourceID)
         }
       >
-        {`${resource.status === "inactive" ? 'Activate' : 'Deactivate'}`}
+        {`${resource.status === "inactive" ? "Activate" : "Deactivate"}`}
       </button>,
     ];
   } else {

--- a/app/components/edit/EditSidebar.tsx
+++ b/app/components/edit/EditSidebar.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { withRouter } from "react-router-dom";
+import { withRouter, useHistory } from "react-router-dom";
 import type { RouteComponentProps } from "react-router";
 
 import type {
   InternalOrganization,
   InternalTopLevelService,
 } from "../../pages/OrganizationEditPage";
+import * as dataService from "../../utils/DataService";
 import styles from "./EditSidebar.module.scss";
 
 type SaveButtonProps = {
@@ -49,7 +50,24 @@ const EditSidebar = ({
   resource,
   submitting,
 }: EditSidebarProps) => {
+  const history = useHistory();
   let actionButtons: JSX.Element[];
+
+  const handleActivation = (id: number): void => {
+    /* eslint-disable no-alert */
+    if (window.confirm("Are you sure you want to reactivate this resource?")) {
+      dataService.post(`/api/resources/${resource.id}/change_requests`, {
+        change_request: { status: "approved" },
+      }).then(() => {
+        alert(
+          "The resource has been activated. Thank you for your assistance!"
+        );
+        history.go(0);
+      });
+    }
+    /* eslint-enable no-alert */
+  }
+
   if (!newResource) {
     const resourceID = resource.id;
     if (resourceID === undefined)
@@ -64,10 +82,14 @@ const EditSidebar = ({
         type="button"
         className={`${styles.actionButton} ${styles.deactivate}`}
         key="deactive"
-        disabled={submitting || resource.status === "inactive"}
-        onClick={() => handleDeactivation("resource", resourceID)}
+        disabled={submitting}
+        onClick={() =>
+          resource.status === "inactive"
+            ? handleActivation(resourceID)
+            : handleDeactivation("resource", resourceID)
+        }
       >
-        Deactivate
+        {`${resource.status === "inactive" ? 'Activate' : 'Deactivate'}`}
       </button>,
     ];
   } else {

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -8,6 +8,7 @@ import { AddressListItem } from "./EditAddress";
 import EditPatientHandout from "./EditPatientHandout";
 import { EditServiceChildCollection } from "./EditServiceChildCollection";
 import type { Schedule } from "../../models";
+import type { InternalFlattenedService } from "../../pages/OrganizationEditPage";
 
 import s from "./ProvidedService.module.scss";
 
@@ -52,9 +53,9 @@ export interface InternalSchedule {
  * Returns an InternalSchedule.
  */
 const buildScheduleDays = (
-  schedule: Schedule | undefined
+  schedule: Schedule | { schedule_days: never[] } | undefined
 ): InternalSchedule => {
-  const scheduleId = schedule ? schedule.id : null;
+  const scheduleId = schedule && "id" in schedule ? schedule.id : null;
   const currSchedule: Partial<InternalSchedule> = {};
 
   const is24Hours = {
@@ -220,13 +221,24 @@ const TEXT_AREAS = [
   },
 ];
 
+type ProvidedServiceProps = {
+  editServiceById: (
+    id: number,
+    changes: Partial<InternalFlattenedService>
+  ) => void;
+  handleDeactivation: (type: "resource" | "service", id: number) => void;
+  index: number;
+  service: InternalFlattenedService;
+  resourceAddresses: Record<any, any>[];
+};
+
 const ProvidedService = ({
   editServiceById,
   handleDeactivation,
   index,
   service,
   resourceAddresses,
-}) => {
+}: ProvidedServiceProps) => {
   const handleChange = (field, value) => {
     const { id } = service;
     editServiceById(id, { id, [field]: value });
@@ -387,7 +399,9 @@ const ProvidedService = ({
           canInheritFromParent
           shouldInheritFromParent={service.shouldInheritScheduleFromParent}
           setShouldInheritFromParent={setShouldInheritScheduleFromParent}
-          scheduleId={service.schedule.id}
+          scheduleId={
+            "id" in service.schedule ? service.schedule.id : undefined
+          }
           scheduleDaysByDay={service.scheduleObj}
           handleScheduleChange={(value) => handleChange("scheduleObj", value)}
         />
@@ -408,28 +422,6 @@ const ProvidedService = ({
       </ul>
     </li>
   );
-};
-
-ProvidedService.propTypes = {
-  service: PropTypes.shape({
-    id: PropTypes.number,
-    fee: PropTypes.string,
-    categories: PropTypes.array,
-    notes: PropTypes.array,
-    schedule: PropTypes.object,
-    documents: PropTypes.array,
-    eligibilities: PropTypes.array,
-    email: PropTypes.string,
-    instructions: PropTypes.array,
-    name: PropTypes.string,
-    required_documents: PropTypes.string,
-    application_process: PropTypes.string,
-    long_description: PropTypes.string,
-    shouldInheritScheduleFromParent: PropTypes.bool.isRequired,
-  }).isRequired,
-  handleDeactivation: PropTypes.func.isRequired,
-  editServiceById: PropTypes.func.isRequired,
-  index: PropTypes.number.isRequired,
 };
 
 export default ProvidedService;

--- a/app/models/Service.ts
+++ b/app/models/Service.ts
@@ -11,6 +11,11 @@ import {
   Program,
 } from "./Meta";
 
+export interface Instruction {
+  id: number;
+  instruction: string;
+}
+
 // A Service is provided by an Organization
 export interface Service {
   id: number;
@@ -22,10 +27,12 @@ export interface Service {
   categories: Category[];
   certified_at: string | null;
   certified: boolean;
+  documents: unknown[];
   eligibilities: Eligibility[];
   email: string | null;
   featured: boolean | null;
   fee: string | null;
+  instructions: Instruction[];
   interpretation_services: string | null;
   long_description: string;
   notes: Note[];

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -1329,15 +1329,18 @@ class OrganizationEditPage extends React.Component<Props, State> {
 
   handleDeactivation(type: "resource" | "service", id: number): void {
     const { history } = this.props;
-    let confirmMessage: string | undefined;
-    let path: string | null = null;
+    let confirmMessage: string;
+    let path: string;
     if (type === "resource") {
       confirmMessage = "Are you sure you want to deactivate this resource?";
       path = `/api/resources/${id}`;
     } else if (type === "service") {
       confirmMessage = "Are you sure you want to remove this service?";
       path = `/api/services/${id}`;
+    } else {
+      throw new Error(`Unexpected type: ${type}`);
     }
+
     // eslint-disable-next-line no-alert
     if (window.confirm(confirmMessage)) {
       if (id < 0) {
@@ -1348,7 +1351,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
         });
       } else {
         dataService
-          .APIDelete(path as string, { change_request: { status: "2" } } as any)
+          .APIDelete(path, { change_request: { status: "2" } } as any)
           .then(() => {
             // eslint-disable-next-line no-alert
             alert(

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -1329,17 +1329,17 @@ class OrganizationEditPage extends React.Component<Props, State> {
 
   handleDeactivation(type: "resource" | "service", id: number): void {
     const { history } = this.props;
-    let confirmMessage: string | null = null;
+    let confirmMessage: string | undefined;
     let path: string | null = null;
     if (type === "resource") {
-      confirmMessage = "Are you sure you want to deactive this resource?";
+      confirmMessage = "Are you sure you want to deactivate this resource?";
       path = `/api/resources/${id}`;
     } else if (type === "service") {
       confirmMessage = "Are you sure you want to remove this service?";
       path = `/api/services/${id}`;
     }
     // eslint-disable-next-line no-alert
-    if (window.confirm(confirmMessage as any) === true) {
+    if (window.confirm(confirmMessage)) {
       if (id < 0) {
         this.setState(({ deactivatedServiceIds }) => {
           const newDeactivatedServiceIds = new Set(deactivatedServiceIds);
@@ -1348,11 +1348,12 @@ class OrganizationEditPage extends React.Component<Props, State> {
         });
       } else {
         dataService
-          .APIDelete(path as any, { change_request: { status: "2" } } as any)
+          .APIDelete(path as string, { change_request: { status: "2" } } as any)
           .then(() => {
+            // eslint-disable-next-line no-alert
             alert(
               "Successful! \n \nIf this was a mistake, please let someone from the ShelterTech team know."
-            ); // eslint-disable-line no-alert
+            );
             if (type === "resource") {
               // Resource successfully deactivated. Redirect to home.
               history.push({ pathname: "/" });


### PR DESCRIPTION
Built this out as a way to test https://github.com/ShelterTechSF/askdarcel-web/pull/1247 changes and to fix something that's been in the backlog.

Displays activate button if resource has been deactivated and enable re-activating a resource. 

I also made a couple small TS changes to the handleDeactivate function for greater type specificity. Let me know if they get in your way all and ill revert them.

![image](https://user-images.githubusercontent.com/3012520/230673192-d0637c01-dcaa-4596-8dae-ba156a9cb4bd.png)
