### PR TITLE
Increase logo size in email.

### DIFF
--- a/auth0/passwordless-email-template.liquid
+++ b/auth0/passwordless-email-template.liquid
@@ -11,7 +11,7 @@
       <td align="center" valign="top" id="bodyCell" style="-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: &quot;ProximaNova&quot;, sans-serif;height: 100% !important;">
       <div class="main">
         <p style="text-align: center;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; margin-bottom: 30px;">
-          <img src="https://www.sfserviceguide.org/dist/sf-service-email.png" width="50" alt="SF Service Guide" style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
+          <img src="https://www.sfserviceguide.org/dist/sf-service-email.png" width="200" alt="SF Service Guide" style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
         </p>
 
         <!-- Email change content -->


### PR DESCRIPTION
The original placeholder width of 50 px is way too small for our logo, which is very wide and short. Setting it to 200 px looks better.

### Before

<img width="931" alt="Screenshot 2024-06-27 at 5 15 54 PM" src="https://github.com/ShelterTechSF/askdarcel-web/assets/1002748/b4f9ab67-2027-4893-8357-029076be8f60">


### After

<img width="948" alt="Screenshot 2024-06-27 at 5 15 45 PM" src="https://github.com/ShelterTechSF/askdarcel-web/assets/1002748/266bae6b-1303-4366-95ec-542870904335">