### PR TITLE
Fix webpack dev server hot reload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ $ cp config.example.yml config.yml
 # Install node dependencies
 $ docker compose run --rm web npm install
 
-# Build static assets bundle
-$ docker compose run --rm web npm run build
-
 # Run dev server
 $ docker compose up
 ```
@@ -116,12 +113,6 @@ To install the dependencies, from the top directory run
 
 ```sh
 npm install
-```
-
-To build the bundled script with webpack run
-
-```sh
-npm run build
 ```
 
 And to run the dev server, run

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
   entry: ["whatwg-fetch", "@babel/polyfill", path.resolve(appRoot, "init.tsx")],
   output: {
     path: buildDir,
-    publicPath: "/dist/",
+    publicPath: process.env.NODE_ENV === "development" ? "/" : "/dist/",
     filename: "bundle.[contenthash].js",
   },
   resolve: {
@@ -193,15 +193,5 @@ module.exports = {
         pathRewrite: { "^/api/": "" },
       },
     },
-    static: [
-      {
-        directory: buildDir,
-        publicPath: "/dist",
-      },
-      {
-        directory: buildDir,
-        publicPath: "",
-      },
-    ],
   },
 };


### PR DESCRIPTION
Fixes #1444.

When we added content hashing to the bundle.js file name, it broke the local dev server. A previous workaround, https://github.com/ShelterTechSF/askdarcel-web/pull/1438, only made it so that it would work if you run `npm run build`, which is still painful to do if you have to run it on every edit.

The root cause of the issue is that our webpack was misconfigured in the first place, and adding the hash highlighted the issue. The webpack dev server is normally supposed to serve all HTTP requests through versions of files it has in memory. However, in our original setup, the index.html file was actually being served from disk, using the version built by `npm run build`, not the in-memory one that the webpack dev server creates and updates upon changes to any file. When the hash got added to the bundle.js file, the prebuilt index.html could not point to the correct bundle.js file, since its name would change every time you made an edit to the site.

The real solution is to stop serving the prebuilt index.html file from disk at all. The reason that we were using the prebuilt index.html file is because we configure the webpack `publicPath` setting to set it to `/dist`, which would cause the webpack dev server to serve the in-memory version of index.html from `/dist/index.html`, but falling back to the prebuilt one on disk at `build/index.html`.

To fix this, we change the webpack configuration for local development to set `publicPath` to `/` in dev environments. This makes the local dev server serve all assets out of `/` rather than `/dist`.

A side effect of this is that we no longer depend on any of the prebuilt assets anymore, so we can remove all the other settings related to falling back to those. We can also now remove those steps from the README, as they are no longer necessary.

Also, for full disclosure, I gave in and subscribed to Claude Code, so Claude's the one who actually figured this out. All I did was review and guide it.