### PR TITLE
feat: add v2 route for separate backend service config

### DIFF
--- a/docker/tiller/templates/askdarcel-web.conf.erb
+++ b/docker/tiller/templates/askdarcel-web.conf.erb
@@ -23,6 +23,25 @@ server {
         proxy_redirect off;
     }
 
+    location ~ ^/api/v2/(.*)$ {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+
+        # See https://forum.nginx.org/read.php?2,215830,215832#msg-215832
+        # nginx only resolves DNS for statically-configured domain names
+        # once on startup. Since the API is behind an ELB whose IPs may
+        # change, we must configure nginx to resolve DNS dynamically.
+        # To do this, we configure a DNS resolver here and use a variable
+        # rather than a literal URL when configuring the proxy below.
+        resolver <%= open('/etc/resolv.conf').read.match(/nameserver (.*)/)[1] rescue '8.8.8.8' %>;
+        resolver_timeout 5s;
+
+        set api_go_url <%= env_api_go_url.chomp '/' %>;
+        proxy_pass $api_go_url/$1$is_args$args;
+        proxy_redirect off;
+    }
+
     location ~ ^/api/(.*)$ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -159,6 +159,10 @@ module.exports = {
       "/api-docs": {
         target: process.env.API_URL || "http://localhost:3000",
       },
+      "/api/v2/": {
+        target: process.env.API_GO_URL || "http://localhost:3000",
+        pathRewrite: { "^/api/v2/": "" },
+      },
       "/api/": {
         target: process.env.API_URL || "http://localhost:3000",
         pathRewrite: { "^/api/": "" },


### PR DESCRIPTION
Maybe not the long term plan, but for now we can consider routing to `api/v2` to hit the Go backend.  If we want to migrate any routes from the web app, we can add that `/v2` path param.