### PR TITLE
Add textRendering attribute to map marker text element

### DIFF
--- a/app/components/ui/MapElements.tsx
+++ b/app/components/ui/MapElements.tsx
@@ -52,6 +52,7 @@ export const CustomMarker = ({
         fill="#276ce5"
         fontWeight="bold"
         textAnchor="middle"
+        textRendering="geometricPrecision"
       >
         {text}
       </text>


### PR DESCRIPTION
Setting the textRendering attribute of the map marker text element to "geometricPrecision" fixes the issue with the text overflowing in chrome. The appearance is still not identical between the two browsers but I think its close enough.
chrome:
![map-markers-chrome](https://github.com/user-attachments/assets/f4631896-05c2-4fc3-96d1-090334d3d72f)
firefox:
![map-markers-firefox](https://github.com/user-attachments/assets/cb8feeec-10fa-47b4-8c7a-1a1160fc492e)
