### PR TITLE
Edit Page: Add strict type for ProvidedService's handleChange() function.

### DIFF
--- a/app/components/edit/EditServiceChildCollection.tsx
+++ b/app/components/edit/EditServiceChildCollection.tsx
@@ -29,15 +29,13 @@ export const EditServiceChildCollection = <T extends CollectionItem>({
   label,
   blankItemTemplate,
   buttonText,
-  propertyKeyName,
 }: {
   initialCollectionData: any[] | undefined;
-  handleCollectionChange: (field: string, value: T[]) => void;
+  handleCollectionChange: (value: T[]) => void;
   CollectionItemComponent: FC<ComponentProps>;
   label: string;
   blankItemTemplate: T;
   buttonText: string;
-  propertyKeyName: string;
 }) => {
   const [itemCollection, setItemCollection] = useState<T[]>(
     initialCollectionData || []
@@ -60,7 +58,7 @@ export const EditServiceChildCollection = <T extends CollectionItem>({
     ];
 
     setItemCollection(newCollection);
-    handleCollectionChange(propertyKeyName, newCollection);
+    handleCollectionChange(newCollection);
   };
 
   const removeItem = (index: number) => {
@@ -81,7 +79,7 @@ export const EditServiceChildCollection = <T extends CollectionItem>({
     }
 
     setItemCollection(newCollection);
-    handleCollectionChange(propertyKeyName, newCollection);
+    handleCollectionChange(newCollection);
   };
 
   const itemComponents = itemCollection.flatMap((item, index) => {

--- a/app/components/edit/EditServices.tsx
+++ b/app/components/edit/EditServices.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import ProvidedService from "./ProvidedService";
 
-import type { InternalFlattenedService } from "../../pages/OrganizationEditPage";
+import type {
+  InternalFlattenedService,
+  InternalTopLevelService,
+} from "../../pages/OrganizationEditPage";
 
 type Props = {
   addService: () => void;
   editServiceById: (
     id: number,
-    changes: Partial<InternalFlattenedService>
+    changes: Partial<InternalTopLevelService>
   ) => void;
   handleDeactivation: (type: "resource" | "service", id: number) => void;
   services: InternalFlattenedService[];

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -14,7 +14,7 @@ import EditSidebar from "../components/edit/EditSidebar";
 import { buildScheduleDays } from "../components/edit/ProvidedService";
 import type { InternalSchedule } from "../components/edit/ProvidedService";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
-import type { Organization, Schedule, Service } from "../models";
+import type { Instruction, Organization, Schedule, Service } from "../models";
 import * as dataService from "../utils/DataService";
 import "./OrganizationEditPage.scss";
 
@@ -503,6 +503,20 @@ export interface InternalOrganization
   services?: InternalOrganizationService[];
 }
 
+/** Internal version of an Instruction.
+ *
+ * This differs from the Instruction that comes from the API in that the
+ * `service_id` exists.
+ */
+interface InternalInstruction extends Instruction {
+  /** The ID of the service this instruction is attached to.
+   *
+   * TODO: Why is this needed? Shouldn't the InternalTopLevelService that this
+   * is attached to know its ID?
+   */
+  service_id: number;
+}
+
 /** Internal shape of a Service stored at the top-level of the component state.
  *
  * This differs from the Service coming from the API in that the `addresses`
@@ -518,6 +532,16 @@ export interface InternalTopLevelService
    * These are the numeric indexes into the Organization's `addresses` array.
    */
   addressHandles?: number[];
+
+  /** Changes to the instructions attached to the service.
+   *
+   * This differs from the `instructions` field on the API Service type in that
+   * this one also has a `service_id` field.
+   */
+  instructions?: InternalInstruction[];
+
+  /** Changes to the notes attached to this service. */
+  notesObj?: any;
 
   /** A Schedule attached to the service.
    *


### PR DESCRIPTION
Refs #1175.

The new type for `handleChange()` requires that:

1. the field name actually matches the name of a real field on the InternalTopLevelService type, and
2. the type of the new value matches the type of the field on the InternalTopLevelService type.

This gives us much stricter type checking, since different fields of InternalTopLevelService have very different types, and this allows us to actually check those types against the values that we are passing in.

Several of the other changes in this commit are to pass type checking, now that we're more strictly enforcing calls to `handleChange()`. Two notable changes are that we've removed the `propertyKeyName` prop to `EditServiceChildCollection`, since it can be baked into the `handleCollectionChange` function, and slightly changing the type of the `editServiceById` prop on the `EditServices` componen to accept an `InternalTopLevelService` rather than an `InternalFlattenedService`.