### PR TITLE
Switch from `docker-compose` to `docker compose`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,11 @@ jobs:
       - run: npm ci
       - run: cp config.example.yml config.yml
       - run: npm run build
-      - run: docker-compose -f docker-compose.test.yml up -d db api api-go frontend
+      - run: docker compose -f docker-compose.test.yml up -d db api api-go frontend
       - run: sleep 60
       - run: yarn cypress run
       - if: always()
-        run: docker-compose -f docker-compose.test.yml logs -t # Output all docker logs from API and frontend to help debugging after the fact
+        run: docker compose -f docker-compose.test.yml logs -t # Output all docker logs from API and frontend to help debugging after the fact
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ $ cp config.example.yml config.yml
 
 ```sh
 # Install node dependencies
-$ docker-compose run --rm web npm install
+$ docker compose run --rm web npm install
 
 # Build static assets bundle
-$ docker-compose run --rm web npm run build
+$ docker compose run --rm web npm run build
 
 # Run dev server
-$ docker-compose up
+$ docker compose up
 ```
 
 You should be able to view the web app in your browser at http://localhost:8080.
@@ -80,7 +80,7 @@ The following command will stop all running Docker containers, delete them, and
 remove their volumes:
 
 ```sh
-$ docker-compose down --remove-orphans --volumes
+$ docker compose down --remove-orphans --volumes
 ```
 
 Note: When you run that command, you may get an error message about removing
@@ -92,8 +92,8 @@ ERROR: error while removing network: network askdarcel id
 endpoints
 ```
 
-If this happens, then you need to run `docker-compose stop` in the askdarcel-api
-application first before running the `docker-compose down` command above.
+If this happens, then you need to run `docker compose stop` in the askdarcel-api
+application first before running the `docker compose down` command above.
 
 ## Non-Docker Development Environment
 
@@ -151,7 +151,7 @@ Note: Make sure you have the dev server running (`npm run dev`) before you try r
 If you are using Docker, then you'll need to run it somewhat like this:
 
 ```
-$ docker-compose run --rm -p 1337:1337 -e BASE_URL=http://web:8080 web npm run testcafe -- --skip-js-errors remote --skip-js-errors --hostname localhost --ports 1337,1338 ./testcafe/
+$ docker compose run --rm -p 1337:1337 -e BASE_URL=http://web:8080 web npm run testcafe -- --skip-js-errors remote --skip-js-errors --hostname localhost --ports 1337,1338 ./testcafe/
 ```
 
 This will spin up a web server at http://localhost:1337/ and print out a URL to use. You should manually enter it into your browser to start the tests.


### PR DESCRIPTION
Docker apparently moved the standalone `docker-compose` command into a subcommand of the `docker` command, and they deprecated the standalone command. GitHub Actions recently updated to a new enough Docker version that dropped the standalone `docker-compose` command, which is causing CI to fail.

This updates both the CI configuration as well as our README to only use the subcommand version.

See https://github.com/orgs/community/discussions/116610