### PR TITLE
Replace banner with heat advisory for March 2026.

### DIFF
--- a/app/components/ui/Banner.tsx
+++ b/app/components/ui/Banner.tsx
@@ -8,18 +8,29 @@ export const Banner = () => (
       <img src={icon("alert")} alt="attention" className={styles.alertIcon} />
       <div>
         <strong className={styles.title}>
-          HELP IDENTIFY AND STOP HUMAN TRAFFICKING
+          SHELTER ACCESS DURING HEAT RISK WEATHER:
         </strong>
         <p>
           <a
             className={styles.bannerLink}
             target="_blank"
             rel="noreferrer"
-            href="https://www.sf.gov/help-identify-and-stop-human-trafficking"
+            href="https://t.e2ma.net/click/ujixxj/mdg5ukid/ebhabt"
           >
-            Resources
+            Get information
           </a>{" "}
-          for victims of human trafficking.
+          on expanded shelter access during heat risk weather in San Francisco.
+        </p>
+        <p>
+          <a
+            className={styles.bannerLink}
+            target="_blank"
+            rel="noreferrer"
+            href="https://hsh.sfgov.org/services"
+          >
+            General information
+          </a>{" "}
+          on finding temporary shelter.
         </p>
       </div>
     </div>


### PR DESCRIPTION
<img width="1370" height="243" alt="Screenshot 2026-03-18 at 9 13 59 PM" src="https://github.com/user-attachments/assets/a0196b73-da06-4f92-bf60-efd8c6496aa1" />

This updates the yellow banner on the site with a heat advisory for the heat wave we're currently undergoing in the Bay. We've done a few of these in the past, so this uses the exact same language as before, but it updates the link to the latest advisory notice on the City's website.