### PR TITLE
[AuthService] Rename Auth0-specific ID field.

### DIFF
--- a/app/utils/AuthService.ts
+++ b/app/utils/AuthService.ts
@@ -43,7 +43,7 @@ export const initializeUserSession = (
         const authObject = {
           user: {
             email: idTokenPayload.email,
-            id: idTokenPayload.sub,
+            externalId: idTokenPayload.sub,
           },
           accessTokenObject: {
             token: accessToken,

--- a/app/utils/useAppContext.tsx
+++ b/app/utils/useAppContext.tsx
@@ -19,8 +19,13 @@ export interface UserSignUpData {
 }
 
 export type AuthState = {
+  /** Fields that come from the identity provider (Auth0). */
   user: {
-    id: string;
+    /** The Auth0 user ID, as opposed the ID in our own API.
+     *
+     * This is contained in the Auth0 JWT as the `sub` (subject) field.
+     */
+    externalId: string;
     email: string;
   };
   accessTokenObject: {
@@ -94,7 +99,7 @@ export const AppProvider = ({
       SessionCacher.clearUserSignUpData();
       AuthService.saveUser(
         newUserData,
-        authState.user.id,
+        authState.user.externalId,
         authState.accessTokenObject.token
       );
     }


### PR DESCRIPTION
We have two different notions of user IDs: one from Auth0, which is a string and is contained in the JWT, and one from our own API, which is an integer. This renames the `id` field within the auth state to `externalId`, to make it clearer that these are from the identity provider.

I wanted to split this off from a much larger PR I'm making, since this is kind of important on its own, and I didn't want it to get lost in the noise.