### PR TITLE
Fix short description change request 1452

### DIFF
--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -1561,31 +1561,31 @@ class OrganizationEditPage extends React.Component<Props, State> {
     // Resource
     const field_changes: Partial<Organization> = {};
     let resourceModified = false;
-    if (name !== resource.name) {
+    if (name !== undefined && name !== resource.name) {
       field_changes.name = name;
       resourceModified = true;
     }
-    if (long_description !== resource.long_description) {
+    if (long_description !== undefined && long_description !== resource.long_description) {
       field_changes.long_description = long_description;
       resourceModified = true;
     }
-    if (website !== resource.website) {
+    if (website !== undefined && website !== resource.website) {
       field_changes.website = website;
       resourceModified = true;
     }
-    if (email !== resource.email) {
+    if (email !== undefined && email !== resource.email) {
       field_changes.email = email;
       resourceModified = true;
     }
-    if (alternate_name !== resource.alternate_name) {
+    if (alternate_name !== undefined && alternate_name !== resource.alternate_name) {
       field_changes.alternate_name = alternate_name;
       resourceModified = true;
     }
-    if (legal_status !== resource.legal_status) {
+    if (legal_status !== undefined && legal_status !== resource.legal_status) {
       field_changes.legal_status = legal_status;
       resourceModified = true;
     }
-    if (internal_note !== resource.internal_note) {
+    if (internal_note !== undefined && internal_note !== resource.internal_note) {
       field_changes.internal_note = internal_note;
       resourceModified = true;
     }

--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -1569,10 +1569,6 @@ class OrganizationEditPage extends React.Component<Props, State> {
       field_changes.long_description = long_description;
       resourceModified = true;
     }
-    if (short_description !== resource.short_description) {
-      field_changes.short_description = short_description;
-      resourceModified = true;
-    }
     if (website !== resource.website) {
       field_changes.website = website;
       resourceModified = true;


### PR DESCRIPTION
## Summary
Fixes an issue where the frontend sends a change request even when the user clicks save without making any edits.

## Root Cause
The edit page compares values in component state with values returned from the API to determine if a resource was modified. However, many fields in state can be `undefined` while the API returns actual values (strings or null). This caused comparisons like `undefined !== "value"` to always evaluate as true, incorrectly marking the resource as modified.

Additionally, `short_description` was being compared even though it is not editable on this page, which also contributed to false positives.

## Fix
- Removed the `short_description` comparison
- Updated all resource field comparisons to ignore `undefined` values:
  - Only compare when the state value is defined AND different from the API value

## Testing
Tested using resource id 2:

- Clicking Save without changes:
  - No `change_requests` request sent

- Modifying a field:
  - `change_requests` request is sent correctly

This confirms the fix prevents false-positive change requests while preserving correct behavior.