### PR TITLE
Revert "Update phone change request paths to v2"

### DIFF
--- a/app/pages/OrganizationEditPage.tsx
+++ b/app/pages/OrganizationEditPage.tsx
@@ -174,19 +174,11 @@ function updateCollectionObject(
   path: string,
   promises: Promise<unknown>[]
 ) {
-  if (path === "phones") {
-    promises.push(
-      dataService.post(`/api/v2/${path}/${id}/change_requests`, {
-        change_request: { action: ACTION_EDIT, field_changes: object },
-      })
-    );
-  } else {
-    promises.push(
-      dataService.post(`/api/${path}/${id}/change_requests`, {
-        change_request: { action: ACTION_EDIT, field_changes: object },
-      })
-    );
-  }
+  promises.push(
+    dataService.post(`/api/${path}/${id}/change_requests`, {
+      change_request: { action: ACTION_EDIT, field_changes: object },
+    })
+  );
 }
 
 /**
@@ -213,7 +205,7 @@ function createNewPhoneNumber(
   promises: Promise<unknown>[]
 ) {
   promises.push(
-    dataService.post("/api/v2/change_requests", {
+    dataService.post("/api/change_requests", {
       change_request: {
         action: ACTION_INSERT,
         field_changes: item,


### PR DESCRIPTION
Reverts ShelterTechSF/askdarcel-web#1447

https://github.com/ShelterTechSF/sheltertech-go/issues/260 describes a bug we have where the v2 phone change request endpoints currently require auth, which is breaking the site because these routes didn't previously require authentication, and we don't actually want them to enforce authentication. To fix prod quickly, we're just reverting this PR so that the edit page switches back to the v1 endpoint for editing phones, routing it back to the Rails app.

Once we fix https://github.com/ShelterTechSF/sheltertech-go/issues/260, we can restore these changes again.