### PR TITLE
1271 add subcategories step to internet tile pathway

### DIFF
--- a/app/pages/ServiceDiscoveryForm/constants.ts
+++ b/app/pages/ServiceDiscoveryForm/constants.ts
@@ -56,7 +56,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     id: "1000007",
     name: "Internet Access",
     slug: "internet-access-resources",
-    steps: ["results"],
+    steps: ["subcategories", "results"],
     subcategorySubheading: defaultSubheading,
   },
   {


### PR DESCRIPTION
![image](https://github.com/ShelterTechSF/askdarcel-web/assets/3012520/dea8aaae-02a7-486e-83af-608011198eb5)

Internet subcategories have been added to Staging and Prod via Rails console (https://www.sfserviceguide.org/api/categories/subcategories?id=1000007)