### PR TITLE
Adjust listing page side icons to more closely match figma designs

### DIFF
--- a/app/components/listing/ActionBar.scss
+++ b/app/components/listing/ActionBar.scss
@@ -5,32 +5,35 @@
 
   li {
     text-align: center;
-    border: 1px solid $color-grey2;
-    width: 128px;
-    height: 128px;
+    border: 1px solid $color-grey3;
+    width: 110px;
+    height: 110px;
 
     a {
       color: $color-textfade;
-      padding: $padding-default 0;
+      padding-top: $padding-default;
       display: flex;
+      gap: 12px;
       flex-direction: column;
-      width: 128px;
-      height: 128px;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
 
       img {
-        display: block;
-        margin: $padding-default $padding-default $padding-large;
-        font-size: $padding-xxlarge;
-        max-height: 72px;
+        height: 36px;
+        width: 36px;
+        margin: 0 auto;
       }
 
       span {
         font-size: $padding-large;
+        color: $color-grey6;
+        line-height: 1.2;
       }
     }
 
     &:hover {
-      background: $color-grey2;
+      background: $color-grey3;
       color: $color-title;
     }
   }

--- a/app/components/listing/ActionBar.scss
+++ b/app/components/listing/ActionBar.scss
@@ -1,8 +1,6 @@
 @import "../../styles/utils/helpers";
 
 .action-sidebar {
-  margin-bottom: $padding-xlarge 0;
-
   li {
     text-align: center;
     border: 1px solid $color-grey3;

--- a/app/components/listing/ActionBar.scss
+++ b/app/components/listing/ActionBar.scss
@@ -1,7 +1,7 @@
 @import "../../styles/utils/helpers";
 
 .action-sidebar {
-  margin: $padding-xlarge 0;
+  margin-bottom: $padding-xlarge 0;
 
   li {
     text-align: center;

--- a/app/pages/ServiceListingPage.tsx
+++ b/app/pages/ServiceListingPage.tsx
@@ -227,7 +227,7 @@ export const ServiceProgramDetails = ({
   service,
   organization,
 }: ServiceProgramDetailsProps) => (
-  <span>
+  <span className="service--program--details">
     A service
     {service.program ? ` in the ${service.program.name} program` : null}
     {" offered by "}

--- a/app/styles/components/_listing-page.scss
+++ b/app/styles/components/_listing-page.scss
@@ -34,8 +34,6 @@
   }
 
   header {
-    padding: $padding-xlarge 0;
-
     p {
       font-size: 13px;
     }
@@ -62,6 +60,10 @@
       padding: calc-em(20px) 0;
     }
   }
+}
+
+.service--program--details {
+  padding: $padding-default;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/app/styles/components/_listing-page.scss
+++ b/app/styles/components/_listing-page.scss
@@ -84,7 +84,6 @@
   display: flex;
   &--left {
     width: calc-em(660px);
-    border-right: 1px solid #ddd;
     padding-right: $padding-large;
     position: relative;
     display: flex;
@@ -95,7 +94,6 @@
   @include r_max($break-tablet-s) {
     margin-top: 0;
     &--left {
-      border-right: none;
       padding-right: 0;
     }
   }


### PR DESCRIPTION
Looking at the large side icons on listing pages finally drove me crazy, so I dug up an old [Figma design](https://www.figma.com/file/0X2KzS0qDEfZPRRm0TQyd5/SFSG-Website?type=design&node-id=1458-235&t=8TEfnDAk8dkge9k9-0) and updated the styles. There are many more differences between the design and our current listing page (and I don't know how current it is), but I find the side icons size to be so noticeable that I'd like to quickly fix them.

<img width="1155" alt="Screen Shot 2023-05-02 at 11 48 15 AM" src="https://user-images.githubusercontent.com/3012520/235758083-090389fa-525b-46a0-9a89-237e0742f366.png">


I also fixed a UI bug where the service description margin wasn't aligning with the service title (too far to the left, see example below):
<img width="936" alt="Screen Shot 2023-05-02 at 11 48 09 AM" src="https://user-images.githubusercontent.com/3012520/235757948-9b485662-3587-4a4e-a728-b930ffb20ea8.png">

