### PR TITLE
Remove ESLint waivers for TypeScript code during transition.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
     "react/forbid-prop-types": "off",
     "react/prefer-stateless-function": "off",
     "react/prop-types": "off",
-    "react/jsx-filename-extension": ["error", { extensions: [".tsx", ".jsx"] }],
+    "react/jsx-filename-extension": ["error", { extensions: [".tsx"] }],
     "react/function-component-definition": [
       "error",
       { namedComponents: "arrow-function" },
@@ -82,34 +82,6 @@ module.exports = {
         "react/jsx-props-no-spreading": "off",
         "max-classes-per-file": "off",
         "spaced-comment": ["error", "always", { markers: ["/"] }],
-      },
-    },
-    // Temporarily disable certain ESLint rules for Edit page files until we
-    // improve the type annotations.
-    {
-      files: [
-        "app/components/edit/*.tsx",
-        "app/pages/OrganizationEditPage.tsx",
-      ],
-      extends: [
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-      ],
-      parser: "@typescript-eslint/parser",
-      parserOptions: {
-        project: "./tsconfig.json",
-      },
-      rules: {
-        "@typescript-eslint/no-floating-promises": "off",
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/restrict-plus-operands": "off",
-        "@typescript-eslint/restrict-template-expressions": "off",
-        "@typescript-eslint/unbound-method": "off",
-        "react/sort-comp": "off",
       },
     },
     {

--- a/app/components/edit/EditCollection.tsx
+++ b/app/components/edit/EditCollection.tsx
@@ -78,13 +78,6 @@ export default function editCollectionHOC<T extends BaseItem>(
       this.removeItem = this.removeItem.bind(this);
     }
 
-    addItem() {
-      const { collection } = this.state;
-      collection.push(blankTemplateObj);
-      // HACK: see comment on State.
-      this.setState(collection as any);
-    }
-
     handleChange(index: number, item: T) {
       const { handleChange } = this.props;
       const { collection } = this.state;
@@ -92,7 +85,16 @@ export default function editCollectionHOC<T extends BaseItem>(
       item.dirty = true;
       collection[index] = item;
       // HACK: see comment on State.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       this.setState(collection as any, () => handleChange(collection));
+    }
+
+    addItem() {
+      const { collection } = this.state;
+      collection.push(blankTemplateObj);
+      // HACK: see comment on State.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      this.setState(collection as any);
     }
 
     removeItem(index: number, item: T) {
@@ -105,6 +107,7 @@ export default function editCollectionHOC<T extends BaseItem>(
       }
 
       // HACK: see comment on State.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       this.setState(collection as any, () => handleChange(collection));
     }
 

--- a/app/components/edit/EditSidebar.tsx
+++ b/app/components/edit/EditSidebar.tsx
@@ -53,7 +53,7 @@ const EditSidebar = ({
   const history = useHistory();
   let actionButtons: JSX.Element[];
 
-  const handleActivation = (id: number): void => {
+  const handleActivation = (): void => {
     /* eslint-disable no-alert */
     if (window.confirm("Are you sure you want to reactivate this resource?")) {
       dataService
@@ -87,7 +87,7 @@ const EditSidebar = ({
         disabled={submitting}
         onClick={() =>
           resource.status === "inactive"
-            ? handleActivation(resourceID)
+            ? handleActivation()
             : handleDeactivation("resource", resourceID)
         }
       >


### PR DESCRIPTION
We had disabled some ESLint rules for our TypeScript code when we were initially migrating the codebase. These should no longer be necessary, so they have been removed, and the remaining failures have either been fixed or ignored at the line level.