### PR TITLE
Fix Volunteer link in footer.

### DIFF
--- a/app/components/ui/Footer.tsx
+++ b/app/components/ui/Footer.tsx
@@ -37,7 +37,7 @@ export const Footer = () => {
                 </li>
                 <li>
                   <a
-                    href="https://www.sheltertech.org/get-involved"
+                    href="https://www.sheltertech.org/volunteer"
                     target="_blank"
                     rel="noopener noreferrer"
                   >


### PR DESCRIPTION
The Footer pointed to the old Volunteer page, which we redesigned and gave a new URL a few years ago.