### PR TITLE
Fix texting component to allow texting Resource info

### DIFF
--- a/app/components/Texting/Texting.tsx
+++ b/app/components/Texting/Texting.tsx
@@ -8,7 +8,10 @@ import { Loader } from "../ui";
 import { SentView } from "./components/SentView";
 import { ErrorView } from "./components/ErrorView";
 
-export type TextListing = {listingName: string} & ({serviceId: number} | {resourceId: number});
+export type TextListing = { listingName: string } & (
+  | { serviceId: number }
+  | { resourceId: number }
+);
 
 /** Payload for the create Texting API endpoint. */
 export interface APITexting {

--- a/app/components/Texting/Texting.tsx
+++ b/app/components/Texting/Texting.tsx
@@ -9,8 +9,8 @@ import { SentView } from "./components/SentView";
 import { ErrorView } from "./components/ErrorView";
 
 export type TextListing = { listingName: string } & (
-  | { serviceId: number }
-  | { resourceId: number }
+  | { serviceId: number; type: "service" }
+  | { resourceId: number; type: "resource" }
 );
 
 /** Payload for the create Texting API endpoint. */

--- a/app/components/Texting/Texting.tsx
+++ b/app/components/Texting/Texting.tsx
@@ -8,31 +8,29 @@ import { Loader } from "../ui";
 import { SentView } from "./components/SentView";
 import { ErrorView } from "./components/ErrorView";
 
-/** A view of a Service from within the Texting component.
- *
- * TODO: Replace this with an app-wide Service type.
- */
-export interface TextingService {
-  serviceName: string;
-  serviceId: number;
+
+export interface TextListing {
+  listingName: string;
+  serviceId?: number;
+  resourceId?: number;
 }
 
 /** Payload for the create Texting API endpoint. */
 export interface APITexting {
   recipient_name: string;
   phone_number: string;
-  service_id: number;
+  service_id?: number;
+  resource_id?: number;
 }
 
-// Text resource informations to the user phone
-
+// This component texts resource or service informations to the user's phone
 export const Texting = ({
   closeModal,
-  service,
+  listing,
   isShowing,
 }: {
   closeModal: () => void;
-  service: TextingService;
+  listing: TextListing;
   isShowing: boolean;
 }) => {
   const [view, setView] = useState("");
@@ -69,7 +67,7 @@ export const Texting = ({
       activeView = (
         <FormView
           handleSubmit={handleSubmit}
-          service={service}
+          listing={listing}
           closeModal={closeModal}
         />
       );

--- a/app/components/Texting/Texting.tsx
+++ b/app/components/Texting/Texting.tsx
@@ -8,7 +8,6 @@ import { Loader } from "../ui";
 import { SentView } from "./components/SentView";
 import { ErrorView } from "./components/ErrorView";
 
-
 export interface TextListing {
   listingName: string;
   serviceId?: number;

--- a/app/components/Texting/Texting.tsx
+++ b/app/components/Texting/Texting.tsx
@@ -8,11 +8,7 @@ import { Loader } from "../ui";
 import { SentView } from "./components/SentView";
 import { ErrorView } from "./components/ErrorView";
 
-export interface TextListing {
-  listingName: string;
-  serviceId?: number;
-  resourceId?: number;
-}
+export type TextListing = {listingName: string} & ({serviceId: number} | {resourceId: number});
 
 /** Payload for the create Texting API endpoint. */
 export interface APITexting {

--- a/app/components/Texting/components/FormView/FormView.tsx
+++ b/app/components/Texting/components/FormView/FormView.tsx
@@ -3,7 +3,7 @@ import Heading from "./Heading";
 import Privacy from "./Privacy";
 import Buttons from "./Buttons";
 import styles from "./Form.module.scss";
-import type { APITexting, TextingService } from "../../Texting";
+import type { APITexting, TextListing } from "../../Texting";
 
 const initialState = {
   recipientName: "",
@@ -12,17 +12,17 @@ const initialState = {
 } as const;
 
 export const FormView = ({
-  service,
+  listing,
   handleSubmit,
   closeModal,
 }: {
-  service: TextingService;
+  listing: TextListing;
   handleSubmit: (data: APITexting) => void;
   closeModal: () => void;
 }) => {
   const [state, setState] = useState(initialState);
   const { recipientName, phoneNumber, agreed } = state;
-  const { serviceName, serviceId } = service;
+  const { listingName, serviceId, resourceId } = listing;
   const onChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { type, name, value, checked } = evt.target;
     const newValue = type === "checkbox" ? checked : value;
@@ -35,13 +35,14 @@ export const FormView = ({
       recipient_name: recipientName,
       phone_number: phoneNumber,
       service_id: serviceId,
+      resource_id: resourceId,
     };
     handleSubmit(data);
   };
 
   return (
     <div>
-      <Heading serviceName={serviceName} />
+      <Heading listingName={listingName} />
       <div className={styles.inputField}>
         <label className={styles.label}>
           First name (optional)

--- a/app/components/Texting/components/FormView/FormView.tsx
+++ b/app/components/Texting/components/FormView/FormView.tsx
@@ -22,7 +22,7 @@ export const FormView = ({
 }) => {
   const [state, setState] = useState(initialState);
   const { recipientName, phoneNumber, agreed } = state;
-  const { listingName, serviceId, resourceId } = listing;
+  const { listingName } = listing;
   const onChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const { type, name, value, checked } = evt.target;
     const newValue = type === "checkbox" ? checked : value;
@@ -34,8 +34,8 @@ export const FormView = ({
     const data = {
       recipient_name: recipientName,
       phone_number: phoneNumber,
-      service_id: serviceId,
-      resource_id: resourceId,
+      service_id: listing.type === "service" ? listing.serviceId : undefined,
+      resource_id: listing.type === "resource" ? listing.resourceId : undefined,
     };
     handleSubmit(data);
   };

--- a/app/components/Texting/components/FormView/Heading.tsx
+++ b/app/components/Texting/components/FormView/Heading.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import styles from "./Form.module.scss";
 
-const Heading = ({ serviceName }: { serviceName: string }) => (
+const Heading = ({ listingName }: { listingName: string }) => (
   <div>
-    <h1 className={styles.title}>{`Text me information for ${serviceName}`}</h1>
+    <h1 className={styles.title}>{`Text me information for ${listingName}`}</h1>
     <h3 className={styles.description}>
       You will receive their address and phone number.
     </h3>

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -84,15 +84,15 @@ const SearchResults = ({ searchResults, expandList, setExpandList }) => {
   );
 };
 
-// eslint-disable-next-line no-unused-vars
-const SearchResult = ({ hit, index, setCenterCoords }) => {
+const SearchResult = ({ hit, index }) => {
   const [textingIsOpen, setTextingIsOpen] = useState(false);
   const [clinicianActionsIsOpen, setClinicianActionsIsOpen] = useState(false);
   const [handoutModalIsOpen, setHandoutModalIsOpen] = useState(false);
 
-  const service = {
-    serviceName: hit.name,
-    serviceId: hit.service_id,
+  const listing = {
+    listingName: hit.name,
+    serviceId: hit.type === 'service' ? hit.id : null,
+    resourceId: hit.type === 'resource' ? hit.id : null,
   };
 
   const toggleTextingModal = () => setTextingIsOpen(!textingIsOpen);
@@ -201,7 +201,7 @@ const SearchResult = ({ hit, index, setCenterCoords }) => {
     <div className={styles.searchResult}>
       <Texting
         closeModal={toggleTextingModal}
-        service={service}
+        listing={listing}
         isShowing={textingIsOpen}
       />
       <ClinicianActions

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -91,8 +91,8 @@ const SearchResult = ({ hit, index }) => {
 
   const listing = {
     listingName: hit.name,
-    serviceId: hit.type === 'service' ? hit.id : null,
-    resourceId: hit.type === 'resource' ? hit.id : null,
+    serviceId: hit.type === "service" ? hit.id : null,
+    resourceId: hit.type === "resource" ? hit.id : null,
   };
 
   const toggleTextingModal = () => setTextingIsOpen(!textingIsOpen);

--- a/app/components/search/SearchResults/SearchResults.jsx
+++ b/app/components/search/SearchResults/SearchResults.jsx
@@ -91,8 +91,9 @@ const SearchResult = ({ hit, index }) => {
 
   const listing = {
     listingName: hit.name,
-    serviceId: hit.type === "service" ? hit.id : null,
-    resourceId: hit.type === "resource" ? hit.id : null,
+    serviceId: hit.type === "service" ? hit.id : undefined,
+    resourceId: hit.type === "resource" ? hit.id : undefined,
+    type: hit.type,
   };
 
   const toggleTextingModal = () => setTextingIsOpen(!textingIsOpen);


### PR DESCRIPTION
When looking to convert the SearchResults file to TypeScript, I noticed that our Texting component does not support texting Resource info. This is deceptive as the "text me the info" link is displayed on Resource search listings. Thus, I've created a PR to fix this before getting back to migrating the SearchResults page, which I plan to do prior to making some changes to it as part of some UCSF work. See corresponding API PR [here](https://github.com/ShelterTechSF/askdarcel-api/pull/719)