### PR TITLE
Edit Page: Add type annotations to EditPhone and EditCollection.

### DIFF
--- a/app/components/edit/EditPhones.tsx
+++ b/app/components/edit/EditPhones.tsx
@@ -1,10 +1,20 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import _ from "lodash";
 import editCollectionHOC from "./EditCollection";
+import type { InternalPhoneNumber } from "../../pages/OrganizationEditPage";
 
-class EditPhone extends Component<any, any> {
-  constructor(props) {
+type Props = {
+  item: InternalPhoneNumber;
+  handleChange: (index: number, newPhone: InternalPhoneNumber) => void;
+  index: number;
+};
+
+type State = {
+  phone: InternalPhoneNumber;
+};
+
+class EditPhone extends Component<Props, State> {
+  constructor(props: Props) {
     super(props);
 
     const { item } = this.props;
@@ -16,11 +26,14 @@ class EditPhone extends Component<any, any> {
     this.handleFieldChange = this.handleFieldChange.bind(this);
   }
 
-  handleFieldChange(e) {
+  handleFieldChange(e: React.ChangeEvent<HTMLInputElement>) {
     const { value } = e.target;
     const { field } = e.target.dataset;
     const { phone } = this.state;
     const { handleChange, index, item } = this.props;
+
+    if (field === undefined)
+      throw new Error("Expected field to not be undefined");
 
     if (phone[field] || value !== item[field]) {
       phone[field] = value;
@@ -56,21 +69,6 @@ class EditPhone extends Component<any, any> {
     );
   }
 }
-
-// Leaving propTypes definitions here for reference. Remove when we add proper
-// TypeScript types to this component's props.
-//
-// EditPhone.propTypes = {
-//   handleChange: PropTypes.func.isRequired,
-//   index: PropTypes.number.isRequired,
-//   item: PropTypes.shape({
-//     country_code: PropTypes.string,
-//     extension: PropTypes.string,
-//     id: PropTypes.number,
-//     number: PropTypes.string,
-//     service_type: PropTypes.string,
-//   }).isRequired,
-// };
 
 const EditPhones = editCollectionHOC(EditPhone, "Phones", {}, "Add Phone");
 EditPhones.displayName = "EditPhones";

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -18,7 +18,13 @@ import {
 import type { InternalSchedule } from "../components/edit/ProvidedService";
 import type { State as EditNotesState } from "../components/edit/EditNotes";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
-import type { Instruction, Organization, Schedule, Service } from "../models";
+import type {
+  Instruction,
+  Organization,
+  PhoneNumber,
+  Schedule,
+  Service,
+} from "../models";
 import * as dataService from "../utils/DataService";
 import "./OrganizationEditPage.scss";
 
@@ -603,6 +609,17 @@ export interface InternalFlattenedService extends InternalTopLevelService {
   schedule: Schedule | { schedule_days: never[] };
 }
 
+/** Internal shape of a Phone number on the top-level state.
+ *
+ * Differs from a real PhoneNumber in that the `extension` and `country_code`
+ * fields are omitted. Also differs in that all the fields are possibly
+ * undefined, in the case when the form fields for a new phone number are first
+ * added, but before the user fills them out.
+ */
+export type InternalPhoneNumber = Partial<
+  Pick<PhoneNumber, "id" | "number" | "service_type">
+>;
+
 /** The type of route parameters coming from react-router, based on our routes.
  *
  * The `id` property comes from the `:id` in our edit route, where it is
@@ -623,7 +640,7 @@ type State = {
   services: Record<number, InternalTopLevelService>;
   deactivatedServiceIds: Set<number>;
   notes: Partial<EditNotesState>;
-  phones: Record<any, any>[];
+  phones: InternalPhoneNumber[];
   submitting: boolean;
   newResource: boolean;
   inputsDirty: boolean;
@@ -1409,7 +1426,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
     }
   }
 
-  handlePhoneChange(phoneCollection) {
+  handlePhoneChange(phoneCollection: InternalPhoneNumber[]) {
     this.setState({ phones: phoneCollection, inputsDirty: true });
   }
 


### PR DESCRIPTION
Refs #1175.

This adds type annotations to the EditPhone component as well as the editCollectionHOC function. Note that there are some things in editCollectionHOC that cannot be correctly typed, since it appears to be incorrectly calling `setState()`, passing in the array of collection items rather than an object with a `collections` field. We leave the existing code alone, since it may be a little bit of work to untangle the technical debt, but we at least add stronger type annotations to everything around it.