### PR TITLE
Add `API_GO_URL` to development docker-compose.yml.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     command: npm -- run dev --host 0.0.0.0 --disable-host-check
     environment:
       API_URL: http://api:3000
+      API_GO_URL: http://sheltertech-go:3001
       ALGOLIA_INDEX_PREFIX:
       ALGOLIA_APPLICATION_ID:
       ALGOLIA_READ_ONLY_API_KEY:


### PR DESCRIPTION
This environment variable was set in the CI docker-compose.yml file, but not the development one. Setting it in the development one makes the Go API work seamlessly with the development docker-compose networking setup.