### PR TITLE
1274 ipv subcategory sort

### DIFF
--- a/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
+++ b/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
@@ -390,21 +390,9 @@ export const eligibilityMap: Readonly<UcsfEligibilityMap> = {
         },
         {
           isSeeAll: false,
-          checkedId: "52",
-          name: "African/Black",
-          checked: false,
-        },
-        {
-          isSeeAll: false,
           checkedId: "47",
           name: "API (Asian/Pacific Islander)",
           alias: "Asian and Pacific Islander",
-          checked: false,
-        },
-        {
-          isSeeAll: false,
-          checkedId: "53",
-          name: "Jewish",
           checked: false,
         },
         {
@@ -418,12 +406,6 @@ export const eligibilityMap: Readonly<UcsfEligibilityMap> = {
           isSeeAll: false,
           checkedId: "54",
           name: "LGBTQ+",
-          checked: false,
-        },
-        {
-          isSeeAll: false,
-          checkedId: "49",
-          name: "Middle Eastern and North African",
           checked: false,
         },
         {

--- a/app/models/SearchHits.ts
+++ b/app/models/SearchHits.ts
@@ -66,25 +66,27 @@ export const transformHits = (
     }
   });
 
+  // Some of our tile category results that may provide more urgent services need to be sorted
+  // by 24 hour availability. Moreover, in some cases, certain services, that have "24/7" in
+  // their name should be prioritized as well. Thus, this logic orders hits by 24/7
+  // availability, and if there are ties, where both services in the comparison are open 24/7,
+  // the logic breaks the tie by alphabetical rank – this is a heuristic of sorts
+  // to prioritize services with names beginning with the numeric "24".
   return sortBy24HourAvailability
-    // Some of our tile category results that may provide more urgent services need to be sorted
-    // by 24 hour availability. Moreover, in some cases, certain services, that have "24/7" in
-    // their name should be prioritized as well. Thus, this logic orders hits by 24/7
-    // availability, and if there are ties, where both services in the comparison are open 24/7,
-    // the logic breaks the tie by alphabetical rank – this is a heuristic of sorts
-    // to prioritize services with names beginning with the numeric "24".
     ? hitsWithRecurringSchedule.sort((a, b) => {
-      const aIsOpen24_7 = a.recurringSchedule && a.recurringSchedule.isOpen24_7();
-      const bIsOpen24_7 = b.recurringSchedule && b.recurringSchedule.isOpen24_7();
-      if (aIsOpen24_7 === bIsOpen24_7) {
-        return a.name <= b.name ? -1 : 1;
-      }
+        const aIsOpen24_7 =
+          a.recurringSchedule && a.recurringSchedule.isOpen24_7();
+        const bIsOpen24_7 =
+          b.recurringSchedule && b.recurringSchedule.isOpen24_7();
+        if (aIsOpen24_7 === bIsOpen24_7) {
+          return a.name <= b.name ? -1 : 1;
+        }
 
-      if (aIsOpen24_7) {
-        return -1;
-      }
+        if (aIsOpen24_7) {
+          return -1;
+        }
 
-      return 1;
-    })
+        return 1;
+      })
     : hitsWithRecurringSchedule;
 };

--- a/app/pages/ServiceDiscoveryForm/constants.ts
+++ b/app/pages/ServiceDiscoveryForm/constants.ts
@@ -9,6 +9,7 @@ export interface ServiceCategory {
   algoliaCategoryName: string;
   sortBy24HourAvailability?: boolean;
   disableGeoLocation?: boolean;
+  sortAlgoliaSubcategoryRefinements?: boolean;
   id: string;
   name: string;
   abbreviatedName?: string;
@@ -174,5 +175,6 @@ export const CATEGORIES: Readonly<ServiceCategory[]> = [
     slug: "ucsf-partner-violence-resources",
     steps: ["subcategories", "eligibilities", "results"],
     subcategorySubheading: defaultSubheading,
+    sortAlgoliaSubcategoryRefinements: true,
   },
 ];

--- a/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.tsx
+++ b/app/pages/ServiceDiscoveryResults/ServiceDiscoveryResults.tsx
@@ -140,7 +140,12 @@ const InnerServiceDiscoveryResults = ({
   userLatLng: string;
 }) => {
   const subcategoryNames = subcategories.map((c) => c.name);
-  const { name: categoryName, slug: categorySlug, id: categoryId } = category;
+  const {
+    name: categoryName,
+    slug: categorySlug,
+    id: categoryId,
+    sortAlgoliaSubcategoryRefinements,
+  } = category;
 
   return (
     <div className={styles.container}>
@@ -182,6 +187,9 @@ const InnerServiceDiscoveryResults = ({
             categorySlug={categorySlug}
             subcategories={subcategories}
             subcategoryNames={subcategoryNames}
+            sortAlgoliaSubcategoryRefinements={
+              sortAlgoliaSubcategoryRefinements
+            }
           />
 
           <div className={styles.results}>

--- a/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
+++ b/app/pages/UcsfDiscoveryForm/UcsfDiscoveryForm.tsx
@@ -8,6 +8,8 @@ import qs from "qs";
 import ReactGA from "react-ga";
 import ReactGA_4 from "react-ga4";
 
+import type { Category } from "models/Meta";
+
 import { icon } from "assets";
 import { Button } from "components/ui/inline/Button/Button";
 import { Section } from "components/ucsf/Section/Section";
@@ -30,11 +32,6 @@ import { useSubcategoriesForCategory } from "../../hooks/APIHooks";
 
 import styles from "./UcsfDiscoveryForm.module.scss";
 
-interface SubcategoryRefinement {
-  name: string;
-  id: number;
-}
-
 const seeAllPseudoId = -1;
 
 const Page = () => {
@@ -55,7 +52,7 @@ const Page = () => {
     useState<SelectedSubcategories>(defaultSelectedSubcategories);
   const [currentStep, setCurrentStep] = useState(0);
 
-  const subcategories: SubcategoryRefinement[] =
+  const subcategories: Category[] =
     useSubcategoriesForCategory(category?.id ?? null) || [];
 
   const selectedResource = UCSF_RESOURCES.find(


### PR DESCRIPTION
UCSF asked us to order our sidebar subcategories by a defined order that they sent us. Our CategoryRelationship table has a "child_priority_rank" field that I set for the child categories returned by our `Ucsf-ipv` parent category. I then use this order to sort the categories returned by Algolia.

This PR also removes some of the static eligibilities from the IPV constant eligibility list defined on the f/e. These eligibilities are not used for now. Speaking of which, maybe we should create a CategoryEligibility table similar to the CategoryRelationship table that will allow us to define eligibilities to be associated with a given parent category in the DB. 