### PR TITLE
Edit Page: Add type annotations to EditSchedule.

### DIFF
--- a/app/components/edit/EditScheduleDay.tsx
+++ b/app/components/edit/EditScheduleDay.tsx
@@ -1,6 +1,14 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
+import type { InternalScheduleDay } from "./ProvidedService";
 import { stringToTime, timeToTimeInputValue } from "../../utils/time";
+
+type TimeInputRowProps = {
+  dayOfWeekAbbrev: (typeof DAYS_OF_WEEK)[keyof typeof DAYS_OF_WEEK];
+  index: number;
+  scheduleDay: InternalScheduleDay;
+  is24Hours: boolean;
+  setScheduleDay: (s: InternalScheduleDay) => void;
+};
 
 const TimeInputRow = ({
   dayOfWeekAbbrev,
@@ -8,7 +16,7 @@ const TimeInputRow = ({
   scheduleDay,
   is24Hours,
   setScheduleDay,
-}) => {
+}: TimeInputRowProps) => {
   const removeTime = () => {
     const newScheduleDay = {
       ...scheduleDay,
@@ -24,7 +32,10 @@ const TimeInputRow = ({
     setScheduleDay(newScheduleDay);
   };
 
-  const changeOpenOrCloseTime = (field, value) => {
+  const changeOpenOrCloseTime = (
+    field: "opens_at" | "closes_at",
+    value: string
+  ) => {
     const parsedTime = stringToTime(value);
     const changedField = field === "opens_at" ? "openChanged" : "closeChanged";
     const newScheduleDay = {
@@ -82,7 +93,7 @@ const TimeInputRow = ({
   );
 };
 
-const DAYS_OF_WEEK = Object.freeze({
+const DAYS_OF_WEEK = {
   Monday: "M",
   Tuesday: "T",
   Wednesday: "W",
@@ -90,10 +101,20 @@ const DAYS_OF_WEEK = Object.freeze({
   Friday: "F",
   Saturday: "S",
   Sunday: "Su",
-});
+} as const;
 
-class EditScheduleDay extends Component<any, any> {
-  setScheduleDayForIndex = (index, scheduleDay) => {
+type EditScheduleDayProps = {
+  scheduleDays: InternalScheduleDay[];
+  day: keyof typeof DAYS_OF_WEEK;
+  setScheduleDays: (x: InternalScheduleDay[]) => void;
+  scheduleId: number | undefined;
+};
+
+class EditScheduleDay extends Component<EditScheduleDayProps> {
+  setScheduleDayForIndex = (
+    index: number,
+    scheduleDay: InternalScheduleDay
+  ) => {
     const { scheduleDays, setScheduleDays } = this.props;
     const newScheduleDays = [
       ...scheduleDays.slice(0, index),
@@ -112,7 +133,7 @@ class EditScheduleDay extends Component<any, any> {
     setScheduleDays(tempDaySchedule);
   };
 
-  setIs24Hours = (is24Hours) => {
+  setIs24Hours = (is24Hours: boolean) => {
     const { scheduleId, scheduleDays, setScheduleDays } = this.props;
 
     const oldScheduleDay = scheduleDays[0];
@@ -194,19 +215,5 @@ class EditScheduleDay extends Component<any, any> {
     );
   }
 }
-
-// Leaving propTypes definitions here for reference. Remove when we add proper
-// TypeScript types to this component's props.
-//
-// EditScheduleDay.propTypes = {
-//   scheduleDays: PropTypes.arrayOf(
-//     PropTypes.shape({
-//       closes_at: PropTypes.number,
-//       opens_at: PropTypes.number,
-//     })
-//   ).isRequired,
-//   day: PropTypes.string.isRequired,
-//   setScheduleDays: PropTypes.func.isRequired,
-// };
 
 export default EditScheduleDay;

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -14,7 +14,7 @@ import type {
 
 import s from "./ProvidedService.module.scss";
 
-interface InternalScheduleDay {
+export interface InternalScheduleDay {
   opens_at: number | null;
   closes_at: number | null;
   /** The DB ID of the ScheduleDay. */
@@ -48,6 +48,15 @@ export interface InternalSchedule {
   Friday: InternalScheduleDay[];
   Saturday: InternalScheduleDay[];
   Sunday: InternalScheduleDay[];
+}
+
+/** If the argument is either an InternalSchedule or an empty object, return
+ *  true if it is an InternalSchedule.
+ */
+export function isNonEmptyInternalSchedule(
+  schedule: InternalSchedule | Record<string, never>
+): schedule is InternalSchedule {
+  return "Monday" in schedule;
 }
 
 /** Build UI state schedule from API schedule.
@@ -249,7 +258,7 @@ const ProvidedService = ({
     editServiceById(id, { id, [field]: value });
   };
 
-  const setShouldInheritScheduleFromParent = (shouldInherit) => {
+  const setShouldInheritScheduleFromParent = (shouldInherit: boolean) => {
     const { scheduleObj: scheduleDaysByDay } = service;
 
     let tempScheduleDays: InternalSchedule;

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -53,10 +53,10 @@ export interface InternalSchedule {
 /** If the argument is either an InternalSchedule or an empty object, return
  *  true if it is an InternalSchedule.
  */
-export function isNonEmptyInternalSchedule(
+export function isEmptyInternalSchedule(
   schedule: InternalSchedule | Record<string, never>
-): schedule is InternalSchedule {
-  return "Monday" in schedule;
+): schedule is Record<string, never> {
+  return !("Monday" in schedule);
 }
 
 /** Build UI state schedule from API schedule.

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -11,7 +11,10 @@ import EditNotes from "../components/edit/EditNotes";
 import EditSchedule from "../components/edit/EditSchedule";
 import EditPhones from "../components/edit/EditPhones";
 import EditSidebar from "../components/edit/EditSidebar";
-import { buildScheduleDays } from "../components/edit/ProvidedService";
+import {
+  buildScheduleDays,
+  isNonEmptyInternalSchedule,
+} from "../components/edit/ProvidedService";
 import type { InternalSchedule } from "../components/edit/ProvidedService";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
 import type { Instruction, Organization, Schedule, Service } from "../models";
@@ -1416,7 +1419,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
     this.setState(object);
   }
 
-  handleScheduleChange(scheduleObj) {
+  handleScheduleChange(scheduleObj: InternalSchedule) {
     this.setState({ scheduleObj, inputsDirty: true });
   }
 
@@ -1458,6 +1461,8 @@ class OrganizationEditPage extends React.Component<Props, State> {
   renderSectionFields() {
     const { resource, scheduleObj } = this.state;
     assertDefined(resource, "Tried to access resource before it was defined");
+    if (!isNonEmptyInternalSchedule(scheduleObj))
+      throw new Error("Expected scheduleObj to not be empty");
     return (
       <section id="info" className="edit--section">
         <ul className="edit--section--list">

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -13,7 +13,7 @@ import EditPhones from "../components/edit/EditPhones";
 import EditSidebar from "../components/edit/EditSidebar";
 import {
   buildScheduleDays,
-  isNonEmptyInternalSchedule,
+  isEmptyInternalSchedule,
 } from "../components/edit/ProvidedService";
 import type { InternalSchedule } from "../components/edit/ProvidedService";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
@@ -1461,7 +1461,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
   renderSectionFields() {
     const { resource, scheduleObj } = this.state;
     assertDefined(resource, "Tried to access resource before it was defined");
-    if (!isNonEmptyInternalSchedule(scheduleObj))
+    if (isEmptyInternalSchedule(scheduleObj))
       throw new Error("Expected scheduleObj to not be empty");
     return (
       <section id="info" className="edit--section">

--- a/app/utils/time.ts
+++ b/app/utils/time.ts
@@ -7,7 +7,7 @@ import moment from "moment";
  * '700' to new Date(..., ..., ..., 7, 0)
  * '1330' to new Date(..., ..., ..., 13, 30)
  */
-function timeToDate(hours: string) {
+function timeToDate(hours: number | null) {
   if (hours === null) {
     return null;
   }
@@ -33,7 +33,7 @@ function timeToDate(hours: string) {
  * '700' to '7:00'
  * '1330' to '13:30'
  */
-export function timeToTimeInputValue(hours: string) {
+export function timeToTimeInputValue(hours: number | null) {
   const date = timeToDate(hours);
   if (date === null) {
     return "";


### PR DESCRIPTION
Refs #1175.

This adds type annotations to EditSchedule and related components on the Edit Page. It doesn't add any new types, but it loosens a few types in existing places to account for nullness, which the code already safely handled before.