### PR TITLE
Re-enable tsconfig `noImplicitAny`

### DIFF
--- a/app/components/edit/EditPhones.tsx
+++ b/app/components/edit/EditPhones.tsx
@@ -34,6 +34,12 @@ class EditPhone extends Component<Props, State> {
 
     if (field === undefined)
       throw new Error("Expected field to not be undefined");
+    // This condition needs to be kept up to date with the `data-field`
+    // attributes on the `<input>` tags rendered on this component.
+    if (field !== "number" && field !== "service_type")
+      throw new Error(
+        "Expectied field to be either `number` or `service_type`"
+      );
 
     if (phone[field] || value !== item[field]) {
       phone[field] = value;

--- a/app/components/edit/ProvidedService.tsx
+++ b/app/components/edit/ProvidedService.tsx
@@ -279,7 +279,11 @@ const ProvidedService = ({
       // we're building up the InternalSchedule day by day, but we know that
       // we'll have all the keys in the end, so we cast back to
       // InternalSchedule.
-      tempScheduleDays = Object.entries(scheduleDaysByDay).reduce<
+      const scheduleDaysByDayEntries = Object.entries(scheduleDaysByDay) as [
+        keyof InternalSchedule,
+        InternalFlattenedService[]
+      ][];
+      tempScheduleDays = scheduleDaysByDayEntries.reduce<
         Partial<InternalSchedule>
       >(
         (acc, [day, scheduleDays]) => ({

--- a/app/components/ui/WeGlot.tsx
+++ b/app/components/ui/WeGlot.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
+import type { HelmetTags } from "react-helmet-async";
 
 const onLoad = (apiKey: string, targetLangCode: string | null) => {
   // HACK: suppress TS compile errors when accessing the global WeGlot instance created by the script.
@@ -59,7 +60,10 @@ export const WeGlot = ({
    * Instead, when the cdn.weglot.com script is added on the client, add an event listener when it loads
    * to trigger a React effect to run the Weglot initialization logic above.
    */
-  const handleChangeClientState = (newState, addedTags) => {
+  const handleChangeClientState = (
+    newState: unknown,
+    addedTags: HelmetTags
+  ) => {
     if (addedTags && addedTags.scriptTags) {
       const foundScript = addedTags.scriptTags.find(
         ({ src }) => src === WEGLOT_SRC

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -154,13 +154,21 @@ const applyChanges = (
 
 /** Return an object that contains only the key-value pairs in `curr` that are different than `orig`.
  */
-function getDiffObject<T extends {}>(curr: T, orig: T): Partial<T> {
-  return Object.entries(curr).reduce((acc, [key, value]) => {
-    if (!_.isEqual(orig[key], value)) {
-      acc[key] = value;
-    }
-    return acc;
-  }, {});
+function getDiffObject<T extends Record<string, unknown>>(
+  curr: T,
+  orig: T
+): Partial<T> {
+  return Object.entries(curr).reduce<Partial<T>>(
+    (acc, [untypedKey, untypedValue]) => {
+      const key = untypedKey as keyof T;
+      const value = untypedValue as T[typeof key];
+      if (!_.isEqual(orig[key], value)) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {}
+  );
 }
 
 function updateCollectionObject(
@@ -1218,7 +1226,7 @@ class OrganizationEditPage extends React.Component<Props, State> {
         .then((resp) => resp.json())
         // After new services are created, grab their IDs and associate them
         // with addresses.
-        .then((resp) =>
+        .then((resp: { services: { service: Service }[] }) =>
           Promise.all(
             resp.services.map(({ service }, i) => {
               const serviceAddressPromises = newServicesAddressHandles[i].map(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "jsx": "react",
     "noEmit": true, // No need to emit .d.ts files, since we're not publishing a package.
     "strict": true,
-    "noImplicitAny": false, // Temporarily allow implicit any as we are migrating the codebase
     "moduleResolution": "node",
     "esModuleInterop": true, // Allows us to use default imports with CommonJS modules (which some third-party packages use)
     "skipLibCheck": true // Don't type check .d.ts files, which mostly come from third party libraries.


### PR DESCRIPTION
I had temporarily disabled this setting in https://github.com/ShelterTechSF/askdarcel-web/pull/1230 in order to make the TypeScript migration of the Edit Page easier. Now that the Edit Page has been fully migrated to TypeScript, we can re-enable this setting.

There were a handful of places where I needed to add explicit type annotations in order to make this pass again, but they were relatively straightforward to fix. Note that one of the fixes was to the WeGlot component, which was code added after I had disabled `noImplicitAny`.