### PR TITLE
reposition alert icon to baseline

### DIFF
--- a/app/components/ui/Banner.module.scss
+++ b/app/components/ui/Banner.module.scss
@@ -25,6 +25,7 @@
   display: grid;
   grid-template-columns: 24px 1fr;
   gap: 30px;
+  align-items: baseline;
   @media screen and (max-width: $break-tablet-s) {
     width: 96%;
     gap: 12px;


### PR DESCRIPTION
<img width="3048" height="1410" alt="Screenshot 2025-07-29 at 5 44 09 PM" src="https://github.com/user-attachments/assets/e6f07678-066b-421b-afc8-951f81a4fc30" />

The banner is not shown in the app so I put it on the homepage.