### PR TITLE
Refinements fix

### DIFF
--- a/app/components/search/Refinements/RefinementListFilter.tsx
+++ b/app/components/search/Refinements/RefinementListFilter.tsx
@@ -17,10 +17,7 @@ const RefinementListFilter = ({ items, refine }: Props) => (
   <ul>
     {items.map((item) => (
       <label key={item.label} className={styles.checkBox}>
-        <span style={{ fontWeight: 800, color: "black", marginLeft: "auto" }}>
-          ({item.count})
-        </span>
-        <span>{item.label}</span>
+        {item.label}
         <input
           className={styles.refinementInput}
           type="checkbox"

--- a/app/components/search/Refinements/RefinementListFilter.tsx
+++ b/app/components/search/Refinements/RefinementListFilter.tsx
@@ -17,7 +17,10 @@ const RefinementListFilter = ({ items, refine }: Props) => (
   <ul>
     {items.map((item) => (
       <label key={item.label} className={styles.checkBox}>
-        {item.label}
+        <span style={{ fontWeight: 800, color: "black", marginLeft: "auto" }}>
+          ({item.count})
+        </span>
+        <span>{item.label}</span>
         <input
           className={styles.refinementInput}
           type="checkbox"

--- a/app/components/search/Sidebar/Sidebar.tsx
+++ b/app/components/search/Sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo } from "react";
 
-import { whiteLabel } from "utils";
 import {
   eligibilitiesMapping,
   categoriesMapping,

--- a/app/components/search/Sidebar/Sidebar.tsx
+++ b/app/components/search/Sidebar/Sidebar.tsx
@@ -78,24 +78,37 @@ const Sidebar = ({
       />
     );
   } else {
-    const transformEligibilities = (items: { label: string }[]) => {
-      let itemsList = items;
-      if (eligibilityNames.length > 0) {
-        itemsList = items.filter(({ label }) =>
-          eligibilityNames.includes(label)
-        );
-      }
-
-      return itemsList.sort(orderByLabel);
-    };
-
     // Service Results Page
     if (eligibilities.length) {
       eligibilityRefinementJsx = (
         <RefinementListFilter
           attribute="eligibilities"
-          limit={whiteLabel.refinementListLimit}
-          transformItems={transformEligibilities}
+          /*
+            The eligibilityNames array represents a static list of eligibilites that are displayed
+            in the ServiceDiscovery form of the parent tile category. (Currently, only the UCSF
+            whitelabel uses this mechanism.)
+
+            If the eligibilityNames array is > 0, we use it to filter out Algolia's returned set
+            of eligibilities. For such cases, we want Algolia to return a large number of
+            eligiblities to ensure that the returned eligibilities include those on the static list.
+            If eligibilityNames is < 1, we just pass Algolia's default limit, 10, and accept those
+            10 without filtering them.
+
+            N.B.: Eligibilities, and refinements in general, are returned by Algolia in order of
+            `[count:desc`, name:asc`]. In other words, the 10 default eligibilities are the most
+            tagged eligibilities of the returned services, with `name:asc` acting as a tiebreaker.
+          */
+          limit={eligibilityNames.length > 0 ? 100 : 10}
+          transformItems={(items: { label: string }[]) => {
+            let itemsList = items;
+            if (eligibilityNames.length > 0) {
+              itemsList = items.filter(({ label }) =>
+                eligibilityNames.includes(label)
+              );
+            }
+
+            return itemsList.sort(orderByLabel);
+          }}
         />
       );
     }
@@ -103,7 +116,16 @@ const Sidebar = ({
       categoryRefinementJsx = (
         <RefinementListFilter
           attribute="categories"
-          limit={whiteLabel.refinementListLimit}
+          /*
+            Algolia returns all categories that the union of returned services are tagged with.
+            The transformItems method filters out any of these categories that are not children
+            of the parent tile category (these children are members of the subcategoryNames
+            array). Since the number of tagged categories returned by Algolia can be very large,
+            we need to set an artificially high limit to ensure that the returned set contains
+            the desired subcategories; these are the initial subcategories displayed to the user
+            as checkboxes in the ServiceDiscoveryForm view.
+          */
+          limit={100}
           transformItems={(items: { label: string }[]) =>
             items
               .filter(({ label }) => subcategoryNames.includes(label))

--- a/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
+++ b/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
@@ -22,13 +22,6 @@ interface UcsfEligibilityMap {
   [key: string]: EligibilityGroup[];
 }
 
-// N.B.: Until we have found a way to make use of Algolia's "Show More" refinements button,
-// none of the below resource groups should have a _total_ eligibility amount that exceeds the
-// refinementListLimit value defined in the UCSF whitelabel config in whitelabel.ts.
-// E.g., The ucsf-mental-health-resources should not have more than a sum total of X eligibilities
-// among all of its eligibility groups. This excludes any "See All" eligibilities, which we do not
-// display in the sidebar.
-
 /* eslint-disable object-curly-newline */
 export const eligibilityMap: Readonly<UcsfEligibilityMap> = {
   "ucsf-mental-health-resources": [

--- a/app/utils/whitelabel.ts
+++ b/app/utils/whitelabel.ts
@@ -45,7 +45,6 @@ interface WhiteLabelSite {
   intercom: boolean;
   logoLinkDestination: string;
   navLogoStyle: string;
-  refinementListLimit: number;
   showBanner: boolean;
   showBreakingNews: boolean;
   showClinicianAction: boolean;
@@ -107,7 +106,6 @@ services and re-entry programs.`,
   intercom: false,
   logoLinkDestination: "/",
   navLogoStyle: styles.siteNav,
-  refinementListLimit: 10,
   showPrintResultsBtn: true,
   showBanner: false,
   showBreakingNews: false,
@@ -218,7 +216,6 @@ Department, and UCSF School of Medicine in partnership with SF Service Guide.`,
   enabledTranslations: [],
   homePageComponent: "UcsfHomePage",
   navLogoStyle: styles.navLogoUcsf,
-  refinementListLimit: 15,
   showClinicianAction: true,
   showHandoutsIcon: true,
   showHeaderQrCode: true,


### PR DESCRIPTION
This expands the refinement limit value that we pass to the Algolia search component, if we are filtering out returned refinements – in cases where we are using `transformItems` to filter the returned refinements, we want the limit to be high to ensure that Algolia returns all of the refinements that we actually want to display. It's a little bit complicated, so I tried my best to explain it in comments. Let me know if this can be improved at all.

Tl;dr: Algolia passes back a limited amount of eligibility or category refinements. We have been filtering this returned list in some cases, without realizing that the original, unfiltered list may not even contain all of the refinements that we want to display. That's why sometimes the list on the sidebar can be very short.
