### PR TITLE
Fix Docker image by pinning to Debian Bookworm.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:stable
+# tiller is not compatible with Ruby 3.2.0, so we have to stay on the latest
+# Debian Bookworm release of nginx until we can migrate off tiller.
+FROM nginx:1.28.0-bookworm
 
 RUN apt-get update && apt-get -y install ruby && gem install tiller
 


### PR DESCRIPTION
We are currently encountering the following error when trying to deploy our production image:

    Error : Could not open common configuration files!
    undefined method `exists?' for class File
    tiller v1.5.0 (https://github.com/markround/tiller) <github@markround.com>

This is due to the tiller (https://github.com/markround/tiller) project having been abandoned 6 years ago and not being compatible with Ruby 3.2.0. The official nginx Docker image recently upgraded from Debian Bookworm to Trixie, which in turn upgraded Ruby from 3.1 to 3.3.

Until we have time to move off tiller completely, we are pinning the Docker image builds to the latest nginx release on Debian Bookworm, which is nginx 1.8.0.