### PR TITLE
Organization Page: Add margin to service description paragraphs.

### DIFF
--- a/app/styles/components/_listing-page.scss
+++ b/app/styles/components/_listing-page.scss
@@ -189,6 +189,11 @@
     }
     &--description {
       margin-top: calc-em(15px);
+      p {
+        white-space: pre-line;
+        padding-right: 6px;
+        margin-top: calc-em(10px);
+      }
     }
     &--details-toggle {
       margin-top: calc-em(20px);


### PR DESCRIPTION
Fixes #1290. Note that in the ticket description, I had incorrectly stated that we weren't rendering Markdown for Service descriptions. The actual culprit was some missing CSS for Service descriptions.

The Organization descriptions had [a snippet of CSS](https://github.com/ShelterTechSF/askdarcel-web/blob/7d3f829ba04c0884a119b0433d06ced2c20ebd0c/app/styles/components/_org-page.scss#L86-L90) to add top-margin to all `<p>` elements, but the Service descriptions lacked this CSS, which caused consecutive paragraphs to have too little space between them. This adds the same spacing to the Services.

**Before**
<img width="878" alt="Screen Shot 2023-08-21 at 9 05 47 AM" src="https://github.com/ShelterTechSF/askdarcel-web/assets/1002748/4b167887-49e5-4d6c-801e-205f16cfcc81">

**After**
<img width="887" alt="Screen Shot 2023-08-21 at 9 04 20 AM" src="https://github.com/ShelterTechSF/askdarcel-web/assets/1002748/19558c6e-b17a-458d-9b75-70bf4c1825ca">
