### PR TITLE
DC-Nav: Add African/Black eligibility to IPV category.

### DIFF
--- a/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
+++ b/app/components/ucsf/RefinementLists/ucsfEligibilitiesMap.ts
@@ -397,6 +397,13 @@ export const eligibilityMap: Readonly<UcsfEligibilityMap> = {
         },
         {
           isSeeAll: false,
+          checkedId: "25",
+          name: "African/Black",
+          alias: "Black/African American",
+          checked: false,
+        },
+        {
+          isSeeAll: false,
           checkedId: "48",
           name: "Latinx",
           alias: "Latinx/Hispanic",


### PR DESCRIPTION
UCSF would like to add this to the second page of DC-Nav's Intimate Partner Violence form, which lists service eligibilities in the form of patient demographics. Our actual internal eligibility name is "African/Black", but they would like it to be displayed as "Black/African American", so we make use of the `alias` field to rename it in the UI.

<img width="1128" alt="Screenshot 2025-03-26 at 7 29 51 PM" src="https://github.com/user-attachments/assets/25275208-fe65-4f18-bfbd-de346b2c1204" />
