### PR TITLE
Use v2 API route for GET services by ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - run: npm ci
       - run: cp config.example.yml config.yml
       - run: npm run build
-      - run: docker-compose -f docker-compose.test.yml up -d db api frontend
+      - run: docker-compose -f docker-compose.test.yml up -d db api api-go frontend
       - run: sleep 60
       - run: yarn cypress run
       - if: always()

--- a/app/models/Service.ts
+++ b/app/models/Service.ts
@@ -104,7 +104,7 @@ export const shouldServiceInheritScheduleFromOrg = (service: Service) =>
  * into a nicer-to-use data model of RecurringSchedules.
  */
 export const fetchService = (id: string): Promise<Service> =>
-  get(`/api/services/${id}`).then(({ service }: { service: Service }) => {
+  get(`/api/v2/services/${id}`).then(({ service }: { service: Service }) => {
     const recurringSchedule = shouldServiceInheritScheduleFromOrg(service)
       ? parseAPISchedule(service.schedule)
       : parseAPISchedule(service.resource.schedule);

--- a/cypress/e2e/service_page.cy.ts
+++ b/cypress/e2e/service_page.cy.ts
@@ -63,7 +63,7 @@ describe("Service Page", () => {
     cy.visit(page.url(serviceId));
     // Intercept client's AJAX request to services endpoint and alias as "getServiceData". Pass
     // the alias to #wait method below to delay test execution until the request has returned
-    cy.intercept("GET", `/api/services/${serviceId}`, (req) => {
+    cy.intercept("GET", `/api/v2/services/${serviceId}`, (req) => {
       // Deleting "if-none-match" headers forces the intercept to make a fresh request rather than
       // potentially resolving a cached object
       delete req.headers["if-none-match"];
@@ -102,7 +102,7 @@ describe("Service Page", () => {
       }
     );
 
-    cy.request<{ service: Service }>(`/api/services/${serviceId}`).then(
+    cy.request<{ service: Service }>(`/api/v2/services/${serviceId}`).then(
       (res) => {
         expect(res.status).to.eq(200);
         const { service } = res.body;

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,15 @@ services:
     ports: ["5432:5432"]
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "psql -U postgres -d askdarcel_development -c 'SELECT 1;' || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   api:
     image: sheltertechsf/askdarcel-api:latest
@@ -23,13 +32,27 @@ services:
       # ALGOLIA_API_KEY:
       # ALGOLIA_INDEX_PREFIX:
 
+  api-go:
+    image: sheltertechsf/sheltertech-go:latest
+    networks: [askdarcel]
+    ports: ["3001:3001"]
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: askdarcel_development
+      DB_USER: postgres
+
   frontend:
     image: nginx:stable
     networks: [askdarcel]
     ports: ["8080:8080"]
-    depends_on: [api]
+    depends_on: [api, api-go]
     environment:
       NGINX_API_URL: http://api:3000
+      NGINX_API_GO_URL: http://api-go:3001
       NGINX_PORT: 8080
       NGINX_SERVER_NAME: frontend
     volumes:

--- a/docker/templates/default.conf.template
+++ b/docker/templates/default.conf.template
@@ -4,6 +4,25 @@ server {
 
     root /app/askdarcel;
 
+    location ~ ^/api/v2/(.*)$ {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+
+        # See https://forum.nginx.org/read.php?2,215830,215832#msg-215832
+        # nginx only resolves DNS for statically-configured domain names
+        # once on startup. Since the API is behind an ELB whose IPs may
+        # change, we must configure nginx to resolve DNS dynamically.
+        # To do this, we configure a DNS resolver here and use a variable
+        # rather than a literal URL when configuring the proxy below.
+        resolver 127.0.0.11;
+        resolver_timeout 5s;
+
+        set $api_url ${NGINX_API_GO_URL};
+        proxy_pass $api_url/api/$1$is_args$args;
+        proxy_redirect off;
+    }
+
     location ~ ^/api/(.*)$ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This would flip all GET services by ID to use Go server.

Will discuss with team before any action on this.