### PR TITLE
Migrate Edit Page to TypeScript Part 6

### DIFF
--- a/app/components/edit/MultiSelectDropdown.tsx
+++ b/app/components/edit/MultiSelectDropdown.tsx
@@ -1,22 +1,67 @@
 import React, { Component, Fragment } from "react";
-import PropTypes from "prop-types";
 import Select from "react-select";
 import * as dataService from "../../utils/DataService";
 import "react-select/dist/react-select.css";
 
-function dataToSelectValue(data) {
+/** Base type for a selectable option.
+ *
+ * This is the type that external consumers of this component see, and it is
+ * used as both the props for selected items as well as the handler for changing
+ * the set of selected items.
+ */
+interface SelectOption {
+  id: number;
+  name: string;
+}
+
+/** Internal type for interfacing with react-select.
+ *
+ * react-select requires that its inputs have a label field and a value field,
+ * so we internally wrap a SelectOption with this internal type.
+ */
+interface InternalSelectOption<T extends SelectOption> {
+  label: string;
+  value: T;
+}
+
+/** Transform a SelectOption to an InternalSelectOption. */
+function dataToSelectValue<T extends SelectOption>(
+  data: T
+): InternalSelectOption<T> {
   return {
     label: data.name,
     value: data,
   };
 }
 
-class MultiSelectDropdown extends Component<any, any> {
-  constructor(props) {
+type Props<T extends SelectOption> = {
+  selectedItems?: T[];
+  handleSelectChange: (newSelections: T[]) => void;
+  optionsRoute: string;
+  label: string;
+};
+
+type State<T extends SelectOption> = {
+  selectedValues: InternalSelectOption<T>[];
+  options: InternalSelectOption<T>[];
+};
+
+/** A multi-select dropdown menu.
+ *
+ * T is the type of the selection options, where T must conform to the
+ * SelectOption interface.
+ */
+class MultiSelectDropdown<T extends SelectOption> extends Component<
+  Props<T>,
+  State<T>
+> {
+  constructor(props: Props<T>) {
     super(props);
 
+    const { selectedItems = [] } = props;
+
     this.state = {
-      selectedValues: props.selectedItems.map(dataToSelectValue),
+      selectedValues: selectedItems.map(dataToSelectValue),
       options: [],
     };
 
@@ -32,7 +77,7 @@ class MultiSelectDropdown extends Component<any, any> {
     });
   }
 
-  handleChange(newValues) {
+  handleChange(newValues: InternalSelectOption<T>[]) {
     const { handleSelectChange } = this.props;
     this.setState({ selectedValues: newValues }, () => {
       handleSelectChange(newValues.map((val) => val.value));
@@ -50,30 +95,21 @@ class MultiSelectDropdown extends Component<any, any> {
           multi
           value={selectedValues}
           options={options}
-          onChange={this.handleChange}
+          /* This `as any` type assertion is necessary to work around a lack a
+           * flexibility in @types/react-select's types. When the Select
+           * component is configured in `multi` mode, onChange will send an
+           * array of values, not an individual value, but the current types
+           * require us to define a change handler that can accept either a
+           * single value or an array of values. We're currently using an
+           * ancient version of react-select, so it's possible that this has
+           * been fixed in future versions, especially since it looks like
+           * react-select v2 is a complete rewrite, and v5 comes with native
+           * TypeScript types. */
+          onChange={this.handleChange as any}
         />
       </>
     );
   }
 }
-
-// Leaving propTypes definitions here for reference. Remove when we add proper
-// TypeScript types to this component's props.
-//
-// MultiSelectDropdown.propTypes = {
-//   selectedItems: PropTypes.arrayOf(
-//     PropTypes.shape({
-//       id: PropTypes.number.isRequired,
-//       name: PropTypes.string.isRequired,
-//     }).isRequired
-//   ),
-//   handleSelectChange: PropTypes.func.isRequired,
-//   optionsRoute: PropTypes.string.isRequired,
-//   label: PropTypes.string.isRequired,
-// };
-
-(MultiSelectDropdown as any).defaultProps = {
-  selectedItems: [],
-};
 
 export default MultiSelectDropdown;

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -108,7 +108,14 @@ const buildScheduleDays = (
 };
 export { buildScheduleDays };
 
-const InputField = ({ type, label, placeholder, value, setValue }) => (
+type InputFieldProps = {
+  type?: string,
+  label: string,
+  placeholder: string,
+  value?: string | null | undefined,
+  setValue: (x: string) => void,
+}
+const InputField = ({ type = "text", label, placeholder, value = "", setValue }: InputFieldProps) => (
   <>
     <label htmlFor="input">{label}</label>
     <input
@@ -119,19 +126,6 @@ const InputField = ({ type, label, placeholder, value, setValue }) => (
     />
   </>
 );
-
-InputField.propTypes = {
-  type: PropTypes.string,
-  label: PropTypes.string.isRequired,
-  placeholder: PropTypes.string.isRequired,
-  value: PropTypes.string,
-  setValue: PropTypes.func.isRequired, // A function to call when setting a new value
-};
-
-InputField.defaultProps = {
-  type: "text",
-  value: "",
-};
 
 const EditAddresses = ({ service, resourceAddresses, handleChange }) => {
   const selectableOptions = resourceAddresses.flatMap((address, handle) => {

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import EditNotes from "./EditNotes";
 import EditSchedule from "./EditSchedule";
 import MultiSelectDropdown from "./MultiSelectDropdown";
@@ -109,13 +108,19 @@ const buildScheduleDays = (
 export { buildScheduleDays };
 
 type InputFieldProps = {
-  type?: string,
-  label: string,
-  placeholder: string,
-  value?: string | null | undefined,
-  setValue: (x: string) => void,
-}
-const InputField = ({ type = "text", label, placeholder, value = "", setValue }: InputFieldProps) => (
+  type?: string;
+  label: string;
+  placeholder: string;
+  value?: string | null | undefined;
+  setValue: (x: string) => void;
+};
+const InputField = ({
+  type = "text",
+  label,
+  placeholder,
+  value = "",
+  setValue,
+}: InputFieldProps) => (
   <>
     <label htmlFor="input">{label}</label>
     <input

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/react-instantsearch": "^5.0.1",
         "@types/react-modal": "^3.12.0",
         "@types/react-router-dom": "^5.1.7",
+        "@types/react-select": "^1.3.0",
         "@typescript-eslint/eslint-plugin": "^5.30.0",
         "@typescript-eslint/parser": "^5.30.0",
         "babel-loader": "^8.2.0",
@@ -4995,6 +4996,15 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/react-select": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-1.3.0.tgz",
+      "integrity": "sha512-a9XMXDxYTCTFAHGdQ86hWlhdFWtcXCRGN3iXONB7w1vNcO9+J4CvAUsYgWNekIcMMNvpKK/dIrsVaTLSERnwig==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react/node_modules/csstype": {
@@ -33338,6 +33348,15 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "@types/react-select": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-1.3.0.tgz",
+      "integrity": "sha512-a9XMXDxYTCTFAHGdQ86hWlhdFWtcXCRGN3iXONB7w1vNcO9+J4CvAUsYgWNekIcMMNvpKK/dIrsVaTLSERnwig==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/responselike": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/react-instantsearch": "^5.0.1",
     "@types/react-modal": "^3.12.0",
     "@types/react-router-dom": "^5.1.7",
+    "@types/react-select": "^1.3.0",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "babel-loader": "^8.2.0",


### PR DESCRIPTION
Refs #1175.

This migrates a couple of generic editing widgets to TypeScript, `InputField` and `MultiSelectDropdown`. Most of the diff is in the latter, and most of the diff is actually just comments from me trying to reverse engineer what was going on. It looks like we have an expected shape for the objects being passed to `MultiSelectDropdown`, and then `react-select` imposes its own requirements on the values passed to it, so a good amount of our component is bridging the two formats.