### PR TITLE
Hook up saved search APIs.

### DIFF
--- a/app/components/search/Header/Header.module.scss
+++ b/app/components/search/Header/Header.module.scss
@@ -1,7 +1,8 @@
 @import "~styles/utils/_helpers.scss";
 
 .header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto;
   padding: 15px 35px;
   border-bottom: 1px solid $color-grey3;
   justify-content: space-between;
@@ -12,6 +13,11 @@
   @media screen and (max-width: $break-tablet-s) {
     padding: 14px 14px 5px;
   }
+}
+
+.headerActions {
+  display: flex;
+  gap: 36px;
 }
 
 .title {

--- a/app/components/search/Header/Header.tsx
+++ b/app/components/search/Header/Header.tsx
@@ -14,11 +14,15 @@ export const Header = ({
   translateResultsTitle = true,
   expandList,
   setExpandList,
+  searchSaved,
+  saveSearch,
 }: {
   resultsTitle: string;
   translateResultsTitle?: boolean;
   expandList: boolean;
   setExpandList: (_expandList: boolean) => void;
+  searchSaved?: boolean;
+  saveSearch?: (() => void) | null;
 }) => {
   const [qrCodeModalOpen, setQrCodeModalOpen] = useState(false);
 
@@ -31,58 +35,69 @@ export const Header = ({
       >
         {resultsTitle}
       </h1>
-      <Button
-        onClick={() => {
-          setQrCodeModalOpen(true);
-        }}
-        addClass={`${styles.qrCodeBtn} ${
-          showHeaderQrCode ? styles.showBtn : ""
-        }`}
-        styleType="transparent"
-      >
-        <>
-          <img src={assetIcon("qr-code")} alt="QR code icon" />
-          <span className={styles.btnText}>Resource List QR Code</span>
-        </>
-      </Button>
-      <Button
-        onClick={() => {
-          window.print();
-        }}
-        addClass={`${styles.printAllBtn} ${
-          showPrintResultsBtn ? styles.showBtn : ""
-        }`}
-        styleType="transparent"
-      >
-        <>
-          <img src={assetIcon("print-blue")} alt="Printer icon" />
-          <span className={styles.btnText}>Print all results</span>
-        </>
-      </Button>
-      <QrCodeModal isOpen={qrCodeModalOpen} setIsOpen={setQrCodeModalOpen} />
-      <div className={styles.mapListToggleContainer}>
-        <button
-          type="button"
-          className={styles.mapListToggleBtn}
-          onClick={() => setExpandList(true)}
+      <div className={styles.headerActions}>
+        <Button
+          onClick={() => {
+            setQrCodeModalOpen(true);
+          }}
+          addClass={`${styles.qrCodeBtn} ${
+            showHeaderQrCode ? styles.showBtn : ""
+          }`}
+          styleType="transparent"
         >
-          <span
-            className={`${styles.listIcon} ${
-              expandList ? styles.activeView : ""
-            }`}
-          />
-        </button>
-        <button
-          type="button"
-          className={styles.mapListToggleBtn}
-          onClick={() => setExpandList(false)}
+          <>
+            <img src={assetIcon("qr-code")} alt="QR code icon" />
+            <span className={styles.btnText}>Resource List QR Code</span>
+          </>
+        </Button>
+        {saveSearch ? (
+          <Button
+            onClick={saveSearch}
+            styleType="transparent"
+            disabled={searchSaved}
+          >
+            {searchSaved ? "Results Saved!" : "Save Results"}
+          </Button>
+        ) : null}
+        <Button
+          onClick={() => {
+            window.print();
+          }}
+          addClass={`${styles.printAllBtn} ${
+            showPrintResultsBtn ? styles.showBtn : ""
+          }`}
+          styleType="transparent"
         >
-          <span
-            className={`${styles.mapIcon} ${
-              !expandList ? styles.activeView : ""
-            }`}
-          />
-        </button>
+          <>
+            <img src={assetIcon("print-blue")} alt="Printer icon" />
+            <span className={styles.btnText}>Print all results</span>
+          </>
+        </Button>
+        <QrCodeModal isOpen={qrCodeModalOpen} setIsOpen={setQrCodeModalOpen} />
+        <div className={styles.mapListToggleContainer}>
+          <button
+            type="button"
+            className={styles.mapListToggleBtn}
+            onClick={() => setExpandList(true)}
+          >
+            <span
+              className={`${styles.listIcon} ${
+                expandList ? styles.activeView : ""
+              }`}
+            />
+          </button>
+          <button
+            type="button"
+            className={styles.mapListToggleBtn}
+            onClick={() => setExpandList(false)}
+          >
+            <span
+              className={`${styles.mapIcon} ${
+                !expandList ? styles.activeView : ""
+              }`}
+            />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/app/models/SavedSearch.ts
+++ b/app/models/SavedSearch.ts
@@ -1,0 +1,40 @@
+import { get, post } from "utils/DataService";
+
+export interface SavedSearchQuery {
+  eligibilities: string[];
+  categories: string[];
+  lat: number | null;
+  lng: number | null;
+  query: string;
+}
+
+export interface SavedSearch {
+  id: number;
+  user_id: number;
+  name: string;
+  search: SavedSearchQuery;
+}
+
+type PostSavedSearch = Omit<SavedSearch, "id">;
+
+export interface SavedSearches {
+  saved_searches: SavedSearch[];
+}
+
+export function getSavedSearchesForUser(
+  userId: number,
+  authToken: string
+): Promise<SavedSearches> {
+  return get(`/api/v2/saved_searches?user_id=${userId}`, {
+    Authorization: `bearer ${authToken}`,
+  });
+}
+
+export function createSavedSearch(
+  savedSearch: PostSavedSearch,
+  authToken: string
+): Promise<SavedSearch> {
+  return post(`/api/v2/saved_searches`, savedSearch, {
+    Authorization: `bearer ${authToken}`,
+  }).then((resp) => resp.json());
+}


### PR DESCRIPTION
This hooks up the placeholder locations in the Navigator UI with the saved search APIs.

When a user is logged in, we add a "Save Results" button to the search results page, and pressing that button will fire an API request to save the current search filters and query to the database. This involved pulling out the pieces of the search state object that Algolia's InstantSearch API manages into the format our API accepts.

On the main dashboard page, we perform the reverse operation, querying our API for saved searches, and then reconstituting a simulacrum of the serach state object, solely for the purposes of generating the URL query parameters directly from that object, which is how the search results page normally works.

Since I made some small UI changes, here's a screenshot showing what the "Save Results" button looks like:

<img width="1381" alt="Screenshot 2024-06-27 at 9 03 59 AM" src="https://github.com/ShelterTechSF/askdarcel-web/assets/1002748/b98d6cdb-2acf-4a03-b677-57232f115f77">
