### PR TITLE
Add SFSeal footer to Our415, allow configuring whitelabel footer options

### DIFF
--- a/app/components/ui/Footer.scss
+++ b/app/components/ui/Footer.scss
@@ -1,3 +1,5 @@
+@import "../../styles/utils/_helpers.scss";
+
 .site-footer {
   display: flex;
   align-items: center;
@@ -51,7 +53,7 @@
   height: 100%;
   width: 1280px;
   margin: 0 auto;
-  @media screen and (max-width: 767px) {
+  @media screen and (max-width: $break-tablet-s) {
     width: auto;
   }
 }
@@ -62,7 +64,7 @@
   justify-content: center;
   img {
     width: 150px;
-    @media screen and (max-width: 767px) {
+    @media screen and (max-width: $break-tablet-s) {
       width: 120px;
     }
   }
@@ -96,7 +98,7 @@
 .site-footer__disclosure {
   text-align: center;
   padding-top: 80px;
-  @media screen and (max-width: 767px) {
+  @media screen and (max-width: $break-tablet-s) {
     display: block;
     text-align: center;
     padding: 25px;

--- a/app/components/ui/Footer.scss
+++ b/app/components/ui/Footer.scss
@@ -56,6 +56,18 @@
   }
 }
 
+.site-footer__sfseal-center {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  img {
+    width: 150px;
+    @media screen and (max-width: 767px) {
+      width: 120px;
+    }
+  }
+}
+
 .service-guide {
   flex: 2 2 0;
   display: flex;

--- a/app/components/ui/Footer.tsx
+++ b/app/components/ui/Footer.tsx
@@ -1,100 +1,110 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import whiteLabel from "../../utils/whitelabel";
+import SFSeal from "../../assets/img/sf-seal.png";
 import "./Footer.scss";
 
 export const Footer = () => {
-  const { title } = whiteLabel;
+  const { title, footerOptions } = whiteLabel;
 
   return (
     <footer className="site-footer" role="contentinfo">
       <div className="site-footer__content">
         <div className="site-footer__top">
-          <section className="service-guide">
-            <div className="service-guide__icon" />
-            <h1 className="service-guide__text">
-              <Link to="/">{title}</Link>
-            </h1>
-          </section>
-          <section className="site-footer__links">
-            <ul>
-              <h1>About Us</h1>
-              <li>
-                <Link to="/about">About SFSG</Link>
-              </li>
-              <li>
-                <a
-                  href="https://help.sfserviceguide.org"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  FAQ
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.sheltertech.org/get-involved"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Volunteer
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.sheltertech.org/donate"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Donate
-                </a>
-              </li>
-            </ul>
-            <ul>
-              <h1>Connect</h1>
-              <li>
-                <a href="mailto:info@sheltertech.org">Email</a>
-              </li>
-              <li>
-                <a
-                  href="https://www.facebook.com/ShelterTechOrg"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Facebook
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://twitter.com/sheltertechorg"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Twitter
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.instagram.com/shelter_tech"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Instagram
-                </a>
-              </li>
-            </ul>
-            <ul>
-              <h1>Legal</h1>
-              <li>
-                <Link to="/terms-of-service">Terms of Service</Link>
-              </li>
-              <li>
-                <Link to="/privacy-policy">Privacy Policy</Link>
-              </li>
-              {/* <li><a href="#">API Policy</a></li> */}
-            </ul>
-          </section>
+          {footerOptions.showTitle && (
+            <section className="service-guide">
+              <div className="service-guide__icon" />
+              <h1 className="service-guide__text">
+                <Link to="/">{title}</Link>
+              </h1>
+            </section>
+          )}
+          {footerOptions.showLinks && (
+            <section className="site-footer__links">
+              <ul>
+                <h1>About Us</h1>
+                <li>
+                  <Link to="/about">About SFSG</Link>
+                </li>
+                <li>
+                  <a
+                    href="https://help.sfserviceguide.org"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    FAQ
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.sheltertech.org/get-involved"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Volunteer
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.sheltertech.org/donate"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Donate
+                  </a>
+                </li>
+              </ul>
+              <ul>
+                <h1>Connect</h1>
+                <li>
+                  <a href="mailto:info@sheltertech.org">Email</a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.facebook.com/ShelterTechOrg"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Facebook
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://twitter.com/sheltertechorg"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Twitter
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.instagram.com/shelter_tech"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Instagram
+                  </a>
+                </li>
+              </ul>
+              <ul>
+                <h1>Legal</h1>
+                <li>
+                  <Link to="/terms-of-service">Terms of Service</Link>
+                </li>
+                <li>
+                  <Link to="/privacy-policy">Privacy Policy</Link>
+                </li>
+                {/* <li><a href="#">API Policy</a></li> */}
+              </ul>
+            </section>
+          )}
         </div>
+        {footerOptions.showSFSeal && (
+          <div className="site-footer__sfseal-center">
+            <img src={SFSeal} alt="City of San Francisco Seal" />
+          </div>
+        )}
         <div className="site-footer__disclosure">
           Created and maintained by ©{new Date().getFullYear()} ShelterTech, a
           501(c)(3) nonprofit | Made with love in San Francisco

--- a/app/pages/OrganizationListingPage.tsx
+++ b/app/pages/OrganizationListingPage.tsx
@@ -19,7 +19,7 @@ import {
   TableOfOpeningTimes,
   WebsiteRenderer,
 } from "../components/listing";
-import { Loader } from "../components/ui";
+import { Footer, Loader } from "../components/ui";
 import whitelabel from "../utils/whitelabel";
 import {
   fetchOrganization,
@@ -184,6 +184,7 @@ export const OrganizationListingPage = () => {
           </div>
         </div>
       </article>
+      {whitelabel.footerOptions.showOnListingPages && <Footer />}
     </div>
   );
 };

--- a/app/pages/ServiceListingPage.tsx
+++ b/app/pages/ServiceListingPage.tsx
@@ -15,7 +15,7 @@ import {
   TableOfContactInfo,
   TableOfOpeningTimes,
 } from "components/listing";
-import { Datatable, Loader } from "components/ui";
+import { Datatable, Footer, Loader } from "components/ui";
 import whiteLabel from "../utils/whitelabel";
 import {
   fetchService,
@@ -27,7 +27,8 @@ import {
   Service,
 } from "../models";
 
-const { title: whiteLabelTitle } = whiteLabel;
+const { title: whiteLabelTitle, footerOptions: whiteLabelFooterOpts } =
+  whiteLabel;
 
 // Page at /services/123
 export const ServiceListingPage = () => {
@@ -196,6 +197,7 @@ export const ServiceListingPage = () => {
           </div>
         </div>
       </article>
+      {whiteLabelFooterOpts.showOnListingPages && <Footer />}
     </div>
   );
 };

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -35,6 +35,12 @@ interface WhiteLabelSite {
    * [1]: https://cloud.google.com/translate/docs/languages
    */
   enabledTranslations: readonly string[];
+  footerOptions: {
+    showOnListingPages: boolean;
+    showTitle: boolean;
+    showLinks: boolean;
+    showSFSeal: boolean;
+  };
   homePageComponent: homepageComponentEnums;
   intercom: boolean;
   logoLinkDestination: string;
@@ -88,6 +94,12 @@ variety of other services, from education and legal aid to senior
 services and re-entry programs.`,
   aboutPageTitle: "SF Service Guide",
   enabledTranslations: ["en", "es", "tl", "zh-TW"],
+  footerOptions: {
+    showOnListingPages: false,
+    showTitle: true,
+    showLinks: true,
+    showSFSeal: false,
+  },
   homePageComponent: "HomePage",
   intercom: false,
   logoLinkDestination: "/",
@@ -126,6 +138,12 @@ const SFFamilies: WhiteLabelSite = {
   },
   ...whiteLabelDefaults,
   enabledTranslations: ["en", "es", "tl", "zh-TW", "vi", "ar", "ru"],
+  footerOptions: {
+    showOnListingPages: true,
+    showTitle: false,
+    showLinks: false,
+    showSFSeal: true,
+  },
   logoLinkDestination: "https://www.our415.org/",
   navLogoStyle: styles.navLogoSFFamilies,
   showBanner: false,


### PR DESCRIPTION
Our415 has requested that we add the City of San Francisco seal as a footer on their listing pages. (They don't want any of the other stuff on there, like links to ShelterTech social media.) Verified default whitelabel looks the same on home page and listing pages.

As for Our415:
![2023-04-30 22 49 36](https://user-images.githubusercontent.com/834403/235413451-9e4f22c6-44e1-4efc-b334-3d2cfb8caafd.gif)
