### PR TITLE
Edit Page: Add type annotations to EditNotes.

### DIFF
--- a/app/components/edit/EditNote.tsx
+++ b/app/components/edit/EditNote.tsx
@@ -1,8 +1,19 @@
 import React, { Component } from "react";
+import type { InternalNote, InternalNoteChanges } from "./EditNotes";
 
-/* eslint-disable react/no-multi-comp */
-class EditNote extends Component<any, any> {
-  constructor(props) {
+type Props = {
+  index: number;
+  note: InternalNote;
+  handleChange: (key: number, note: InternalNoteChanges) => void;
+  removeNote: (index: number) => void;
+};
+
+type State = {
+  note: InternalNoteChanges;
+};
+
+class EditNote extends Component<Props, State> {
+  constructor(props: Props) {
     super(props);
     this.state = {
       note: {},
@@ -10,7 +21,7 @@ class EditNote extends Component<any, any> {
     this.handleFieldChange = this.handleFieldChange.bind(this);
   }
 
-  handleFieldChange(e) {
+  handleFieldChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const { note } = this.state;
     const {
       handleChange,
@@ -23,7 +34,7 @@ class EditNote extends Component<any, any> {
   }
 
   render() {
-    let note: any = null;
+    let note: JSX.Element | null = null;
     const { index, note: currentNote, removeNote } = this.props;
     if (!currentNote.isRemoved) {
       note = (

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -13,6 +13,7 @@ import EditPhones from "../components/edit/EditPhones";
 import EditSidebar from "../components/edit/EditSidebar";
 import { buildScheduleDays } from "../components/edit/ProvidedService";
 import type { InternalSchedule } from "../components/edit/ProvidedService";
+import type { State as EditNotesState } from "../components/edit/EditNotes";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
 import type { Instruction, Organization, Schedule, Service } from "../models";
 import * as dataService from "../utils/DataService";
@@ -30,6 +31,11 @@ function assertDefined<T>(x: T | undefined, msg: string): asserts x is T {
 const ACTION_INSERT = "insert";
 const ACTION_EDIT = "edit";
 const ACTION_REMOVE = "remove";
+
+interface UriObj {
+  id: number | undefined;
+  path: string;
+}
 
 /**
  * Apply a set of changes to a base array of Services.
@@ -224,7 +230,11 @@ function postSchedule(scheduleObj, promises) {
   });
 }
 
-function postNotes(notesObj, promises, uriObj) {
+function postNotes(
+  notesObj: Partial<EditNotesState>,
+  promises: Promise<unknown>[],
+  uriObj: UriObj
+) {
   if (notesObj && notesObj.notes) {
     const { notes } = notesObj;
     Object.entries(notes).forEach(([key, currentNote]: any) => {
@@ -541,7 +551,7 @@ export interface InternalTopLevelService
   instructions?: InternalInstruction[];
 
   /** Changes to the notes attached to this service. */
-  notesObj?: any;
+  notesObj?: EditNotesState;
 
   /** A Schedule attached to the service.
    *
@@ -609,7 +619,7 @@ type State = {
   /** Mapping from service ID to service. */
   services: Record<number, InternalTopLevelService>;
   deactivatedServiceIds: Set<number>;
-  notes: Record<any, any>;
+  notes: Partial<EditNotesState>;
   phones: Record<any, any>[];
   submitting: boolean;
   newResource: boolean;
@@ -1420,7 +1430,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
     this.setState({ scheduleObj, inputsDirty: true });
   }
 
-  handleNotesChange(notesObj) {
+  handleNotesChange(notesObj: EditNotesState) {
     this.setState({ notes: notesObj, inputsDirty: true });
   }
 


### PR DESCRIPTION
Refs #1175.

This is a mostly straightforward change to add strict type annotations to anything related to editing notes. There were some surprising things discovered from adding strict types, mostly involving the direct mutation of objects that should not be mutated in React. We leave this behavior in for now, but with comments describing what should eventually be fixed.