### PR TITLE
Migrate Edit Page to TypeScript: Final

### DIFF
--- a/app/models/Service.ts
+++ b/app/models/Service.ts
@@ -27,6 +27,7 @@ export interface Service {
   categories: Category[];
   certified_at: string | null;
   certified: boolean;
+  documents: unknown[];
   eligibilities: Eligibility[];
   email: string | null;
   featured: boolean | null;

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -297,23 +297,6 @@ function postInstructions(instructions, promises) {
   }
 }
 
-function postDocuments(documents, promises) {
-  if (documents?.length > 0) {
-    documents.forEach((currentDocument) => {
-      if (currentDocument.isRemoved) {
-        const uri = `/api/documents/${currentDocument.id}`;
-        promises.push(dataService.APIDelete(uri));
-      } else if (currentDocument.id) {
-        const uri = `/api/documents/${currentDocument.id}`;
-        promises.push(dataService.put(uri, { document: currentDocument }));
-      } else {
-        const uri = "/api/documents";
-        promises.push(dataService.post(uri, { document: currentDocument }));
-      }
-    });
-  }
-}
-
 /** Return an array of Promises performing the correct update operation.
  *
  * Note that this will return a promise that resolves to null for addresses that
@@ -1018,7 +1001,6 @@ class OrganizationEditPage extends React.Component<Props, State> {
         delete currentService.scheduleObj;
         postInstructions(currentService.instructions, promises);
         delete currentService.instructions;
-        postDocuments(currentService.documents, promises);
         delete currentService.documents;
         delete currentService.shouldInheritScheduleFromParent;
         const { addressHandles }: { addressHandles: number[] } = currentService;


### PR DESCRIPTION
Refs #1175.

This should be the last major PR to migrate the Edit Page over to TypeScript. This goes through the last remaining functions in the OrganizationEditPage and adds type annotations to them. There were a number of weird things that I hit, but I hope most of the inline comments are self-explanatory.

One thing to note is that most of the `postServices()` is basically unsalvageable, since we start with an object of type `InternalService`, and we gradually morph and delete properties off of it until we get an object that looks more or less like `Service`, the type that represents what the API sends to the frontend app upon a GET request. There's no way for TypeScript to handle this because the object is in an intermediate state during the entirety of the transition. As such, I liberally added `// @ts-ignore` comments to the function until it passed TypeScript type checking. This entire function should probably be rewritten from scratch, and instead of gradually mutating the internal representation of a Service until it looks like an API-compatible one, we should just build the API-compatible one from a brand new object.

There are actually a handful of smaller TypeScript-related things that I still need to do in a followup PR, since I had disabled the `noImplicitAny` configuration option in https://github.com/ShelterTechSF/askdarcel-web/pull/1230. Re-enabling it will require changes to stuff outside of the Edit Page because a few of the other changes we've been making to the site run afoul of that option, but I plan to do that in a separate PR.