### PR TITLE
Add more logging statements around authentication.

### DIFF
--- a/app/utils/AuthService.ts
+++ b/app/utils/AuthService.ts
@@ -27,6 +27,7 @@ export const initializeUserSession = (
     // eslint-disable-next-line no-console
     console.log("cookies exist? ", document.cookie);
     const stateToken = sessionStorage.getItem("authStateToken") ?? "";
+    console.log(`Getting authStateToken: ${stateToken}`);
     authClient.parseHash({ hash, state: stateToken }, (err, authResult) => {
       sessionStorage.removeItem("authStateToken");
 
@@ -107,7 +108,9 @@ export const passwordlessLogin = (
   email: string,
   verificationCode: string
 ) => {
+  console.log("In passwordlessLogin");
   const stateToken = createStateToken();
+  console.log(`Setting authStateToken: ${stateToken}`);
   sessionStorage.setItem("authStateToken", stateToken);
   authClient.passwordlessLogin(
     {


### PR DESCRIPTION
We're still hitting issues in prod related to authentication, and adding logging around the `passwordlessLogin` function and the state tokens will help us debug it.