### PR TITLE
Migrate Edit Page to TypeScript Part XII

### DIFF
--- a/app/components/edit/EditSidebar.tsx
+++ b/app/components/edit/EditSidebar.tsx
@@ -123,10 +123,9 @@ const EditSidebar = ({
   }
   // Populate existing services so they show up on the sidebar
   // Do a 2-level-deep clone of the newServices object
-  const allServices = Object.entries(newServices).reduce(
-    (acc, [id, service]: any) => ({ ...acc, [id]: { ...service } }),
-    {}
-  );
+  const allServices: Record<number, InternalTopLevelService> = Object.entries(
+    newServices
+  ).reduce((acc, [id, service]) => ({ ...acc, [id]: { ...service } }), {});
   if (resource.services) {
     resource.services.forEach((service) => {
       allServices[service.id].name = service.name;
@@ -162,7 +161,7 @@ const EditSidebar = ({
           </p>
         )}
         <ul className={styles.list}>
-          {Object.entries(allServices).map(([key, service]: any) => (
+          {Object.entries(allServices).map(([key, service]) => (
             <li key={key} className={styles.listItem}>
               <a
                 href={`#${key}`}

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -118,7 +118,9 @@ const applyChanges = (
   return newTransformedItems;
 };
 
-function getDiffObject(curr, orig) {
+/** Return an object that contains only the key-value pairs in `curr` that are different than `orig`.
+ */
+function getDiffObject<T extends {}>(curr: T, orig: T): Partial<T> {
   return Object.entries(curr).reduce((acc, [key, value]) => {
     if (!_.isEqual(orig[key], value)) {
       acc[key] = value;
@@ -413,7 +415,8 @@ const prepSchedule = (scheduleObj) => {
   return newSchedule;
 };
 
-const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+const deepClone = <T extends unknown>(obj: T): T =>
+  JSON.parse(JSON.stringify(obj));
 
 type AddressChangeType =
   | { type: "markedForRemoval"; handle: number }
@@ -486,7 +489,7 @@ const computeTypeOfChangeToAddresses = (
  * This recipe was copied from
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
  */
-const setDifference = (set1, set2) =>
+const setDifference = <T extends unknown>(set1: Set<T>, set2: Set<T>): Set<T> =>
   new Set([...set1].filter((x) => !set2.has(x)));
 
 // Helper functions for computing views on state.
@@ -973,7 +976,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
         postDocuments(currentService.documents, promises);
         delete currentService.documents;
         delete currentService.shouldInheritScheduleFromParent;
-        const { addressHandles } = currentService;
+        const { addressHandles }: { addressHandles: number[] } = currentService;
         delete currentService.addressHandles;
         if (!_.isEmpty(currentService)) {
           promises.push(

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -15,15 +15,23 @@ import {
   buildScheduleDays,
   isEmptyInternalSchedule,
 } from "../components/edit/ProvidedService";
-import type { InternalSchedule } from "../components/edit/ProvidedService";
-import type { State as EditNotesState } from "../components/edit/EditNotes";
+import type {
+  InternalSchedule,
+  InternalScheduleDay,
+} from "../components/edit/ProvidedService";
+import type {
+  State as EditNotesState,
+  InternalNoteChanges,
+} from "../components/edit/EditNotes";
 import type { PopupMessageProp } from "../components/ui/PopUpMessage";
 import type {
   Address,
   Instruction,
+  Note,
   Organization,
   PhoneNumber,
   Schedule,
+  ScheduleDay,
   Service,
 } from "../models";
 import * as dataService from "../utils/DataService";
@@ -394,17 +402,54 @@ function createFullSchedule(scheduleObj) {
   return { schedule_days: [] };
 }
 
-const prepNotesData = (notes) => Object.values(notes).map((note) => ({ note }));
+/** A new Note object that is about to be POSTed to the API. */
+type NewNote = Omit<Note, "id">;
 
-const prepSchedule = (scheduleObj) => {
-  const newSchedule: any[] = [];
-  let tempDay = {};
-  Object.keys(scheduleObj).forEach((day) => {
-    scheduleObj[day].forEach((curr) => {
+/** Prepare new notes to be created along with a new Resource.
+ *
+ * This function may look more complicated than it needs to be, but it's due to
+ * technical debt in the EditNotes component, which prevents us from precisely
+ * describing the type of the InternalNoteChanges. InternalNoteChanges.note is
+ * only only undefined in the case where we are removing an existing note, but
+ * on the New Resource page, we cannot remove any notes because none of them
+ * have been created on the API side in the first place. Therefore, we know that
+ * the `note` field on all `InternalNoteChanges` should be defined. We add a
+ * runtime type assertion here to ensure this invariant is held even if we
+ * refactor the EditNotes component.
+ */
+const prepNotesData = (
+  notes: Record<number, InternalNoteChanges>
+): { note: NewNote }[] =>
+  Object.values(notes).map((note) => {
+    const noteValue = note.note;
+    assertDefined(
+      noteValue,
+      "Expected all notes to have a defined `note` field"
+    );
+    return { note: { note: noteValue } };
+  });
+
+/** A new ScheduleDay object that is about to be POSTed to the API. */
+type NewScheduleDay = Omit<ScheduleDay, "id">;
+
+const prepSchedule = (
+  scheduleObj: Record<string, never> | InternalSchedule
+): NewScheduleDay[] => {
+  const newSchedule: NewScheduleDay[] = [];
+  Object.keys(scheduleObj).forEach((untypedDay) => {
+    // Object.keys() always returns strings, even when we know(?) that the keys
+    // are a more precise type, since object types in TypeScript only desrcibe
+    // the minimum set of keys required, and there could always be more keys
+    // present than we are aware of. We explicitly perform this type assertion
+    // to constrain `day` to just the days of the week. In the future, we should
+    // avoid using Object.keys() and Object.entries().
+    const day = untypedDay as keyof InternalSchedule;
+    const scheduleDays: InternalScheduleDay[] = scheduleObj[day];
+    scheduleDays.forEach((curr) => {
       if (curr.opens_at === null || curr.closes_at === null) {
         return;
       }
-      tempDay = {
+      const tempDay = {
         day,
         opens_at: curr.opens_at,
         closes_at: curr.closes_at,
@@ -1295,6 +1340,10 @@ class OrganizationEditPage extends React.Component<Props, State> {
     }
   }
 
+  /** Submit a POST request to create a new Resource with the current state.
+   *
+   * For editing an existing Resource, see `handleSubmit()`.
+   */
   createResource() {
     const {
       scheduleObj,

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -438,7 +438,7 @@ const prepSchedule = (
   const newSchedule: NewScheduleDay[] = [];
   Object.keys(scheduleObj).forEach((untypedDay) => {
     // Object.keys() always returns strings, even when we know(?) that the keys
-    // are a more precise type, since object types in TypeScript only desrcibe
+    // are a more precise type, since object types in TypeScript only describe
     // the minimum set of keys required, and there could always be more keys
     // present than we are aware of. We explicitly perform this type assertion
     // to constrain `day` to just the days of the week. In the future, we should


### PR DESCRIPTION
Refs #1175.

I think this will be the penultimate PR for the Edit Page TypeScript migration. This adds type annotations everything except for the code path for editing existing Resources. Specifically, this fixes up some `any` types on the EditSidebar component, it adds type annotations to some generic utility functions (e.g. `deepClone()`), and it adds type annotations to the code that's called when creating a brand new Resource.

After this is merged, I think I should be able to do the last set of changes all in one shot.