### PR TITLE
1274 Show service type/categories first in UCSF discovery steps

### DIFF
--- a/app/pages/ServiceDiscoveryForm/constants.ts
+++ b/app/pages/ServiceDiscoveryForm/constants.ts
@@ -124,7 +124,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     name: "Mental Health Resources",
     abbreviatedName: "Mental Health",
     slug: "ucsf-mental-health-resources",
-    steps: ["eligibilities", "subcategories", "results"],
+    steps: ["subcategories", "eligibilities", "results"],
     subcategorySubheading: defaultSubheading,
   },
   {
@@ -133,7 +133,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     name: "Shelter Resources",
     abbreviatedName: "Shelter",
     slug: "ucsf-shelter-resources",
-    steps: ["eligibilities", "subcategories", "results"],
+    steps: ["subcategories", "eligibilities", "results"],
     subcategorySubheading: defaultSubheading,
   },
   {
@@ -142,7 +142,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     name: "Substance Use Resources",
     abbreviatedName: "Substance Use",
     slug: "ucsf-substance-use-resources",
-    steps: ["eligibilities", "subcategories", "results"],
+    steps: ["subcategories", "eligibilities", "results"],
     subcategorySubheading: defaultSubheading,
   },
   {
@@ -151,7 +151,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     name: "Food Insecurity Resources",
     abbreviatedName: "Food Insecurity",
     slug: "ucsf-food-insecurity-resources",
-    steps: ["eligibilities", "subcategories", "results"],
+    steps: ["subcategories", "eligibilities", "results"],
     subcategorySubheading: defaultSubheading,
   },
   {
@@ -170,7 +170,7 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     name: "Intimate Partner Violence Resources",
     abbreviatedName: "Intimate Partner Violence",
     slug: "ucsf-partner-violence-resources",
-    steps: ["eligibilities", "subcategories", "results"],
+    steps: ["subcategories", "eligibilities", "results"],
     subcategorySubheading: defaultSubheading,
   },
 ];


### PR DESCRIPTION
I think I said that UCSF wanted the refinements order switched on the sidebar during our product/dev meeting, but indeed it was actually in the discovery steps (brain fog). Fortunately that was a much easier change to make.