### PR TITLE
Prod auth bug fix

### DIFF
--- a/app/Router.tsx
+++ b/app/Router.tsx
@@ -2,7 +2,7 @@ import type { PopupMessageProp } from "components/ui";
 import React from "react";
 import { Switch, Route, Redirect } from "react-router-dom";
 import { whiteLabel, useAppContext } from "utils";
-import { ProtectedRoute } from "components/utils";
+import { ProtectedRoute, PublicRoute } from "components/utils";
 
 import { AuthInterstitial } from "pages/AuthInterstitial";
 import { HomePage } from "pages/HomePage";
@@ -53,12 +53,6 @@ export const Router = ({
       <Route exact path="/about" component={AboutPage} />
       <Route exact path="/auth" component={AuthInterstitial} />
       <Route exact path="/demo/listing" component={ListingDebugPage} />
-      <ProtectedRoute
-        exact
-        isAuthenticated={!!authState}
-        path="/navigator-dashboard"
-        component={NavigatorDashboard}
-      />
       {/* NB: /organizations/new must be listed before /organizations/:id or else the /new
                 step will be interpreted as an ID and will thus break the OrganizationEditPage */}
       <Route
@@ -107,9 +101,30 @@ export const Router = ({
         path="/breaking-news/edit"
         component={EditBreakingNewsPage}
       />
-      <Route exact path="/log-in" component={LoginPage} />
-      <Route exact path="/sign-up" component={SignUpPage} />
-      <Route exact path="/log-out" component={LogoutPage} />
+      <ProtectedRoute
+        exact
+        isAuthenticated={!!authState}
+        path="/navigator-dashboard"
+        component={NavigatorDashboard}
+      />
+      <PublicRoute
+        exact
+        isAuthenticated={!!authState}
+        path="/log-in"
+        component={LoginPage}
+      />
+      <PublicRoute
+        exact
+        isAuthenticated={!!authState}
+        path="/sign-up"
+        component={SignUpPage}
+      />
+      <ProtectedRoute
+        exact
+        isAuthenticated={!!authState}
+        path="/log-out"
+        component={NavigatorDashboard}
+      />
 
       {/* UCSF white label paths */}
       <Route

--- a/app/Router.tsx
+++ b/app/Router.tsx
@@ -123,7 +123,7 @@ export const Router = ({
         exact
         isAuthenticated={!!authState}
         path="/log-out"
-        component={NavigatorDashboard}
+        component={LogoutPage}
       />
 
       {/* UCSF white label paths */}

--- a/app/components/utils/PublicRoute.tsx
+++ b/app/components/utils/PublicRoute.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import {
+  Redirect,
+  Route,
+  RouteComponentProps,
+  RouteProps,
+} from "react-router-dom";
+
+interface PublicRouteProps extends RouteProps {
+  // The type here is copied from the react-router component typing in react-router/index.d.ts
+  component:
+    | React.ComponentType<RouteComponentProps<any>>
+    | React.ComponentType<any>;
+  isAuthenticated: boolean;
+  redirectTo?: string;
+}
+
+export const PublicRoute = ({
+  component: Component,
+  isAuthenticated,
+  redirectTo = "/navigator-dashboard",
+  ...rest
+}: PublicRouteProps) => {
+  return (
+    <Route
+      {...rest}
+      render={(props) =>
+        !isAuthenticated ? (
+          <Component {...props} />
+        ) : (
+          <Redirect to={{ pathname: redirectTo }} />
+        )
+      }
+    />
+  );
+};

--- a/app/components/utils/index.ts
+++ b/app/components/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./ProtectedRoute";
+export * from "./PublicRoute";

--- a/app/pages/AuthInterstitial.tsx
+++ b/app/pages/AuthInterstitial.tsx
@@ -1,8 +1,8 @@
 /**
  * This is the interstial redirect page after a user is authenticated via Auth0.
  * The useEffect hook contains logic that checks the url for a hash, which contains an encoded
- * access token. The code then intializes the user session using by decoding the token and
- * passing the user props to the AppContext authState
+ * access token. The code then intializes the user session by decoding the token and passing
+ * the user props to the AppContext authState.
  *
  */
 
@@ -13,12 +13,16 @@ import { useAppContext } from "utils";
 import { Loader } from "components/ui";
 
 export const AuthInterstitial = () => {
-  const { authClient, setAuthState } = useAppContext();
+  const { authClient, authState, setAuthState } = useAppContext();
   const history = useHistory();
 
   useEffect(() => {
     const { hash } = window.location;
-    if (!hash || !hash.includes("access_token")) {
+    // In some cases the effect can run twice, the second time happening after the user authState
+    // has been successfully created. If `initializeUserSession` is run after a session already exists
+    // it causes an unhandled rejection, which breaks the login flow. Thus, we check if the authState
+    // already exists and if so, prevent the initUserSession method from being called again.
+    if ((authState && !hash) || !hash.includes("access_token")) {
       return;
     }
 
@@ -29,7 +33,7 @@ export const AuthInterstitial = () => {
     ).then(() => {
       history.push("navigator-dashboard");
     });
-  }, [history, setAuthState, authClient]);
+  }, [authClient, authState, history, setAuthState]);
 
   return (
     <div>

--- a/app/pages/AuthInterstitial.tsx
+++ b/app/pages/AuthInterstitial.tsx
@@ -22,7 +22,7 @@ export const AuthInterstitial = () => {
     // has been successfully created. If `initializeUserSession` is run after a session already exists
     // it causes an unhandled rejection, which breaks the login flow. Thus, we check if the authState
     // already exists and if so, prevent the initUserSession method from being called again.
-    if ((authState && !hash) || !hash.includes("access_token")) {
+    if (authState || !hash || !hash.includes("access_token")) {
       return;
     }
 


### PR DESCRIPTION
Mostly to fix an issue where the user session init code was being run twice and breaking the log-in flow. it was only happening on prod for some reason. this should patch it at least. Also added a public route component to redirect authed users navigating the the log-in/sign-up pages