### PR TITLE
Edit Page: Add type annotations to EditAddress

### DIFF
--- a/app/components/edit/EditServices.tsx
+++ b/app/components/edit/EditServices.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ProvidedService from "./ProvidedService";
 
 import type {
+  InternalAddress,
   InternalFlattenedService,
   InternalTopLevelService,
 } from "../../pages/OrganizationEditPage";
@@ -14,7 +15,7 @@ type Props = {
   ) => void;
   handleDeactivation: (type: "resource" | "service", id: number) => void;
   services: InternalFlattenedService[];
-  resourceAddresses: Record<any, any>[];
+  resourceAddresses: InternalAddress[];
 };
 
 const EditServices = ({

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -8,6 +8,7 @@ import EditPatientHandout from "./EditPatientHandout";
 import { EditServiceChildCollection } from "./EditServiceChildCollection";
 import type { Schedule } from "../../models";
 import type {
+  InternalAddress,
   InternalFlattenedService,
   InternalTopLevelService,
 } from "../../pages/OrganizationEditPage";
@@ -144,7 +145,19 @@ const InputField = ({
   </>
 );
 
-const EditAddresses = ({ service, resourceAddresses, handleChange }) => {
+type EditAddressesProps = {
+  service: InternalFlattenedService;
+  resourceAddresses: InternalAddress[];
+  handleChange: <K extends keyof InternalTopLevelService>(
+    field: K,
+    value: InternalTopLevelService[K]
+  ) => void;
+};
+const EditAddresses = ({
+  service,
+  resourceAddresses,
+  handleChange,
+}: EditAddressesProps) => {
   const selectableOptions = resourceAddresses.flatMap((address, handle) => {
     // Don't include addresses that have already been added to the service
     if (service.addressHandles.includes(handle)) {
@@ -163,7 +176,7 @@ const EditAddresses = ({ service, resourceAddresses, handleChange }) => {
     }
     return [{ value: handle, label: address.name || address.address_1 }];
   });
-  const handleSelectChange = (e) => {
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = parseInt(e.target.value, 10);
     handleChange("addressHandles", [...service.addressHandles, selectedValue]);
   };
@@ -240,7 +253,7 @@ type ProvidedServiceProps = {
   handleDeactivation: (type: "resource" | "service", id: number) => void;
   index: number;
   service: InternalFlattenedService;
-  resourceAddresses: Record<any, any>[];
+  resourceAddresses: InternalAddress[];
 };
 
 const ProvidedService = ({

--- a/app/models/Meta.ts
+++ b/app/models/Meta.ts
@@ -11,7 +11,6 @@ export interface Address {
   city: string;
   state_province: string;
   postal_code: string;
-  country: string;
   latitude: string;
   longitude: string;
 }

--- a/app/models/Meta.ts
+++ b/app/models/Meta.ts
@@ -2,10 +2,10 @@ import { RecurringSchedule } from "./RecurringSchedule";
 
 export interface Address {
   id: number;
-  attention: string;
+  attention: string | null;
   name: string | null;
   address_1: string;
-  address_2: string;
+  address_2: string | null;
   address_3: string | null;
   address_4: string | null;
   city: string;

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -1242,12 +1242,9 @@ class OrganizationEditPage extends React.Component<Props, State> {
     } = this.state;
     const { history } = this.props;
     const schedule = prepSchedule(scheduleObj);
-    // TODO: Stop sending the country field after it is no longer required on the
-    // API side.
-    const modifiedAddresses = addresses.map((a) => ({ country: "USA", ...a }));
     const newResource = {
       name,
-      addresses: modifiedAddresses,
+      addresses,
       long_description,
       email,
       website,

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -19,6 +19,7 @@ import type { InternalSchedule } from "../components/edit/ProvidedService";
 import type { State as EditNotesState } from "../components/edit/EditNotes";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
 import type {
+  Address,
   Instruction,
   Organization,
   PhoneNumber,
@@ -107,7 +108,11 @@ const applyChanges = (
     const { schedule } = flattenedService;
     if (schedule === undefined)
       throw new Error("Expected flattened service to have a schedule");
-    newTransformedItems.push({ ...flattenedService, schedule });
+    newTransformedItems.push({
+      addressHandles: [],
+      ...flattenedService,
+      schedule,
+    });
   });
 
   return newTransformedItems;
@@ -318,9 +323,13 @@ function postDocuments(documents, promises) {
  *
  * Otherwise, assume that the address is unmodified and don't do anything.
  */
-const postAddresses = (addresses, uriObj) =>
+const postAddresses = (
+  addresses: InternalAddress[],
+  uriObj: { path: string; id: number | undefined }
+): Promise<unknown>[] =>
   addresses.map((address) => {
-    const { id, isRemoved, dirty } = address;
+    const { isRemoved, dirty } = address;
+    const id = "id" in address ? address.id : undefined;
     const { id: parent_resource_id } = uriObj;
     const postableAddress = { ..._.omit(address, ["dirty", "isRemoved"]) };
 
@@ -406,6 +415,12 @@ const prepSchedule = (scheduleObj) => {
 
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 
+type AddressChangeType =
+  | { type: "markedForRemoval"; handle: number }
+  | { type: "removed"; handle: number }
+  | { type: "modified"; handle: number }
+  | { type: "added" };
+
 /** Determine the type of change between oldAddresses and newAddresses.
  *
  * Given the complete arrays of both the old and new addresses, attempt to
@@ -429,7 +444,10 @@ const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
  * - { type: "modified", handle: number }
  * - { type: "added" } (no handle, because it doesn't exist in oldAddresses)
  */
-const computeTypeOfChangeToAddresses = (oldAddresses, newAddresses) => {
+const computeTypeOfChangeToAddresses = (
+  oldAddresses: InternalAddress[],
+  newAddresses: InternalAddress[]
+): AddressChangeType => {
   if (oldAddresses.length > newAddresses.length) {
     // In this case, we assume that an address was deleted, so we attempt to
     // identify which index was removed so that we can adjust the address
@@ -479,7 +497,7 @@ const setDifference = (set1, set2) =>
 // locations in order to build the complete picture.
 
 /** Get latest list of addresses. */
-const getAddresses = (state) => {
+const getAddresses = (state: State): InternalAddress[] => {
   const { addresses } = state;
   // addresses could be empty if we haven't added, removed, or modified an
   // address. In this case, we want to use the addresses on
@@ -490,7 +508,7 @@ const getAddresses = (state) => {
   // address in the first place, but in that case, using either state.addresses
   // or state.resources.addresses should both give the same result.
   if (addresses.length === 0) {
-    return state.resource.addresses || [];
+    return state.resource?.addresses || [];
   }
   return addresses;
 };
@@ -603,10 +621,17 @@ interface InternalOrganizationService extends Omit<Service, "addresses"> {
  * In addition, the `schedule` field is assumed to always be defined, since
  * either the Schedule came from the original API response or it should have
  * been initialized on the InternalFlattenedService when adding a new Service.
+ *
+ * The `addressHandles` field is also assumed to be defined, since in the case
+ * where the Service already existed on a Resource, the `handleAPIGetResource()`
+ * method will define that field on all Services, and in the case where we
+ * create a new Service, the `addService()` method will initialize it to the
+ * empty array.
  */
 export interface InternalFlattenedService extends InternalTopLevelService {
   id: number;
   schedule: Schedule | { schedule_days: never[] };
+  addressHandles: number[];
 }
 
 /** Internal shape of a Phone number on the top-level state.
@@ -619,6 +644,27 @@ export interface InternalFlattenedService extends InternalTopLevelService {
 export type InternalPhoneNumber = Partial<
   Pick<PhoneNumber, "id" | "number" | "service_type">
 >;
+
+/** Shape of a new address that is being created.
+ *
+ * Note that optional fields are still guaranteed to be set, but will have the
+ * empty string as their value.
+ */
+interface NewAddress {
+  name: string;
+  address_1: string;
+  address_2: string;
+  city: string;
+  state_province: string;
+  postal_code: string;
+}
+
+/** Shape of the `addresses` State variable, which can either come from an
+ * existing address or a new address. */
+export type InternalAddress = (Address | NewAddress) & {
+  isRemoved?: boolean;
+  dirty?: boolean;
+};
 
 /** The type of route parameters coming from react-router, based on our routes.
  *
@@ -635,7 +681,7 @@ type Props = RouteComponentProps<RouteParams> & {
 type State = {
   // Properties that are set at initialization time.
   scheduleObj: Record<string, never> | InternalSchedule;
-  addresses: Record<any, any>[];
+  addresses: InternalAddress[];
   /** Mapping from service ID to service. */
   services: Record<number, InternalTopLevelService>;
   deactivatedServiceIds: Set<number>;
@@ -856,7 +902,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
     const unsavedAddresses =
       addresses.length > 0 ? addresses : resource.addresses;
 
-    const getAddressIDFromHandle = (handle) => {
+    const getAddressIDFromHandle = (handle: number) => {
       // The only case where unsavedAddresses can be undefined is if
       // resource.addresses is undefined, and that can only happen when creating a
       // new Organization. However, if we're calling this
@@ -870,10 +916,11 @@ class OrganizationEditPage extends React.Component<Props, State> {
         "unsavedAddresses should not be undefined"
       );
 
-      if (unsavedAddresses[handle] && unsavedAddresses[handle].id) {
+      const unsavedAddress = unsavedAddresses[handle];
+      if (unsavedAddress && "id" in unsavedAddress && unsavedAddress.id) {
         // Associating with an address that already existed, which means
         // we can simply grab its ID.
-        return Promise.resolve(unsavedAddresses[handle].id);
+        return Promise.resolve(unsavedAddress.id);
       }
       if (postAddressPromises[handle]) {
         // Associating with an address that was just created, which means
@@ -1069,7 +1116,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
   // Whoops!)
   //
   // this.state.addresses only contains modifications to the addresses
-  getFlattenedAddresses = () => {
+  getFlattenedAddresses = (): InternalAddress[] => {
     const { resource, addresses } = this.state;
     assertDefined(resource, "Tried to access resource before it was defined");
     const { addresses: resourceAddresses = [] } = resource;
@@ -1082,7 +1129,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
     return [];
   };
 
-  setAddresses = (addresses) => {
+  setAddresses = (addresses: InternalAddress[]) => {
     this.setState((state) => {
       // Update addresses, and possibly update services as well due to addresses
       // being removed.
@@ -1108,14 +1155,18 @@ class OrganizationEditPage extends React.Component<Props, State> {
         addresses
       );
 
-      let newServices = null;
+      // A mapping from service ID to service. The key is a string and not a
+      // number because putting a number in an object causes it to be converted
+      // to a string. We should probably be using Maps and not Objects when
+      // using non-string keys to avoid that conversion.
+      let newServices: Record<string, InternalTopLevelService> | null = null;
       if (changeType.type === "removed") {
-        const removedAddressHandle: any = changeType.handle;
+        const removedAddressHandle = changeType.handle;
         // Adjust the address handles on the services to reflect the new
         // indexes.
         newServices = Object.fromEntries(
           Object.entries(oldServices).map(([key, service]) => {
-            let oldServiceAddressHandles: any = null;
+            let oldServiceAddressHandles: number[];
             if (service.addressHandles) {
               // If we had previously made a change to the service's addresses,
               // then they should be on this.state.services[x].addressHandles, and
@@ -1143,7 +1194,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
                 return [key, service];
               }
             }
-            const newAddressHandles = oldServiceAddressHandles.reduce(
+            const newAddressHandles = oldServiceAddressHandles.reduce<number[]>(
               (handles, handle) => {
                 if (handle < removedAddressHandle) {
                   // Address unchanged
@@ -1168,8 +1219,8 @@ class OrganizationEditPage extends React.Component<Props, State> {
         // has a handle to that address, remove it from the service.
         const removedAddressHandle = changeType.handle;
         const someServiceHasStaleHandle = Object.values(oldServices).some(
-          (service: any) => {
-            let addressHandles;
+          (service) => {
+            let addressHandles: number[];
             if (service.addressHandles) {
               ({ addressHandles } = service);
             } else {
@@ -1201,7 +1252,10 @@ class OrganizationEditPage extends React.Component<Props, State> {
         );
         if (someServiceHasStaleHandle) {
           newServices = Object.fromEntries(
-            Object.entries(oldServices).map(([key, service]: any) => {
+            Object.entries(oldServices).map(([key, service]) => {
+              if (service.addressHandles === undefined) {
+                return [key, service];
+              }
               const filteredHandles = service.addressHandles.filter(
                 (handle) => handle !== removedAddressHandle
               );
@@ -1211,11 +1265,21 @@ class OrganizationEditPage extends React.Component<Props, State> {
         }
       }
 
-      const updates: any = { addresses, inputsDirty: true };
+      type StateUpdate = {
+        addresses: InternalAddress[];
+        inputsDirty: boolean;
+        services?: Record<number, InternalTopLevelService>;
+      };
+      const updates: StateUpdate = { addresses, inputsDirty: true };
       if (newServices !== null) {
         updates.services = newServices;
       }
-      return updates;
+      // There's a bug in the TypeScript types for setState() where it doesn't
+      // correctly infer the right types if the return type of this function has
+      // more than one shape and/or has an optional key. We explicitly cast up
+      // to make the `services` key required, helping setState() infer something
+      // reasonable for the case where the `services` key is present.
+      return updates as Required<StateUpdate>;
     });
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "app",
-    "lib": ["dom", "es2015"],
+    "lib": ["dom", "dom.iterable", "es2015"],
     "target": "es2015",
     "allowJs": true, // Allow a mix of JS and TS until we fully migrate to TS.
     "jsx": "react",


### PR DESCRIPTION
Refs #1175.

I feel like I'm finally getting close to the end here. This should be the last subcomponent of the Edit Page that needs type annotations, and I think the bulk of the remaining missing type annotations are all on the top-level OrganizationEditPage itself.

This PR is a bit bigger than the last several that I've submitted. There were a couple refactoring changes I made before actually adding type annotations to the code:

- 129159041b8c73eb9afbeeacb389c89b302b015a removes the `country` field from the `Address` type. We had actually removed this field from the API side while working on the Multiple Addresses project in https://github.com/ShelterTechSF/askdarcel-api/pull/586, since it was confusing to users on the edit page, and [we left some vestiges of it on the frontend](https://github.com/ShelterTechSF/askdarcel-web/pull/1044) just to decouple the merging of the PRs. This commit finally removes those vestiges from the frontend code
- 4435c9b32637ba765de21a5be466e6b43d5be0de corrects a few of the type annotations on the `Address` type by making them nullable. This makes it match the API backend's [DB schema](https://github.com/ShelterTechSF/askdarcel-api/blob/ed2b739b9c1cca65e3dd5972a527306a7d793a1f/db/schema.rb#L25-L45)
- 874ae97669165ca34a3fc206cfc03f561fad8614 is finally the bulk of the changes, which are to add type annotations to the EditAddress component and all components related to it. I think probably the most notable thing here is that I created a new `InternalAddress` type, matching the convention for other types I've defined that are derived from the common ones but specialized to the Edit Page. Here, the main differences are that these reflect only the fields that are visible on the Edit Page, as we don't even display a number of the fields available in the DB table, such as address lines 3 and 4 and the attention field.

  There are other little gotchas related to the type system that I had to deal with, but I believe any of the really tricky ones should have comments above them.

---

One more thing that I feel I should provide a bit of context for is the notion of an "address handle", since some of the code in the diff is related to that. This is something I added during the Multiple Addresses work, and it's supposed to be a field on Services which hold the integer index of an Address defined on the Resource. We need this on the Edit Page in order to simplify the logic on the Edit Page.

Normally, the API returns copies of an Address on the Resource and on the Services, meaning that address information is duplicated between Resources and Services and even across different Services at the same address. On the read/listing pages, this is fine and even a bit convenient, but on the edit page, this makes it extremely problematic to keep track of edits to addresses, since the edits may be made to one address but not the other copies. The way we were originally handling this on the Edit Page was to compute diffs, which was somewhat tractable to do when we could only have a single Address per Resource, and Services could only be at that same address.

To make this work with multiple addresses, right after the Edit Page loads and when the API response with the initial page data comes back from the API, we transform the data such that we remove the copies of the Addresses on all the Services, and we replace them with these address handles. These are like "pointers" in languages that have pointers. By removing all the Addresses on the Services, we ensure that there is only one copy of any particular Address, and it is stored on the Resource. (Actually, it's more complicated than that because we always have two copies of everything on the Edit Page: the original, as it came from the API, and a modified version) This way, when we edit an Address, we only edit a single copy of it, and when we need to determine whether we need to send an update request to the API, we just need to check that one Address.

I hope that wasn't too long-winded of an explanation. I think this is documented in the comments on the Edit Page somewhere, but I wanted to summarize all that in case you were wondering just what an "address handle" is.