### PR TITLE
Fix github CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - run: yarn cypress run
       - if: always()
         run: docker compose -f docker-compose.test.yml logs -t # Output all docker logs from API and frontend to help debugging after the fact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: E2E screenshot(s) and video(s)


### PR DESCRIPTION
Github deprecated v2 of their upload-artifact action, which we were using. This updates it to v4.

CI was failing. See: https://github.com/ShelterTechSF/askdarcel-web/actions/runs/11751183980/job/32741450392
And: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
