### PR TITLE
NavigatorDashboard: Fix infinite rerender bug.

### DIFF
--- a/app/pages/NavigatorDashboard/NavigatorDashboard.tsx
+++ b/app/pages/NavigatorDashboard/NavigatorDashboard.tsx
@@ -61,7 +61,11 @@ const AdvancedSearch = () => {
 
     Promise.all(allPromises)
       .then((values) => {
-        setEligibilities(values);
+        // If PARENT_ELIGIBILITIES hasn't been filled out, then allPromises will
+        // be empty. If this is the case, then calling setEligibilities with an
+        // empty array will cause this component to rerender infinitely, since
+        // the exit condition only checks for non-empty eligibilites.
+        if (values.length !== 0) setEligibilities(values);
       })
       .catch((err) => {
         Sentry.captureException(err);


### PR DESCRIPTION
Since we haven't filled out the `PARENT_ELIGIBILITIES` variable yet, the current logic keeps trying to fetch the child eligibilities for them, setting the `eligibilities` state variable to the empty array over and over again. If we actually set values for the `PARENT_ELIGIBILITIES`, then this wouldn't be a problem, but for now, guard the actual calling of `setEligibilities` to avoid infinite rerendering.